### PR TITLE
Replace telephone numbers in a new group chat with contact names

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -176,7 +176,7 @@
     <string name="GroupUtil_group_updated">Group updated.</string>
     <string name="GroupUtil_joined_the_group">joined the group.</string>
     <string name="GroupUtil_title_is_now">Title is now</string>
-    <string name="GroupUtil_me">Me</string>
+    <string name="GroupUtil_you">You</string>
 
     <!-- ImportExportActivity -->
     <string name="ImportExportActivity_import">Import</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -172,6 +172,12 @@
     <!-- GroupMembersDialog -->
     <string name="GroupMembersDialog_me">Me</string>
 
+    <!-- GroupUtil -->
+    <string name="GroupUtil_group_updated">Group updated.</string>
+    <string name="GroupUtil_joined_the_group">joined the group.</string>
+    <string name="GroupUtil_title_is_now">Title is now</string>
+    <string name="GroupUtil_me">Me</string>
+
     <!-- ImportExportActivity -->
     <string name="ImportExportActivity_import">Import</string>
     <string name="ImportExportActivity_export">Export</string>

--- a/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -97,7 +97,7 @@ public abstract class MessageRecord extends DisplayRecord {
     if (isGroupUpdate() && isOutgoing()) {
       return emphasisAdded("Updated the group.");
     } else if (isGroupUpdate()) {
-      return emphasisAdded(GroupUtil.getDescription(getBody().getBody()));
+      return emphasisAdded(GroupUtil.getDescription(context, getBody().getBody()));
     } else if (isGroupQuit() && isOutgoing()) {
       return emphasisAdded("You have left the group.");
     } else if (isGroupQuit()) {

--- a/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
@@ -57,7 +57,7 @@ public class ThreadRecord extends DisplayRecord {
     if (SmsDatabase.Types.isDecryptInProgressType(type)) {
       return emphasisAdded(context.getString(R.string.MessageDisplayHelper_decrypting_please_wait));
     } else if (isGroupUpdate()) {
-      return emphasisAdded(GroupUtil.getDescription(getBody().getBody()));
+      return emphasisAdded(GroupUtil.getDescription(context, getBody().getBody()));
     } else if (isGroupQuit()) {
       return emphasisAdded(context.getString(R.string.ThreadRecord_left_the_group));
     } else if (isKeyExchange()) {

--- a/src/org/thoughtcrime/securesms/util/GroupUtil.java
+++ b/src/org/thoughtcrime/securesms/util/GroupUtil.java
@@ -63,7 +63,7 @@ public class GroupUtil {
           if (memberName != null) {
             memberList.add(memberName);
           } else if (isOwnNumber(context, memberNumber)){
-            memberList.add(context.getString(R.string.GroupUtil_me));
+            memberList.add(context.getString(R.string.GroupUtil_you));
           } else {
             memberList.add(memberNumber);
           }

--- a/src/org/thoughtcrime/securesms/util/GroupUtil.java
+++ b/src/org/thoughtcrime/securesms/util/GroupUtil.java
@@ -1,10 +1,16 @@
 package org.thoughtcrime.securesms.util;
 
+import android.content.Context;
 import android.util.Log;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.contacts.ContactAccessor;
+import org.whispersystems.textsecure.api.util.InvalidNumberException;
+
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.whispersystems.textsecure.internal.push.PushMessageProtos.PushMessageContent.GroupContext;
@@ -29,32 +35,54 @@ public class GroupUtil {
     return groupId.startsWith(ENCODED_GROUP_PREFIX);
   }
 
-  public static String getDescription(String encodedGroup) {
+  public static boolean isOwnNumber(Context context, String number) {
+    String e164number = "";
+    try {
+      e164number = Util.canonicalizeNumber(context, number);
+    } catch (InvalidNumberException ine) {
+      Log.w("GroupUtil", ine);
+    }
+    return e164number.equals(TextSecurePreferences.getLocalNumber(context));
+  }
+
+  public static String getDescription(Context context, String encodedGroup) {
     if (encodedGroup == null) {
-      return "Group updated.";
+      return context.getString(R.string.GroupUtil_group_updated);
     }
 
     try {
-      String       description = "";
-      GroupContext context     = GroupContext.parseFrom(Base64.decode(encodedGroup));
-      List<String> members     = context.getMembersList();
-      String       title       = context.getName();
+      String       description   = "";
+      GroupContext groupContext  = GroupContext.parseFrom(Base64.decode(encodedGroup));
+      List<String> memberNumbers = groupContext.getMembersList();
+      List<String> memberList    = new ArrayList<String>();
+      String       title         = groupContext.getName();
 
-      if (!members.isEmpty()) {
-        description += Util.join(members, ", ") + " joined the group.";
+      if (!memberNumbers.isEmpty()) {
+        for (String memberNumber : memberNumbers) {
+          String memberName = ContactAccessor.getInstance().getNameForNumber(context, memberNumber);
+          if (memberName != null) {
+            memberList.add(memberName);
+          } else if (isOwnNumber(context, memberNumber)){
+            memberList.add(context.getString(R.string.GroupUtil_me));
+          } else {
+            memberList.add(memberNumber);
+          }
+        }
+
+        description += Util.join(memberList, ", ") + " " + context.getString(R.string.GroupUtil_joined_the_group);
       }
 
       if (title != null && !title.trim().isEmpty()) {
-        description += " Title is now '" + title + "'.";
+        description += " " + context.getString(R.string.GroupUtil_title_is_now) + " '" + title + "'.";
       }
 
       return description;
     } catch (InvalidProtocolBufferException e) {
       Log.w("GroupUtil", e);
-      return "Group updated.";
+      return context.getString(R.string.GroupUtil_group_updated);
     } catch (IOException e) {
       Log.w("GroupUtil", e);
-      return "Group updated.";
+      return context.getString(R.string.GroupUtil_group_updated);
     }
   }
 }


### PR DESCRIPTION
I replaced the telephone numers in a new group chat with the corresponding contact names or in case of the own number with "Me". I also made some old strings translatable.

I copied the check for the own number from #1505 and put it in isOwnNumber(). Perhaps we could put this method in a place where it could be used from both PR's?

**before:**
![before](https://cloud.githubusercontent.com/assets/5296073/3379294/30824ffa-fbef-11e3-9b6b-6c739c3cfbdc.png)
**after:**
![after](https://cloud.githubusercontent.com/assets/5296073/3379296/33605514-fbef-11e3-960f-cc4bcbbdba1e.png)
