### PR TITLE
Per-Recipient notification silencing

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -196,6 +196,9 @@
               android:label="@string/AndroidManifest__media_preview"
               android:windowSoftInputMode="stateHidden"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
+    
+    <activity android:name=".RecipientNotificationSettingsActivity"
+              android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
     <activity android:name=".DummyActivity"
               android:theme="@android:style/Theme.NoDisplay"

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,10 @@ dependencies {
     }
     compile 'com.squareup.dagger:dagger:1.2.2'
     provided 'com.squareup.dagger:dagger-compiler:1.2.2'
+    
+    compile ("com.doomonafireball.betterpickers:library:1.5.2") {
+        exclude group: 'com.android.support', module: 'support-v4'
+    }
 
     androidTestCompile 'com.squareup:fest-android:1.0.8'
     androidTestCompile 'com.google.dexmaker:dexmaker:1.1'

--- a/res/layout/conversation_fragment.xml
+++ b/res/layout/conversation_fragment.xml
@@ -5,6 +5,12 @@
               android:layout_height="match_parent"
               android:orientation="vertical">
 
+    <FrameLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/reminderHolder">
+    </FrameLayout>
+
     <ListView android:id="@android:id/list"
               style="?android:attr/listViewWhiteStyle"
               android:layout_width="fill_parent"

--- a/res/layout/recipient_notification_settings_activity.xml
+++ b/res/layout/recipient_notification_settings_activity.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="vertical"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
+
+    <LinearLayout
+        android:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="20dp"
+        >
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceLarge"
+            android:layout_alignParentLeft="true"
+            android:text="Mute permanently"
+            android:id="@+id/textView"
+            android:layout_gravity="center_vertical|left"
+            android:layout_weight="1"/>
+
+        <ToggleButton
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="New ToggleButton"
+            android:id="@+id/silencePermanentlySwitch"
+            android:layout_alignParentRight="true"
+            android:layout_gravity="center_vertical|right"
+            />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:padding="20dp"
+        android:id="@+id/silenceTemporarilyContainer">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceLarge"
+            android:text="Mute temporarily"
+            android:id="@+id/silenceTemporaryText"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:id="@+id/silenceTemporaryStatus"/>
+    </LinearLayout>
+
+</LinearLayout>

--- a/res/menu/conversation.xml
+++ b/res/menu/conversation.xml
@@ -13,4 +13,8 @@
           android:id="@+id/menu_delete_thread"
           android:icon="@android:drawable/ic_menu_delete" />
 
+    <item android:title="@string/conversation__menu_notification_settings"
+          android:id="@+id/menu_notification_settings"
+          />
+
 </menu>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -843,6 +843,7 @@
     <string name="conversation__menu_leave_group">Leave group</string>
     <string name="conversation__menu_add_contact_info">Add contact info</string>
     <string name="conversation__menu_delete_thread">Delete thread</string>
+    <string name="conversation__menu_notification_settings">Notification settings</string>
 
     <!-- conversation_group_options -->
     <string name="convesation_group_options__recipients_list">Recipients list</string>
@@ -867,6 +868,10 @@
 
     <!-- verify_keys -->
     <string name="verify_keys__menu_verified">Verified</string>
+
+    <!-- Per-Recipient notification settings -->
+    <string name="notification_settings__not_temporarily_muted">Not temporarily muted</string>
+    <string name="notification_settings__muted_until">Muted until: </string>
 
     <!-- reminder_header -->
     <string name="reminder_header_sms_default_title">Use as default SMS app?</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -889,6 +889,10 @@
 
     <!-- media_preview_activity -->
     <string name="media_preview_activity__image_content_description">Image Preview</string>
+    
+    <string name="reminder_header_silenced_title">Notifications muted</string>
+    <string name="reminder_header_silenced_text">Notifications for this thread are currently muted.</string>
+    <string name="reminder_header_silenced_ok">Restore</string>
     <!-- EOF -->
 
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -891,7 +891,7 @@
     <string name="media_preview_activity__image_content_description">Image Preview</string>
     
     <string name="reminder_header_silenced_title">Notifications muted</string>
-    <string name="reminder_header_silenced_text">Notifications for this thread are currently muted.</string>
+    <string name="reminder_header_silenced_text">Notifications for this thread are muted.</string>
     <string name="reminder_header_silenced_ok">Restore</string>
     <!-- EOF -->
 

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -305,6 +305,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     case R.id.menu_distribution_conversation: handleDistributionConversationEnabled(item);       return true;
     case R.id.menu_edit_group:                handleEditPushGroup();                             return true;
     case R.id.menu_leave:                     handleLeavePushGroup();                            return true;
+    case R.id.menu_notification_settings:     handleNotificationSettings();                      return true;
     case android.R.id.home:                   handleReturnToConversationList();                  return true;
     }
 
@@ -519,6 +520,14 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
         }
       }.execute();
     }
+  }
+
+  private void handleNotificationSettings() {
+    Recipient recipient = getRecipients().getPrimaryRecipient();
+
+    Intent notificationSettingsIntent = new Intent(this, RecipientNotificationSettingsActivity.class);
+    notificationSettingsIntent.putExtra("recipient", recipient);
+    startActivity(notificationSettingsIntent);
   }
 
   private void handleDial(Recipient recipient) {

--- a/src/org/thoughtcrime/securesms/RecipientNotificationSettingsActivity.java
+++ b/src/org/thoughtcrime/securesms/RecipientNotificationSettingsActivity.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright (C) 2014 Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import android.os.Bundle;
+import android.view.View;
+import android.widget.CompoundButton;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+import android.widget.ToggleButton;
+
+import com.actionbarsherlock.app.SherlockFragmentActivity;
+import com.actionbarsherlock.view.MenuItem;
+import com.doomonafireball.betterpickers.hmspicker.HmsPickerBuilder;
+import com.doomonafireball.betterpickers.hmspicker.HmsPickerDialogFragment;
+
+import org.thoughtcrime.securesms.database.DatabaseFactory;
+import org.thoughtcrime.securesms.database.RecipientNotificationsDatabase;
+import org.thoughtcrime.securesms.recipients.Recipient;
+import org.thoughtcrime.securesms.util.DynamicLanguage;
+import org.thoughtcrime.securesms.util.DynamicTheme;
+
+import java.text.DateFormat;
+import java.util.Date;
+
+
+/**
+ * Activity that will let the user set a subset of the notification settings on a
+ * per-recipient basis.
+ *
+ * @author Lukas Barth
+ *
+ */
+public class RecipientNotificationSettingsActivity extends SherlockFragmentActivity
+  implements HmsPickerDialogFragment.HmsPickerDialogHandler
+{
+  private static final String FRAG_TAG_TIME_PICKER = "timePickerDialogFragment";
+
+  private Recipient recipient;
+
+  private ToggleButton silencePermanentlyPreference;
+  private TextView silenceUntilText;
+  private TextView silenceTemporaryText;
+  private LinearLayout silenceTemporaryContainer;
+
+  private final DynamicTheme dynamicTheme       = new DynamicTheme();
+  private final DynamicLanguage dynamicLanguage = new DynamicLanguage();
+
+  @Override
+  protected void onCreate(Bundle icicle) {
+    dynamicTheme.onCreate(this);
+    dynamicLanguage.onCreate(this);
+    super.onCreate(icicle);
+
+    this.getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    this.getSupportActionBar().setHomeButtonEnabled(true);
+
+    this.setContentView(R.layout.recipient_notification_settings_activity);
+
+    initializeResources();
+    updateValues();
+  }
+
+  private void updateValues() {
+    RecipientNotificationsDatabase notificationsDatabase = DatabaseFactory.getInstance(this).getNotificationDatabase(this);
+
+    boolean permanentlySilenced = notificationsDatabase.isSilencedPermanently(this.recipient);
+    if (permanentlySilenced) {
+      this.silencePermanentlyPreference.setChecked(true);
+    } else {
+      this.silencePermanentlyPreference.setChecked(false);
+    }
+
+    Long silenceUntil = notificationsDatabase.getSilencedUntil(recipient);
+    Long now = System.currentTimeMillis() / 1000;
+    if ((silenceUntil == null) || (silenceUntil < now)) {
+      this.silenceUntilText.setText(R.string.notification_settings__not_temporarily_muted);
+    } else {
+      Date silenceUntilDate = new Date(silenceUntil * 1000);
+      DateFormat dateFormat = DateFormat.getDateTimeInstance();
+
+      this.silenceUntilText.setText(getString(R.string.notification_settings__muted_until) + dateFormat.format(silenceUntilDate));
+    }
+
+    if (permanentlySilenced) {
+      this.silenceUntilText.setEnabled(false);
+      this.silenceTemporaryText.setEnabled(false);
+      this.silenceTemporaryContainer.setClickable(false);
+    } else {
+      this.silenceUntilText.setEnabled(true);
+      this.silenceTemporaryText.setEnabled(true);
+      this.silenceTemporaryContainer.setClickable(true);
+    }
+  }
+
+  private void initializeResources() {
+    this.recipient = getIntent().getParcelableExtra("recipient");
+
+    this.silencePermanentlyPreference = (ToggleButton) findViewById(R.id.silencePermanentlySwitch);
+    this.silencePermanentlyPreference.setOnCheckedChangeListener(new SilencePermanentlyListener());
+
+    this.silenceUntilText = (TextView) findViewById(R.id.silenceTemporaryStatus);
+    this.silenceTemporaryText = (TextView) findViewById(R.id.silenceTemporaryText);
+
+    this.silenceTemporaryContainer = (LinearLayout) findViewById(R.id.silenceTemporarilyContainer);
+    this.silenceTemporaryContainer.setOnClickListener(new SilenceTemporaryClickListener());
+  }
+
+  @Override
+  public boolean onMenuItemSelected(int featureId, MenuItem item) {
+    int itemId = item.getItemId();
+
+    if (itemId == android.R.id.home) {
+      finish();
+    }
+
+    return true;
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    dynamicTheme.onResume(this);
+    dynamicLanguage.onResume(this);
+  }
+
+  private class SilenceTemporaryClickListener implements View.OnClickListener
+  {
+    @Override
+    public void onClick(View view) {
+      HmsPickerBuilder builder = new HmsPickerBuilder()
+              .setFragmentManager(getSupportFragmentManager())
+              .setStyleResId(R.style.BetterPickersDialogFragment);
+      builder.show();
+    }
+
+  }
+
+  @Override
+  public void onDialogHmsSet(int reference, int hours, int minutes, int seconds) {
+    long now = System.currentTimeMillis() / 1000;
+
+    long then = now + ((hours * 60) + minutes) * 60 + seconds;
+
+    RecipientNotificationsDatabase notificationsDatabase = DatabaseFactory
+            .getNotificationDatabase(RecipientNotificationSettingsActivity.this);
+
+    notificationsDatabase.setSilenceUntil(recipient, then);
+    this.updateValues();
+  }
+
+  private class SilencePermanentlyListener implements CompoundButton.OnCheckedChangeListener {
+
+    @Override
+    public void onCheckedChanged(CompoundButton widget, boolean checked) {
+      RecipientNotificationsDatabase notificationsDatabase = DatabaseFactory
+              .getNotificationDatabase(RecipientNotificationSettingsActivity.this);
+
+      notificationsDatabase.setSilencePermanently(RecipientNotificationSettingsActivity.this.recipient,
+              checked);
+      RecipientNotificationSettingsActivity.this.updateValues();
+    }
+  }
+
+}

--- a/src/org/thoughtcrime/securesms/RecipientNotificationSettingsActivity.java
+++ b/src/org/thoughtcrime/securesms/RecipientNotificationSettingsActivity.java
@@ -17,14 +17,14 @@
 package org.thoughtcrime.securesms;
 
 import android.os.Bundle;
+import android.support.v7.app.ActionBarActivity;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.CompoundButton;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.ToggleButton;
 
-import com.actionbarsherlock.app.SherlockFragmentActivity;
-import com.actionbarsherlock.view.MenuItem;
 import com.doomonafireball.betterpickers.hmspicker.HmsPickerBuilder;
 import com.doomonafireball.betterpickers.hmspicker.HmsPickerDialogFragment;
 
@@ -45,7 +45,7 @@ import java.util.Date;
  * @author Lukas Barth
  *
  */
-public class RecipientNotificationSettingsActivity extends SherlockFragmentActivity
+public class RecipientNotificationSettingsActivity extends ActionBarActivity
   implements HmsPickerDialogFragment.HmsPickerDialogHandler
 {
   private static final String FRAG_TAG_TIME_PICKER = "timePickerDialogFragment";
@@ -121,7 +121,7 @@ public class RecipientNotificationSettingsActivity extends SherlockFragmentActiv
   }
 
   @Override
-  public boolean onMenuItemSelected(int featureId, MenuItem item) {
+  public boolean onOptionsItemSelected(MenuItem item) {
     int itemId = item.getItemId();
 
     if (itemId == android.R.id.home) {

--- a/src/org/thoughtcrime/securesms/components/Reminder.java
+++ b/src/org/thoughtcrime/securesms/components/Reminder.java
@@ -7,27 +7,27 @@ import android.view.ViewGroup;
 import org.thoughtcrime.securesms.R;
 
 public abstract class Reminder {
-  private int             iconResId;
-  private int             titleResId;
-  private int             textResId;
+  private Integer         iconResId;
+  private Integer         titleResId;
+  private Integer         textResId;
   private OnClickListener okListener;
   private OnClickListener cancelListener;
 
-  public Reminder(int iconResId, int titleResId, int textResId) {
+  public Reminder(Integer iconResId, Integer titleResId, Integer textResId) {
     this.iconResId  = iconResId;
     this.titleResId = titleResId;
     this.textResId  = textResId;
   }
 
-  public int getIconResId() {
+  public Integer getIconResId() {
     return iconResId;
   }
 
-  public int getTitleResId() {
+  public Integer getTitleResId() {
     return titleResId;
   }
 
-  public int getTextResId() {
+  public Integer getTextResId() {
     return textResId;
   }
 
@@ -50,4 +50,6 @@ public abstract class Reminder {
   public String getOKText() {
     return null;
   }
+
+  public Integer getCancelResId() { return R.drawable.ic_menu_remove_holo_light; }
 }

--- a/src/org/thoughtcrime/securesms/components/Reminder.java
+++ b/src/org/thoughtcrime/securesms/components/Reminder.java
@@ -46,4 +46,8 @@ public abstract class Reminder {
   public void setCancelListener(OnClickListener cancelListener) {
     this.cancelListener = cancelListener;
   }
+
+  public String getOKText() {
+    return null;
+  }
 }

--- a/src/org/thoughtcrime/securesms/components/ReminderView.java
+++ b/src/org/thoughtcrime/securesms/components/ReminderView.java
@@ -53,9 +53,33 @@ public class ReminderView extends LinearLayout {
   }
 
   public void showReminder(final Reminder reminder) {
-    icon.setImageResource(reminder.getIconResId());
-    title.setText(reminder.getTitleResId());
-    text.setText(reminder.getTextResId());
+    if (reminder.getIconResId() != null) {
+      icon.setImageResource(reminder.getIconResId());
+      icon.setVisibility(View.VISIBLE);
+    } else {
+      icon.setVisibility(View.GONE);
+    }
+
+    if (reminder.getTitleResId() != null) {
+      title.setText(reminder.getTitleResId());
+      title.setVisibility(View.VISIBLE);
+    } else {
+      title.setVisibility(View.GONE);
+    }
+
+    if (reminder.getTextResId() != null) {
+      text.setText(reminder.getTextResId());
+      text.setVisibility(View.VISIBLE);
+    } else {
+      text.setVisibility(View.GONE);
+    }
+
+    if (reminder.getCancelResId() != null) {
+      cancel.setImageResource(reminder.getCancelResId());
+      cancel.setVisibility(View.VISIBLE);
+    } else {
+      cancel.setVisibility(View.GONE);
+    }
 
     ok.setOnClickListener(reminder.getOkListener());
     if (reminder.getOKText() != null) {

--- a/src/org/thoughtcrime/securesms/components/ReminderView.java
+++ b/src/org/thoughtcrime/securesms/components/ReminderView.java
@@ -56,7 +56,12 @@ public class ReminderView extends LinearLayout {
     icon.setImageResource(reminder.getIconResId());
     title.setText(reminder.getTitleResId());
     text.setText(reminder.getTextResId());
+
     ok.setOnClickListener(reminder.getOkListener());
+    if (reminder.getOKText() != null) {
+      ok.setText(reminder.getOKText());
+    }
+
     cancel.setOnClickListener(new OnClickListener() {
       @Override
       public void onClick(View v) {

--- a/src/org/thoughtcrime/securesms/database/RecipientNotificationsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/RecipientNotificationsDatabase.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (C) 2014 Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms.database;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+import android.util.Log;
+
+import org.thoughtcrime.securesms.recipients.Recipient;
+
+/**
+ * Database storing per-recipient notification settings. Please note that this database does
+ * not store Recipient ID <=> settings, but rather Recipient Number <=> Settings, so that
+ * Groups and simple recipients can be handled the same way.
+ *
+ * @author Lukas Barth
+ */
+public class RecipientNotificationsDatabase extends Database {
+
+  private static final String TAG = RecipientNotificationsDatabase.class.getSimpleName();
+
+  private static final String TABLE_NAME        = "notifications";
+  public  static final String ID                = "_id";
+  public  static final String RECIPIENT_NR      = "recipient_nr";
+  public  static final String SILENCE_UNTIL     = "silence_until";
+  public  static final String SILENCE_PERMANENT = "silence_permanent";
+
+  public static final String CREATE_TABLE = "CREATE TABLE " + TABLE_NAME + " (" + ID + " INTEGER PRIMARY KEY, " +
+                                            RECIPIENT_NR + " TEXT UNIQUE, " + SILENCE_UNTIL + " INTEGER, " + SILENCE_PERMANENT + " BOOLEAN NOT NULL);";
+
+  public static final String[] CREATE_INDEXS = {
+    "CREATE INDEX IF NOT EXISTS notifications_recipient_index ON " + TABLE_NAME + " (" + RECIPIENT_NR + ");",
+  };
+
+  public RecipientNotificationsDatabase(Context context, SQLiteOpenHelper databaseHelper) {
+    super(context, databaseHelper);
+  }
+
+  public boolean isSilencedPermanently(Recipient recipient) {
+    SQLiteDatabase db  = databaseHelper.getWritableDatabase();
+    Cursor cursor      = null;
+
+    try {
+      cursor = db.query(TABLE_NAME, null, RECIPIENT_NR + " = ?", new String[] {recipient.getNumber()}, null, null, null);
+
+      if (cursor.isAfterLast()) {
+        return false;
+      }
+
+      cursor.moveToFirst();
+      Boolean isPermanentlySilenced = (cursor.getInt(cursor.getColumnIndexOrThrow(SILENCE_PERMANENT)) > 0);
+
+      return isPermanentlySilenced;
+    } finally {
+      if (cursor != null)
+        cursor.close();
+    }
+  }
+
+  public Long getSilencedUntil(Recipient recipient) {
+    SQLiteDatabase db  = databaseHelper.getWritableDatabase();
+    Cursor cursor      = null;
+
+    try {
+      cursor = db.query(TABLE_NAME, null, RECIPIENT_NR + " = ?", new String[] {recipient.getNumber()}, null, null, null);
+
+      if (cursor.isAfterLast()) {
+        return null;
+      }
+
+      cursor.moveToFirst();
+      Long silencedUntil = cursor.getLong(cursor.getColumnIndexOrThrow(SILENCE_UNTIL));
+
+      return silencedUntil;
+    } finally {
+      if (cursor != null)
+        cursor.close();
+    }
+  }
+
+  private boolean isInDatabase(Recipient recipient) {
+    SQLiteDatabase db  = databaseHelper.getWritableDatabase();
+    Cursor cursor      = null;
+
+    try {
+      cursor = db.query(TABLE_NAME, null, RECIPIENT_NR + " = ?", new String[] {recipient.getNumber()}, null, null, null);
+
+      if (cursor.isAfterLast()) {
+        return false;
+      }
+
+      return true;
+    } finally {
+      if (cursor != null)
+        cursor.close();
+    }
+  }
+
+  public boolean isSilencedNow(Recipient recipient) {
+    SQLiteDatabase db  = databaseHelper.getWritableDatabase();
+    Cursor cursor      = null;
+
+    try {
+      cursor = db.query(TABLE_NAME, null, RECIPIENT_NR + " = ?", new String[] {recipient.getNumber()}, null, null, null);
+
+      if (cursor.isAfterLast()) {
+        return false;
+      }
+
+      cursor.moveToFirst();
+
+      Boolean isPermanentlySilenced = cursor.getInt(cursor.getColumnIndexOrThrow(SILENCE_PERMANENT)) > 0;
+      if (isPermanentlySilenced)
+        return true;
+
+      Long silencedUntil = cursor.getLong(cursor.getColumnIndexOrThrow(SILENCE_UNTIL));
+      Long nowTimestamp = System.currentTimeMillis() / 1000;
+      if ((silencedUntil != null) && (nowTimestamp <= silencedUntil))
+        return true;
+
+      return false;
+    } finally {
+      if (cursor != null)
+        cursor.close();
+    }
+  }
+
+  private void updateRecipient(Recipient recipient, boolean silencePermanent, Long silenceUntil) {
+    SQLiteDatabase db    = databaseHelper.getWritableDatabase();
+
+    ContentValues values = new ContentValues(3);
+    values.put(RECIPIENT_NR, recipient.getNumber());
+    values.put(SILENCE_PERMANENT, silencePermanent);
+    values.put(SILENCE_UNTIL, silenceUntil);
+
+    if (!isInDatabase(recipient)) {
+      Log.d(TAG, "Inserting " + recipient.getName() + " into notifications db");
+      db.insert(TABLE_NAME, null, values);
+    } else {
+      Log.d(TAG, "Updating " + recipient.getName() + " in notifications db");
+      db.update(TABLE_NAME, values, RECIPIENT_NR + " = ?", new String[] {recipient.getNumber()});
+    }
+  }
+
+  public void setSilenceUntil(Recipient recipient, Long silenceUntil) {
+    this.updateRecipient(recipient, this.isSilencedPermanently(recipient), silenceUntil);
+  }
+
+  public void setSilencePermanently(Recipient recipient, boolean silencePermanently) {
+    if (silencePermanently) {
+      this.updateRecipient(recipient, silencePermanently, null);
+    } else {
+      this.updateRecipient(recipient, silencePermanently, this.getSilencedUntil(recipient));
+    }
+  }
+}

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -46,7 +46,7 @@ import org.thoughtcrime.securesms.database.PushDatabase;
 import org.thoughtcrime.securesms.database.RecipientNotificationsDatabase;
 import org.thoughtcrime.securesms.recipients.RecipientFactory;
 import org.thoughtcrime.securesms.recipients.RecipientFormattingException;
-import org.whispersystems.textsecure.crypto.MasterSecret;
+import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.MmsSmsDatabase;
 import org.thoughtcrime.securesms.database.PushDatabase;

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -27,6 +27,7 @@ import android.graphics.Color;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
 import android.net.Uri;
+import android.provider.ContactsContract;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationCompat.BigTextStyle;
 import android.support.v4.app.NotificationCompat.InboxStyle;
@@ -40,6 +41,12 @@ import android.util.Log;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.RoutingActivity;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.contacts.ContactPhotoFactory;
+import org.thoughtcrime.securesms.database.PushDatabase;
+import org.thoughtcrime.securesms.database.RecipientNotificationsDatabase;
+import org.thoughtcrime.securesms.recipients.RecipientFactory;
+import org.thoughtcrime.securesms.recipients.RecipientFormattingException;
+import org.whispersystems.textsecure.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.MmsSmsDatabase;
 import org.thoughtcrime.securesms.database.PushDatabase;
@@ -115,7 +122,17 @@ public class MessageNotifier {
       DatabaseFactory.getThreadDatabase(context).setRead(threadId);
       sendInThreadNotification(context);
     } else {
-      updateNotification(context, masterSecret, true);
+      Recipients recipients = DatabaseFactory.getThreadDatabase(context).getRecipientsForThreadId(threadId);
+      RecipientNotificationsDatabase notificationsDatabase = DatabaseFactory.getNotificationDatabase(context);
+
+      boolean signal;
+      if (notificationsDatabase.isSilencedNow(recipients.getPrimaryRecipient())) {
+        signal = false;
+      } else {
+        signal = true;
+      }
+
+      updateNotification(context, masterSecret, signal);
     }
   }
 

--- a/src/org/thoughtcrime/securesms/notifications/NotificationsMutedReminder.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationsMutedReminder.java
@@ -1,0 +1,52 @@
+package org.thoughtcrime.securesms.notifications;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.view.View;
+
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.components.Reminder;
+import org.thoughtcrime.securesms.components.ReminderView;
+import org.thoughtcrime.securesms.database.DatabaseFactory;
+import org.thoughtcrime.securesms.database.RecipientNotificationsDatabase;
+import org.thoughtcrime.securesms.recipients.Recipient;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
+
+/**
+ * Reminder that a certain thread has been muted.
+ *
+ * @author Lukas Barth
+ */
+public class NotificationsMutedReminder extends Reminder {
+  private Recipient recipient;
+  private Context context;
+
+  @TargetApi(Build.VERSION_CODES.KITKAT)
+  public NotificationsMutedReminder(final Context context, final Recipient recipient, final ReminderView reminderView) {
+    super(R.drawable.alert,
+            R.string.reminder_header_silenced_title,
+            R.string.reminder_header_silenced_text);
+
+    this.context = context;
+
+    final View.OnClickListener okListener = new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        RecipientNotificationsDatabase notificationsDatabase = DatabaseFactory.getNotificationDatabase(context);
+        notificationsDatabase.setSilenceUntil(recipient, null);
+        notificationsDatabase.setSilencePermanently(recipient, false);
+
+        reminderView.hide();
+      }
+    };
+
+    setOkListener(okListener);
+  }
+
+  @Override
+  public String getOKText() {
+    return this.context.getResources().getString(R.string.reminder_header_silenced_ok);
+  }
+}

--- a/src/org/thoughtcrime/securesms/notifications/NotificationsMutedReminder.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationsMutedReminder.java
@@ -25,8 +25,8 @@ public class NotificationsMutedReminder extends Reminder {
 
   @TargetApi(Build.VERSION_CODES.KITKAT)
   public NotificationsMutedReminder(final Context context, final Recipient recipient, final ReminderView reminderView) {
-    super(R.drawable.alert,
-            R.string.reminder_header_silenced_title,
+    super(R.drawable.ic_smiles_bell,
+            null,
             R.string.reminder_header_silenced_text);
 
     this.context = context;
@@ -48,5 +48,10 @@ public class NotificationsMutedReminder extends Reminder {
   @Override
   public String getOKText() {
     return this.context.getResources().getString(R.string.reminder_header_silenced_ok);
+  }
+
+  @Override
+  public Integer getCancelResId() {
+    return null;
   }
 }


### PR DESCRIPTION
This implements a first step towards per-recipient notifications as discussed on the mailing list and wished for in many tickets. So far, I only implemented the possibilities to silence certain people and groups permanently or temporarily, since this seemed to be the minimal consensus achieved on the mailing list.

**WARNING**: This upgrades your database. Although a downgrade should be comparatively easy (delete a table and downgrade the global database version), make sure to have a backup if you test this.