### PR TITLE
Use a SyncAdapter to synchronize the directory "the Android Way"

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -34,6 +34,10 @@
     <uses-permission android:name="android.permission.READ_CALL_LOG" />
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
+    <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
+    <uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
+
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
 
     <permission android:name="org.thoughtcrime.securesms.permission.C2D_MESSAGE"
@@ -207,6 +211,26 @@
         </intent-filter>
     </service>
 
+    <service
+            android:name="org.thoughtcrime.securesms.util.DirectorySyncAuthenticatorService">
+        <intent-filter>
+            <action android:name="android.accounts.AccountAuthenticator"/>
+        </intent-filter>
+        <meta-data
+            android:name="android.accounts.AccountAuthenticator"
+            android:resource="@xml/authenticator" />
+    </service>
+
+    <service
+            android:name="org.thoughtcrime.securesms.util.DirectorySyncService"
+            android:exported="true"
+            android:process=":sync">
+            <intent-filter>
+                <action android:name="android.content.SyncAdapter"/>
+            </intent-filter>
+            <meta-data android:name="android.content.SyncAdapter"
+                    android:resource="@xml/syncadapter" />
+    </service>
 
 <!--	<receiver android:name=".service.BootListener" -->
 <!-- 			  android:enabled="true" -->
@@ -269,7 +293,13 @@
               android:grantUriPermissions="true"
               android:authorities="org.thoughtcrime.provider.securesms" />
 
-    <receiver android:name=".service.RegistrationNotifier"
+    <provider android:name="org.thoughtcrime.securesms.util.DirectorySyncContentProvider"
+              android:authorities="org.thoughtcrime.provider.directorysync"
+              android:exported="false"
+              android:syncable="true"/>
+
+
+        <receiver android:name=".service.RegistrationNotifier"
               android:exported="false">
         <intent-filter>
             <action android:name="org.thoughtcrime.securesms.REGISTRATION_EVENT" />

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -289,6 +289,15 @@
         </intent-filter>
     </receiver>
 
+    <receiver android:name=".util.PackageUpgradeReceiver" >
+      <intent-filter>
+        <action android:name="android.intent.action.PACKAGE_REPLACED" />
+        <data android:scheme="package" android:path="org.thoughtcrime.securesms" />
+    </intent-filter>
+
+    </receiver>
+
+        
     <provider android:name=".providers.PartProvider"
               android:grantUriPermissions="true"
               android:authorities="org.thoughtcrime.provider.securesms" />

--- a/res/xml/authenticator.xml
+++ b/res/xml/authenticator.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<account-authenticator
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accountType="directory.securesms.thoughtcrime.org"
+    android:icon="@drawable/icon"
+    android:smallIcon="@drawable/icon"
+    android:label="@string/app_name"/>

--- a/res/xml/syncadapter.xml
+++ b/res/xml/syncadapter.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<sync-adapter
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:contentAuthority="org.thoughtcrime.provider.directorysync"
+        android:accountType="directory.securesms.thoughtcrime.org"
+        android:userVisible="true"
+        android:supportsUploading="false"
+        android:allowParallelSyncs="false"
+        android:isAlwaysSyncable="true"/>

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -73,8 +73,6 @@ public class ConversationListActivity extends PassphraseRequiredSherlockFragment
     initializeContactUpdatesReceiver();
 
     DirectoryRefreshListener.schedule(this);
-
-    AccountUtil.ensureAccountExists(this);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -1,9 +1,6 @@
 package org.thoughtcrime.securesms;
 
-import android.accounts.Account;
-import android.accounts.AccountManager;
 import android.app.Activity;
-import android.content.Context;
 import android.content.Intent;
 import android.content.res.TypedArray;
 import android.database.ContentObserver;
@@ -34,6 +31,7 @@ import org.thoughtcrime.securesms.recipients.RecipientFactory;
 import org.thoughtcrime.securesms.recipients.Recipients;
 import org.thoughtcrime.securesms.service.KeyCachingService;
 import org.thoughtcrime.securesms.service.SendReceiveService;
+import org.thoughtcrime.securesms.util.AccountUtil;
 import org.thoughtcrime.securesms.util.ActionBarUtil;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicTheme;
@@ -59,13 +57,6 @@ public class ConversationListActivity extends PassphraseRequiredSherlockFragment
   private DrawerToggle drawerToggle;
   private ListView     drawerList;
 
-  // Data needed to add the Android Account needed for the SyncAdapter refreshing the directory
-  public static final String DIRECTORYSYNC_AUTHORITY = "org.thoughtcrime.securesms.providers.directorysync";
-  public static final String DIRECTORYSYNC_ACCOUNT_TYPE = "directory.securesms.thoughtcrime.org";
-  public static final String DIRECTORYSYNC_ACCOUNT = "Directory";
-  Account directorySyncAccount;
-
-
   @Override
   public void onCreate(Bundle icicle) {
     dynamicTheme.onCreate(this);
@@ -83,29 +74,8 @@ public class ConversationListActivity extends PassphraseRequiredSherlockFragment
 
     DirectoryRefreshListener.schedule(this);
 
-    // Create the account needed for the SyncAdapter
-    directorySyncAccount = CreateDirectorySyncAccount(this);
-            DIRECTORYSYNC_INTERVAL);
+    AccountUtil.ensureAccountExists(this);
   }
-
-  public static Account CreateDirectorySyncAccount(Context context) {
-      // Create the account type and default account
-      Account newAccount = new Account(DIRECTORYSYNC_ACCOUNT, DIRECTORYSYNC_ACCOUNT_TYPE);
-      AccountManager accountManager = (AccountManager) context.getSystemService(ACCOUNT_SERVICE);
-      /*
-       * Add the account and account type, no password or user data
-       * If successful, return the Account object, otherwise report an error.
-       */
-      if (accountManager.addAccountExplicitly(newAccount, null, null)) {
-          context.getContentResolver().setIsSyncable(newAccount, DIRECTORYSYNC_AUTHORITY, 1);
-        } else {
-          // TODO error handling
-          Log.e("", "Could not create sync account");
-        }
-
-      return newAccount;
-    }
-
 
   @Override
   public void onPostCreate(Bundle bundle) {

--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -25,6 +25,7 @@ import com.google.i18n.phonenumbers.NumberParseException;
 import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import com.google.i18n.phonenumbers.Phonenumber;
 
+import org.thoughtcrime.securesms.util.AccountUtil;
 import org.thoughtcrime.securesms.util.ActionBarUtil;
 import org.whispersystems.textsecure.crypto.MasterSecret;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
@@ -62,6 +63,9 @@ public class RegistrationActivity extends SherlockActivity {
     initializeResources();
     initializeSpinner();
     initializeNumber();
+
+    Log.i("RegistrationActivity", "Creating TextSecure Directory account");
+    AccountUtil.ensureAccountExists(getApplicationContext());
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/util/AccountUtil.java
+++ b/src/org/thoughtcrime/securesms/util/AccountUtil.java
@@ -1,0 +1,50 @@
+package org.thoughtcrime.securesms.util;
+
+import android.accounts.Account;
+import android.accounts.AccountManager;
+import android.content.Context;
+import android.util.Log;
+
+/**
+ * Utility class to work with the Android Account Framework
+ *
+ * @author Lukas Barth.
+ */
+public class AccountUtil {
+
+  public static final String DIRECTORYSYNC_AUTHORITY = "org.thoughtcrime.securesms.providers.directorysync";
+  public static final String DIRECTORYSYNC_ACCOUNT_TYPE = "directory.securesms.thoughtcrime.org";
+  public static final String DIRECTORYSYNC_ACCOUNT = "Directory";
+  Account directorySyncAccount;
+
+  public static Account getAccount(Context context) {
+    AccountManager accountManager = (AccountManager) context.getSystemService(context.ACCOUNT_SERVICE);
+    Account[] accounts = accountManager.getAccountsByType(DIRECTORYSYNC_ACCOUNT_TYPE);
+
+    if (accounts.length == 0) {
+      return null;
+    }
+
+    return accounts[0];
+  }
+
+  public static void ensureAccountExists(Context context) {
+    if (getAccount(context) == null) {
+      createDirectorySyncAccount(context);
+    }
+  }
+
+  public static Account createDirectorySyncAccount(Context context) {
+    Account newAccount = new Account(DIRECTORYSYNC_ACCOUNT, DIRECTORYSYNC_ACCOUNT_TYPE);
+    AccountManager accountManager = (AccountManager) context.getSystemService(context.ACCOUNT_SERVICE);
+
+    if (accountManager.addAccountExplicitly(newAccount, null, null)) {
+      context.getContentResolver().setIsSyncable(newAccount, DIRECTORYSYNC_AUTHORITY, 1);
+    } else {
+      // TODO error handling
+      Log.e("", "Could not create sync account");
+    }
+
+    return newAccount;
+  }
+}

--- a/src/org/thoughtcrime/securesms/util/DirectorySyncAdapter.java
+++ b/src/org/thoughtcrime/securesms/util/DirectorySyncAdapter.java
@@ -8,33 +8,45 @@ import android.content.SyncResult;
 import android.os.Bundle;
 
 /**
- * Created by Lukas Barth on 28.02.14.
+ * A SyncAdapter in charge of refreshing the directory of push-enabled contacts
+ *
+ * @author Lukas Barth
  */
 public class DirectorySyncAdapter extends AbstractThreadedSyncAdapter {
-    private Context ctx;
+  private Context context;
 
-    public DirectorySyncAdapter(Context context, boolean autoInitialize) {
-        super(context, autoInitialize);
+  private static DirectorySyncAdapter instance = null;
 
-        this.ctx = context;
+  private DirectorySyncAdapter(Context context, boolean autoInitialize) {
+    super(context, autoInitialize);
+
+    this.context = context;
+  }
+
+  private DirectorySyncAdapter(
+          Context context,
+          boolean autoInitialize,
+          boolean allowParallelSyncs) {
+    super(context, autoInitialize);
+
+    this.context = context;
+  }
+
+  public static DirectorySyncAdapter getInstance(Context context) {
+    if (DirectorySyncAdapter.instance == null) {
+      DirectorySyncAdapter.instance = new DirectorySyncAdapter(context, true);
     }
 
-    public DirectorySyncAdapter(
-            Context context,
-            boolean autoInitialize,
-            boolean allowParallelSyncs) {
-        super(context, autoInitialize); // No parallel stuff. Min. API level is 9
+    return DirectorySyncAdapter.instance;
+  }
 
-        this.ctx = context;
-    }
+  public void onPerformSync(
+          Account account,
+          Bundle extras,
+          String authority,
+          ContentProviderClient provider,
+          SyncResult syncResult) {
 
-     public void onPerformSync(
-            Account account,
-            Bundle extras,
-            String authority,
-            ContentProviderClient provider,
-            SyncResult syncResult) {
-
-        DirectoryHelper.refreshDirectory(this.ctx);
-     }
+    DirectoryHelper.refreshDirectory(this.context);
+  }
 }

--- a/src/org/thoughtcrime/securesms/util/DirectorySyncAdapter.java
+++ b/src/org/thoughtcrime/securesms/util/DirectorySyncAdapter.java
@@ -1,0 +1,40 @@
+package org.thoughtcrime.securesms.util;
+
+import android.accounts.Account;
+import android.content.AbstractThreadedSyncAdapter;
+import android.content.ContentProviderClient;
+import android.content.Context;
+import android.content.SyncResult;
+import android.os.Bundle;
+
+/**
+ * Created by Lukas Barth on 28.02.14.
+ */
+public class DirectorySyncAdapter extends AbstractThreadedSyncAdapter {
+    private Context ctx;
+
+    public DirectorySyncAdapter(Context context, boolean autoInitialize) {
+        super(context, autoInitialize);
+
+        this.ctx = context;
+    }
+
+    public DirectorySyncAdapter(
+            Context context,
+            boolean autoInitialize,
+            boolean allowParallelSyncs) {
+        super(context, autoInitialize); // No parallel stuff. Min. API level is 9
+
+        this.ctx = context;
+    }
+
+     public void onPerformSync(
+            Account account,
+            Bundle extras,
+            String authority,
+            ContentProviderClient provider,
+            SyncResult syncResult) {
+
+        DirectoryHelper.refreshDirectory(this.ctx);
+     }
+}

--- a/src/org/thoughtcrime/securesms/util/DirectorySyncAuthenticator.java
+++ b/src/org/thoughtcrime/securesms/util/DirectorySyncAuthenticator.java
@@ -1,0 +1,83 @@
+package org.thoughtcrime.securesms.util;
+
+import android.accounts.AbstractAccountAuthenticator;
+import android.accounts.Account;
+import android.accounts.AccountAuthenticatorResponse;
+import android.accounts.NetworkErrorException;
+import android.content.Context;
+import android.os.Bundle;
+
+/**
+ * We actually don't need to authenticate, but the Android framework needs this.
+ * This was shamelessly taken from
+ * https://developer.android.com/training/sync-adapters/creating-authenticator.html
+ *
+ * Created by Lukas Barth on 28.02.14.
+ */
+public class DirectorySyncAuthenticator extends AbstractAccountAuthenticator {
+    // Simple constructor
+    public DirectorySyncAuthenticator(Context context) {
+        super(context);
+    }
+
+    // Editing properties is not supported
+    @Override
+    public Bundle editProperties(
+            AccountAuthenticatorResponse r, String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    // Don't add additional accounts
+    @Override
+    public Bundle addAccount(
+            AccountAuthenticatorResponse r,
+            String s,
+            String s2,
+            String[] strings,
+            Bundle bundle) throws NetworkErrorException {
+        return null;
+    }
+
+    // Ignore attempts to confirm credentials
+    @Override
+    public Bundle confirmCredentials(
+            AccountAuthenticatorResponse r,
+            Account account,
+            Bundle bundle) throws NetworkErrorException {
+        return null;
+    }
+
+    // Getting an authentication token is not supported
+    @Override
+    public Bundle getAuthToken(
+            AccountAuthenticatorResponse r,
+            Account account,
+            String s,
+            Bundle bundle) throws NetworkErrorException {
+        throw new UnsupportedOperationException();
+    }
+
+    // Getting a label for the auth token is not supported
+    @Override
+    public String getAuthTokenLabel(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    // Updating user credentials is not supported
+    @Override
+    public Bundle updateCredentials(
+            AccountAuthenticatorResponse r,
+            Account account,
+            String s, Bundle bundle) throws NetworkErrorException {
+        throw new UnsupportedOperationException();
+    }
+
+    // Checking features for the account is not supported
+    @Override
+    public Bundle hasFeatures(
+        AccountAuthenticatorResponse r,
+        Account account, String[] strings) throws NetworkErrorException {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/src/org/thoughtcrime/securesms/util/DirectorySyncAuthenticatorService.java
+++ b/src/org/thoughtcrime/securesms/util/DirectorySyncAuthenticatorService.java
@@ -1,0 +1,31 @@
+package org.thoughtcrime.securesms.util;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+
+/**
+ * We actually don't need to authenticate, but the Android framework needs this.
+ * This was shamelessly taken from
+ * https://developer.android.com/training/sync-adapters/creating-authenticator.html
+ *
+ * Created by Lukas Barth on 28.02.14.
+ */
+public class DirectorySyncAuthenticatorService extends Service {
+    private DirectorySyncAuthenticator mAuthenticator;
+
+    @Override
+    public void onCreate() {
+        mAuthenticator = new DirectorySyncAuthenticator(this);
+    }
+
+    /*
+     * When the system binds to this Service to make the RPC call
+     * return the authenticator's IBinder.
+     */
+    @Override
+    public IBinder onBind(Intent intent) {
+        return mAuthenticator.getIBinder();
+    }
+
+}

--- a/src/org/thoughtcrime/securesms/util/DirectorySyncContentProvider.java
+++ b/src/org/thoughtcrime/securesms/util/DirectorySyncContentProvider.java
@@ -1,0 +1,73 @@
+package org.thoughtcrime.securesms.util;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+
+/**
+ * This is only a stub content provider providing no content. We do this because the
+ * Android framework needs a content provider to work with SyncAdapters.
+ *
+ * We could think about actually building a Content Provider for the contact data that we
+ * store in the database.
+ *
+ * This was taken from
+ * https://developer.android.com/training/sync-adapters/creating-stub-provider.html
+ *
+ * Created by Lukas Barth on 28.02.14.
+ */
+public class DirectorySyncContentProvider extends ContentProvider {
+    /*
+     * Always return true, indicating that the
+     * provider loaded correctly.
+     */
+    @Override
+    public boolean onCreate() {
+        return true;
+    }
+    /*
+     * Return an empty String for MIME type
+     */
+    @Override
+    public String getType(Uri uri) {
+        return new String();
+    }
+    /*
+     * query() always returns no results
+     *
+     */
+    @Override
+    public Cursor query(
+            Uri uri,
+            String[] projection,
+            String selection,
+            String[] selectionArgs,
+            String sortOrder) {
+        return null;
+    }
+    /*
+     * insert() always returns null (no URI)
+     */
+    @Override
+    public Uri insert(Uri uri, ContentValues values) {
+        return null;
+    }
+    /*
+     * delete() always returns "no rows affected" (0)
+     */
+    @Override
+    public int delete(Uri uri, String selection, String[] selectionArgs) {
+        return 0;
+    }
+    /*
+     * update() always returns "no rows affected" (0)
+     */
+    public int update(
+            Uri uri,
+            ContentValues values,
+            String selection,
+            String[] selectionArgs) {
+        return 0;
+    }
+}

--- a/src/org/thoughtcrime/securesms/util/DirectorySyncService.java
+++ b/src/org/thoughtcrime/securesms/util/DirectorySyncService.java
@@ -1,0 +1,27 @@
+package org.thoughtcrime.securesms.util;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+
+/**
+ * Created by tinloaf on 28.02.14.
+ */
+public class DirectorySyncService extends Service {
+    private static DirectorySyncAdapter adapter = null;
+    private static final Object sAdapterLock = new Object();
+
+    @Override
+    public void onCreate() {
+        synchronized (DirectorySyncService.sAdapterLock) {
+            if (DirectorySyncService.adapter == null) {
+                DirectorySyncService.adapter = new DirectorySyncAdapter(getApplicationContext(), true);
+            }
+        }
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return DirectorySyncService.adapter.getSyncAdapterBinder();
+    }
+}

--- a/src/org/thoughtcrime/securesms/util/DirectorySyncService.java
+++ b/src/org/thoughtcrime/securesms/util/DirectorySyncService.java
@@ -5,7 +5,9 @@ import android.content.Intent;
 import android.os.IBinder;
 
 /**
- * Created by tinloaf on 28.02.14.
+ * The service to run the directory sync in.
+ * 
+ * @author Lukas Barth
  */
 public class DirectorySyncService extends Service {
     private static DirectorySyncAdapter adapter = null;
@@ -15,7 +17,7 @@ public class DirectorySyncService extends Service {
     public void onCreate() {
         synchronized (DirectorySyncService.sAdapterLock) {
             if (DirectorySyncService.adapter == null) {
-                DirectorySyncService.adapter = new DirectorySyncAdapter(getApplicationContext(), true);
+                DirectorySyncService.adapter = DirectorySyncAdapter.getInstance(getApplicationContext());
             }
         }
     }

--- a/src/org/thoughtcrime/securesms/util/PackageUpgradeReceiver.java
+++ b/src/org/thoughtcrime/securesms/util/PackageUpgradeReceiver.java
@@ -1,0 +1,24 @@
+package org.thoughtcrime.securesms.util;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+/**
+ * Listens to the event that our package was replaced, i.e. updated
+ *
+ * @author Lukas Barth
+ */
+public class PackageUpgradeReceiver extends BroadcastReceiver {
+
+  private void handleAccountCreation(Context context) {
+    Log.i("PackageUpgradeReceiver", "Ensuring TextSecure account");
+    AccountUtil.ensureAccountExists(context);
+  }
+
+  @Override
+  public void onReceive(Context context, Intent intent) {
+    handleAccountCreation(context);
+  }
+}


### PR DESCRIPTION
This prepares us to do synchronizations on regular intervals (adding this is a one-liner) and also allows the user to enable and disable synchronization via the android settings. This would solve #859. Also, this is the way "all apps do synchronization in android". Or so they say...

Synchronizing the directory from the app could be done by calling this SyncAdapter, but I did not change that yet.