### PR TITLE
Improve drafts

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -535,6 +535,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       public void onClick(DialogInterface dialog, int which) {
         if (threadId > 0) {
           DatabaseFactory.getThreadDatabase(ConversationActivity.this).deleteConversation(threadId);
+          threadId = -1;
           finish();
         }
       }
@@ -916,28 +917,40 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void saveDraft() {
-    if (this.threadId <= 0 || this.recipients == null || this.recipients.isEmpty())
+    if (this.recipients == null || this.recipients.isEmpty())
       return;
 
-    final Drafts       drafts           = getDraftsForCurrentState();
-    final long         thisThreadId     = this.threadId;
-    final MasterSecret thisMasterSecret = this.masterSecret.parcelClone();
+    new SaveDraftTask(getDraftsForCurrentState(), this.threadId, this.masterSecret.parcelClone()).execute();
+  }
 
-    new AsyncTask<Void, Void, Void>() {
-      @Override
-      protected Void doInBackground(Void... params) {
-        MasterCipher masterCipher = new MasterCipher(thisMasterSecret);
-        DatabaseFactory.getDraftDatabase(ConversationActivity.this).insertDrafts(masterCipher, thisThreadId, drafts);
-        ThreadDatabase threadDatabase = DatabaseFactory.getThreadDatabase(ConversationActivity.this);
-        if (drafts.size() > 0) {
-          threadDatabase.updateSnippet(thisThreadId, drafts.getSnippet(ConversationActivity.this), Types.BASE_DRAFT_TYPE);
-        } else {
-          threadDatabase.update(thisThreadId);
+  private class SaveDraftTask extends AsyncTask<Void, Void, Void> {
+    private Drafts drafts;
+    private long threadId;
+    private MasterSecret masterSecret;
+
+    SaveDraftTask(Drafts drafts, long threadId, MasterSecret masterSecret) {
+      this.drafts = drafts;
+      this.threadId = threadId;
+      this.masterSecret = masterSecret;
+    }
+
+    @Override
+    protected Void doInBackground(Void... params) {
+      ThreadDatabase threadDatabase = DatabaseFactory.getThreadDatabase(ConversationActivity.this);
+
+      if (drafts.size() > 0) {
+        if (threadId <= 0) {
+            threadId = threadDatabase.getThreadIdFor(getRecipients(), distributionType);
         }
-        MemoryCleaner.clean(thisMasterSecret);
-        return null;
+        MasterCipher masterCipher = new MasterCipher(masterSecret);
+        DatabaseFactory.getDraftDatabase(ConversationActivity.this).insertDrafts(masterCipher, threadId, drafts);
+        threadDatabase.updateSnippet(threadId, drafts.getSnippet(ConversationActivity.this), Types.BASE_DRAFT_TYPE);
+      } else if (threadId > 0) {
+          threadDatabase.update(threadId);
       }
-    }.execute();
+      MemoryCleaner.clean(masterSecret);
+      return null;
+    }
   }
 
   private void calculateCharactersRemaining() {

--- a/src/org/thoughtcrime/securesms/database/DraftDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/DraftDatabase.java
@@ -13,6 +13,7 @@ import org.thoughtcrime.securesms.crypto.MasterCipher;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 public class DraftDatabase extends Database {
 
@@ -49,6 +50,27 @@ public class DraftDatabase extends Database {
   public void clearDrafts(long threadId) {
     SQLiteDatabase db = databaseHelper.getWritableDatabase();
     db.delete(TABLE_NAME, THREAD_ID + " = ?", new String[] {threadId+""});
+  }
+
+  public void clearDrafts(Set<Long> threadIds) {
+    SQLiteDatabase db   = databaseHelper.getWritableDatabase();
+    StringBuilder where = new StringBuilder();
+
+    String[] whereArgs = new String[threadIds.size()];
+    int i = 0;
+    for (long threadId : threadIds) {
+      if (i > 0) where.append(" OR ");
+      where.append(THREAD_ID).append(" = ?");
+      whereArgs[i] = threadId+"";
+      i++;
+    }
+
+    db.delete(TABLE_NAME, where.toString(), whereArgs);
+  }
+
+  public void clearAllDrafts() {
+    SQLiteDatabase db = databaseHelper.getWritableDatabase();
+    db.delete(TABLE_NAME, null, null);
   }
 
   public List<Draft> getDrafts(MasterCipher masterCipher, long threadId) {

--- a/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -290,6 +290,7 @@ public class ThreadDatabase extends Database {
   public void deleteConversation(long threadId) {
     DatabaseFactory.getSmsDatabase(context).deleteThread(threadId);
     DatabaseFactory.getMmsDatabase(context).deleteThread(threadId);
+    DatabaseFactory.getDraftDatabase(context).clearDrafts(threadId);
     deleteThread(threadId);
     notifyConversationListeners(threadId);
     notifyConversationListListeners();
@@ -299,6 +300,7 @@ public class ThreadDatabase extends Database {
   public void deleteConversations(Set<Long> selectedConversations) {
     DatabaseFactory.getSmsDatabase(context).deleteThreads(selectedConversations);
     DatabaseFactory.getMmsDatabase(context).deleteThreads(selectedConversations);
+    DatabaseFactory.getDraftDatabase(context).clearDrafts(selectedConversations);
     deleteThreads(selectedConversations);
     notifyConversationListeners(selectedConversations);
     notifyConversationListListeners();
@@ -307,6 +309,7 @@ public class ThreadDatabase extends Database {
   public void deleteAllConversations() {
     DatabaseFactory.getSmsDatabase(context).deleteAllThreads();
     DatabaseFactory.getMmsDatabase(context).deleteAllThreads();
+    DatabaseFactory.getDraftDatabase(context).clearAllDrafts();
     deleteAllThreads();
   }
 


### PR DESCRIPTION
The first commit is a small fix to delete a draft when the conversation is deleted. Until now the draft wasn't deleted and could reappear in a new thread. The bug can easily be reproduced by creating a new group, creating a draft, delete the thread and create a new group. The new group now contains the draft from the old group.

The second commit adds the possibility to save drafts for recipients you haven't written to before, i.e. no thread exists. This also fixes the behavior described by @landry314 in #103. It is implemented by creating a new thread (if necessary) when a draft is saved. When the draft is deleted and no other messages exist in the thread, the thread is deleted in ThreadDatabase.update().
