### PR TITLE
Enable media message forwarding

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -89,8 +89,7 @@
     <string name="ConversationActivity_select_contact_info">Select contact info</string>
     <string name="ConversationActivity_compose_message">Compose message</string>
     <string name="ConversationActivity_sorry_there_was_an_error_setting_your_attachment">Sorry, there was an error setting your attachment.</string>
-    <string name="ConversationActivity_sorry_the_selected_video_exceeds_message_size_restrictions">Sorry, the selected video exceeds message size restrictions (%1$skB).</string>
-    <string name="ConversationActivity_sorry_the_selected_audio_exceeds_message_size_restrictions">Sorry, the selected audio exceeds message size restrictions (%1$skB).</string>
+    <string name="ConversationActivity_sorry_the_selected_attachment_exceeds_message_size_restrictions">Sorry, the selected attachment exceeds message size restrictions (%1$skB).</string>
     <string name="ConversationActivity_recipient_is_not_a_valid_sms_or_email_address_exclamation">Recipient is not a valid SMS or email address!</string>
     <string name="ConversationActivity_message_is_empty_exclamation">Message is empty!</string>
     <string name="ConversationActivity_group_conversation_recipients">Group conversation recipients</string>

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -33,6 +33,7 @@ import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.loaders.ConversationLoader;
 import org.thoughtcrime.securesms.database.model.MediaMmsMessageRecord;
 import org.thoughtcrime.securesms.database.model.MessageRecord;
+import org.thoughtcrime.securesms.mms.PartAuthority;
 import org.thoughtcrime.securesms.mms.Slide;
 import org.thoughtcrime.securesms.recipients.RecipientFactory;
 import org.thoughtcrime.securesms.recipients.Recipients;
@@ -260,11 +261,35 @@ public class ConversationFragment extends ListFragment
     builder.show();
   }
 
-  private void handleForwardMessage(MessageRecord message) {
-    Intent composeIntent = new Intent(getActivity(), ShareActivity.class);
+  private void handleForwardMessage(final MessageRecord message) {
+    final MediaMmsMessageRecord mmsMessage = message.isMms() ? (MediaMmsMessageRecord)message : null;
+    final Intent composeIntent = new Intent(getActivity(), ShareActivity.class);
     composeIntent.putExtra(ConversationActivity.DRAFT_TEXT_EXTRA, message.getDisplayBody().toString());
     composeIntent.putExtra(ShareActivity.MASTER_SECRET_EXTRA, masterSecret);
-    startActivity(composeIntent);
+
+    if (mmsMessage != null && mmsMessage.containsMediaSlide()) {
+      mmsMessage.fetchMediaSlide(new FutureTaskListener<Slide>() {
+        @Override
+        public void onSuccess(Slide slide) {
+          if (slide.hasAudio() || slide.hasVideo() || slide.hasImage()) {
+            composeIntent.putExtra(ConversationActivity.DRAFT_MEDIA_EXTRA, PartAuthority.getPublicPartUri(slide.getUri()));
+            composeIntent.putExtra(ConversationActivity.DRAFT_MEDIA_TYPE_EXTRA, slide.getContentType());
+          }
+          startActivity(composeIntent);
+        }
+
+        @Override
+        public void onFailure(Throwable error) {
+          Log.w(TAG, "No slide with attachable media found, failing nicely.");
+          Log.w(TAG, error);
+          startActivity(composeIntent);
+        }
+
+      });
+    }
+    else {
+      startActivity(composeIntent);
+    }
   }
 
   private void handleResendMessage(final MessageRecord message) {

--- a/src/org/thoughtcrime/securesms/NewConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/NewConversationActivity.java
@@ -155,9 +155,8 @@ public class NewConversationActivity extends PassphraseRequiredActionBarActivity
       intent.putExtra(ConversationActivity.RECIPIENTS_EXTRA, recipients.getIds());
       intent.putExtra(ConversationActivity.MASTER_SECRET_EXTRA, masterSecret);
       intent.putExtra(ConversationActivity.DRAFT_TEXT_EXTRA, getIntent().getStringExtra(ConversationActivity.DRAFT_TEXT_EXTRA));
-      intent.putExtra(ConversationActivity.DRAFT_AUDIO_EXTRA, getIntent().getParcelableExtra(ConversationActivity.DRAFT_AUDIO_EXTRA));
-      intent.putExtra(ConversationActivity.DRAFT_VIDEO_EXTRA, getIntent().getParcelableExtra(ConversationActivity.DRAFT_VIDEO_EXTRA));
-      intent.putExtra(ConversationActivity.DRAFT_IMAGE_EXTRA, getIntent().getParcelableExtra(ConversationActivity.DRAFT_IMAGE_EXTRA));
+      intent.putExtra(ConversationActivity.DRAFT_MEDIA_EXTRA, getIntent().getParcelableExtra(ConversationActivity.DRAFT_MEDIA_EXTRA));
+      intent.putExtra(ConversationActivity.DRAFT_MEDIA_TYPE_EXTRA, getIntent().getStringExtra(ConversationActivity.DRAFT_MEDIA_TYPE_EXTRA));
       long existingThread = DatabaseFactory.getThreadDatabase(this).getThreadIdIfExistsFor(recipients);
       intent.putExtra(ConversationActivity.THREAD_ID_EXTRA, existingThread);
       intent.putExtra(ConversationActivity.DISTRIBUTION_TYPE_EXTRA, ThreadDatabase.DistributionTypes.DEFAULT);

--- a/src/org/thoughtcrime/securesms/RoutingActivity.java
+++ b/src/org/thoughtcrime/securesms/RoutingActivity.java
@@ -12,6 +12,8 @@ import org.thoughtcrime.securesms.recipients.Recipients;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 
+import ws.com.google.android.mms.ContentType;
+
 public class RoutingActivity extends PassphraseRequiredActionBarActivity {
 
   private static final int STATE_CREATE_PASSPHRASE        = 1;
@@ -133,9 +135,8 @@ public class RoutingActivity extends PassphraseRequiredActionBarActivity {
     intent.putExtra(ConversationActivity.THREAD_ID_EXTRA, parameters.thread);
     intent.putExtra(ConversationActivity.MASTER_SECRET_EXTRA, masterSecret);
     intent.putExtra(ConversationActivity.DRAFT_TEXT_EXTRA, parameters.draftText);
-    intent.putExtra(ConversationActivity.DRAFT_IMAGE_EXTRA, parameters.draftImage);
-    intent.putExtra(ConversationActivity.DRAFT_AUDIO_EXTRA, parameters.draftAudio);
-    intent.putExtra(ConversationActivity.DRAFT_VIDEO_EXTRA, parameters.draftVideo);
+    intent.putExtra(ConversationActivity.DRAFT_MEDIA_EXTRA, parameters.draftMedia);
+    intent.putExtra(ConversationActivity.DRAFT_MEDIA_TYPE_EXTRA, parameters.draftMediaType);
 
     return intent;
   }
@@ -146,9 +147,8 @@ public class RoutingActivity extends PassphraseRequiredActionBarActivity {
 
     if (parameters != null) {
       intent.putExtra(ConversationActivity.DRAFT_TEXT_EXTRA, parameters.draftText);
-      intent.putExtra(ConversationActivity.DRAFT_IMAGE_EXTRA, parameters.draftImage);
-      intent.putExtra(ConversationActivity.DRAFT_AUDIO_EXTRA, parameters.draftAudio);
-      intent.putExtra(ConversationActivity.DRAFT_VIDEO_EXTRA, parameters.draftVideo);
+      intent.putExtra(ConversationActivity.DRAFT_MEDIA_EXTRA, parameters.draftMedia);
+      intent.putExtra(ConversationActivity.DRAFT_MEDIA_TYPE_EXTRA, parameters.draftMediaType);
     }
 
     return intent;
@@ -207,15 +207,13 @@ public class RoutingActivity extends PassphraseRequiredActionBarActivity {
       recipients = null;
     }
 
-    return new ConversationParameters(threadId, recipients, body, null, null, null);
+    return new ConversationParameters(threadId, recipients, body, null, null);
   }
 
   private ConversationParameters getConversationParametersForShareAction() {
-    String type      = getIntent().getType();
-    String draftText = getIntent().getStringExtra(Intent.EXTRA_TEXT);
-    Uri draftImage   = null;
-    Uri draftAudio   = null;
-    Uri draftVideo   = null;
+    String type       = getIntent().getType();
+    String draftText  = getIntent().getStringExtra(Intent.EXTRA_TEXT);
+    Uri    draftMedia = null;
 
     Uri streamExtra = getIntent().getParcelableExtra(Intent.EXTRA_STREAM);
 
@@ -223,15 +221,11 @@ public class RoutingActivity extends PassphraseRequiredActionBarActivity {
       type = getMimeType(streamExtra);
     }
 
-    if (type != null && type.startsWith("image/")) {
-      draftImage = streamExtra;
-    } else if (type != null && type.startsWith("audio/")) {
-      draftAudio = streamExtra;
-    } else if (type != null && type.startsWith("video/")) {
-      draftVideo = streamExtra;
+    if (ContentType.isAudioType(type) || ContentType.isVideoType(type) || ContentType.isImageType(type)) {
+      draftMedia = streamExtra;
     }
 
-    return new ConversationParameters(-1, null, draftText, draftImage, draftAudio, draftVideo);
+    return new ConversationParameters(-1, null, draftText, draftMedia, type);
   }
 
   private String getMimeType(Uri uri) {
@@ -250,7 +244,7 @@ public class RoutingActivity extends PassphraseRequiredActionBarActivity {
     long[] recipientIds   = getIntent().getLongArrayExtra("recipients");
     Recipients recipients = recipientIds == null ? null : RecipientFactory.getRecipientsForIds(this, recipientIds, true);
 
-    return new ConversationParameters(threadId, recipients, null, null, null, null);
+    return new ConversationParameters(threadId, recipients, null, null, null);
   }
 
   private boolean isShareAction() {
@@ -265,19 +259,17 @@ public class RoutingActivity extends PassphraseRequiredActionBarActivity {
     public final long       thread;
     public final Recipients recipients;
     public final String     draftText;
-    public final Uri        draftImage;
-    public final Uri        draftAudio;
-    public final Uri        draftVideo;
+    public final Uri        draftMedia;
+    public final String     draftMediaType;
 
     public ConversationParameters(long thread, Recipients recipients,
-                                  String draftText, Uri draftImage, Uri draftAudio, Uri draftVideo)
+                                  String draftText, Uri draftMedia, String draftMediaType)
     {
-     this.thread     = thread;
-     this.recipients = recipients;
-     this.draftText  = draftText;
-     this.draftImage = draftImage;
-     this.draftAudio = draftAudio;
-     this.draftVideo = draftVideo;
+      this.thread         = thread;
+      this.recipients     = recipients;
+      this.draftText      = draftText;
+      this.draftMedia     = draftMedia;
+      this.draftMediaType = draftMediaType;
     }
   }
 

--- a/src/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/org/thoughtcrime/securesms/ShareActivity.java
@@ -37,7 +37,7 @@ import org.thoughtcrime.securesms.util.MemoryCleaner;
  */
 public class ShareActivity extends PassphraseRequiredActionBarActivity
     implements ShareFragment.ConversationSelectedListener
-  {
+{
   public final static String MASTER_SECRET_EXTRA = "master_secret";
 
   private final DynamicTheme    dynamicTheme    = new DynamicTheme   ();
@@ -58,8 +58,8 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity
 
   @Override
   protected void onNewIntent(Intent intent) {
-      super.onNewIntent(intent);
-      setIntent(intent);
+    super.onNewIntent(intent);
+    setIntent(intent);
   }
 
   @Override
@@ -139,15 +139,13 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity
   private Intent getBaseShareIntent(final Class<?> target) {
     final Intent intent = new Intent(this, target);
     final Intent originalIntent = getIntent();
-    final String draftText  = originalIntent.getStringExtra(ConversationActivity.DRAFT_TEXT_EXTRA);
-    final Uri    draftImage = originalIntent.getParcelableExtra(ConversationActivity.DRAFT_IMAGE_EXTRA);
-    final Uri    draftAudio = originalIntent.getParcelableExtra(ConversationActivity.DRAFT_AUDIO_EXTRA);
-    final Uri    draftVideo = originalIntent.getParcelableExtra(ConversationActivity.DRAFT_VIDEO_EXTRA);
+    final String draftText   = originalIntent.getStringExtra(ConversationActivity.DRAFT_TEXT_EXTRA);
+    final Uri    draftMedia  = originalIntent.getParcelableExtra(ConversationActivity.DRAFT_MEDIA_EXTRA);
+    final String mediaType   = originalIntent.getStringExtra(ConversationActivity.DRAFT_MEDIA_TYPE_EXTRA);
 
     intent.putExtra(ConversationActivity.DRAFT_TEXT_EXTRA, draftText);
-    intent.putExtra(ConversationActivity.DRAFT_IMAGE_EXTRA, draftImage);
-    intent.putExtra(ConversationActivity.DRAFT_AUDIO_EXTRA, draftAudio);
-    intent.putExtra(ConversationActivity.DRAFT_VIDEO_EXTRA, draftVideo);
+    intent.putExtra(ConversationActivity.DRAFT_MEDIA_EXTRA, draftMedia);
+    intent.putExtra(ConversationActivity.DRAFT_MEDIA_TYPE_EXTRA, mediaType);
     intent.putExtra(NewConversationActivity.MASTER_SECRET_EXTRA, masterSecret);
 
     return intent;

--- a/src/org/thoughtcrime/securesms/database/DraftDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/DraftDatabase.java
@@ -109,6 +109,12 @@ public class DraftDatabase extends Database {
       default:    return null;
       }
     }
+
+  public Boolean isValidMediaDraft() {
+    return type.equals(Draft.IMAGE) ||
+           type.equals(Draft.AUDIO) ||
+           type.equals(Draft.VIDEO);
+    }
   }
 
   public static class Drafts extends LinkedList<Draft> {

--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -32,10 +32,11 @@ import android.widget.ImageView;
 import android.widget.Toast;
 
 import org.thoughtcrime.securesms.R;
-import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.util.BitmapDecodingException;
 
 import java.io.IOException;
+
+import ws.com.google.android.mms.ContentType;
 
 public class AttachmentManager {
   private final static String TAG = AttachmentManager.class.getSimpleName();
@@ -64,16 +65,13 @@ public class AttachmentManager {
     attachmentListener.onAttachmentChanged();
   }
 
-  public void setImage(Uri image) throws IOException, BitmapDecodingException {
-    setMedia(new ImageSlide(context, image), 345, 261);
-  }
-
-  public void setVideo(Uri video) throws IOException, MediaTooLargeException {
-    setMedia(new VideoSlide(context, video));
-  }
-
-  public void setAudio(Uri audio) throws IOException, MediaTooLargeException {
-    setMedia(new AudioSlide(context, audio));
+  public void setMedia(Uri media, String contentType) throws IOException, MediaTooLargeException, BitmapDecodingException {
+    if      (ContentType.isAudioType(contentType))
+      setMedia(new AudioSlide(context, media, contentType));
+    else if (ContentType.isVideoType(contentType))
+      setMedia(new VideoSlide(context, media, contentType));
+    else if (ContentType.isImageType(contentType))
+      setMedia(new ImageSlide(context, media), 345, 261);
   }
 
   public void setMedia(final Slide slide, final int thumbnailWidth, final int thumbnailHeight) {
@@ -108,15 +106,15 @@ public class AttachmentManager {
   }
 
   public static void selectVideo(Activity activity, int requestCode) {
-    selectMediaType(activity, "video/*", requestCode);
+    selectMediaType(activity, ContentType.VIDEO_UNSPECIFIED, requestCode);
   }
 
   public static void selectImage(Activity activity, int requestCode) {
-    selectMediaType(activity, "image/*", requestCode);
+    selectMediaType(activity, ContentType.IMAGE_UNSPECIFIED, requestCode);
   }
 
   public static void selectAudio(Activity activity, int requestCode) {
-    selectMediaType(activity, "audio/*", requestCode);
+    selectMediaType(activity, ContentType.AUDIO_UNSPECIFIED, requestCode);
   }
 
   public static void selectContactInfo(Activity activity, int requestCode) {

--- a/src/org/thoughtcrime/securesms/mms/AudioSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/AudioSlide.java
@@ -1,6 +1,6 @@
-/** 
+/**
  * Copyright (C) 2011 Whisper Systems
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -10,7 +10,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -23,32 +23,33 @@ import org.thoughtcrime.securesms.util.SmilUtil;
 import org.w3c.dom.smil.SMILDocument;
 import org.w3c.dom.smil.SMILMediaElement;
 import org.w3c.dom.smil.SMILRegionElement;
-import org.w3c.dom.smil.SMILRegionMediaElement;
 
+import ws.com.google.android.mms.ContentType;
 import ws.com.google.android.mms.pdu.PduPart;
 import android.content.Context;
-import android.database.Cursor;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.provider.MediaStore.Audio;
+import android.util.Log;
 
 public class AudioSlide extends Slide {
+  private static final String TAG = AudioSlide.class.getSimpleName();
 
   public AudioSlide(Context context, PduPart part) {
     super(context, part);
   }
 
-  public AudioSlide(Context context, Uri uri) throws IOException, MediaTooLargeException {
-    super(context, constructPartFromUri(context, uri));
+  public AudioSlide(Context context, Uri uri, String contentType) throws IOException, MediaTooLargeException {
+    super(context, constructPartFromUri(context, uri, contentType));
   }
 
   @Override
-    public boolean hasImage() {
+  public boolean hasImage() {
     return true;
   }
 
   @Override
-    public boolean hasAudio() {
+  public boolean hasAudio() {
     return true;
   }
 
@@ -67,24 +68,17 @@ public class AudioSlide extends Slide {
     return context.getResources().getDrawable(R.drawable.ic_menu_add_sound);
   }
 
-  public static PduPart constructPartFromUri(Context context, Uri uri) throws IOException, MediaTooLargeException {
-    PduPart part = new PduPart();
+  private static PduPart constructPartFromUri(Context context, Uri uri, String contentType)
+      throws IOException, MediaTooLargeException {
+    PduPart part  = new PduPart();
 
     assertMediaSize(context, uri);
 
-    Cursor cursor = null;
+    if (contentType == null || ContentType.isUnspecified(contentType))
+      contentType = getContentTypeFromUri(context, uri, Audio.Media.MIME_TYPE);
 
-    try {
-      cursor = context.getContentResolver().query(uri, new String[]{Audio.Media.MIME_TYPE}, null, null, null);
-
-      if (cursor != null && cursor.moveToFirst())
-        part.setContentType(cursor.getString(0).getBytes());
-      else
-        throw new IOException("Unable to query content type.");
-    } finally {
-      if (cursor != null)
-        cursor.close();
-    } 
+    Log.w(TAG, "Setting mime type: " + contentType);
+    part.setContentType(contentType.getBytes());
 
     part.setDataUri(uri);
     part.setContentId((System.currentTimeMillis()+"").getBytes());

--- a/src/org/thoughtcrime/securesms/mms/Slide.java
+++ b/src/org/thoughtcrime/securesms/mms/Slide.java
@@ -1,6 +1,6 @@
-/** 
+/**
  * Copyright (C) 2011 Whisper Systems
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -10,7 +10,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -26,6 +26,7 @@ import org.w3c.dom.smil.SMILRegionElement;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 
 import android.content.Context;
+import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
@@ -39,7 +40,7 @@ public abstract class Slide {
   protected final PduPart      part;
   protected final Context      context;
   protected       MasterSecret masterSecret;
-	
+
   public Slide(Context context, PduPart part) {
     this.part    = part;
     this.context = context;
@@ -123,6 +124,22 @@ public abstract class Slide {
     while ((read = in.read(buffer)) != -1) {
       size += read;
       if (size > MmsMediaConstraints.MAX_MESSAGE_SIZE) throw new MediaTooLargeException("Media exceeds maximum message size.");
+    }
+  }
+
+  protected static String getContentTypeFromUri(Context context, Uri uri, String mimeType) throws  IOException {
+    Cursor cursor = null;
+
+    try {
+        cursor = context.getContentResolver().query(uri, new String[]{mimeType}, null, null, null);
+        if (cursor != null && cursor.moveToFirst() && cursor.getString(0) != null)
+          return cursor.getString(0);
+        else
+          throw new IOException("Unable to query content type.");
+
+    } finally {
+      if (cursor != null)
+        cursor.close();
     }
   }
 }

--- a/src/org/thoughtcrime/securesms/mms/VideoSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/VideoSlide.java
@@ -1,6 +1,6 @@
-/** 
+/**
  * Copyright (C) 2011 Whisper Systems
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -10,7 +10,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -24,23 +24,23 @@ import org.w3c.dom.smil.SMILDocument;
 import org.w3c.dom.smil.SMILMediaElement;
 import org.w3c.dom.smil.SMILRegionElement;
 
+import ws.com.google.android.mms.ContentType;
 import ws.com.google.android.mms.pdu.PduPart;
-import android.content.ContentResolver;
 import android.content.Context;
-import android.database.Cursor;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
-import android.provider.MediaStore;
+import android.provider.MediaStore.Video;
 import android.util.Log;
 
 public class VideoSlide extends Slide {
+  private static final String TAG = VideoSlide.class.getSimpleName();
 
   public VideoSlide(Context context, PduPart part) {
     super(context, part);
   }
 
-  public VideoSlide(Context context, Uri uri) throws IOException, MediaTooLargeException {
-    super(context, constructPartFromUri(context, uri));
+  public VideoSlide(Context context, Uri uri, String contentType) throws IOException, MediaTooLargeException {
+    super(context, constructPartFromUri(context, uri, contentType));
   }
 
   @Override
@@ -75,25 +75,19 @@ public class VideoSlide extends Slide {
     return SmilUtil.createMediaElement("video", document, new String(getPart().getName()));
   }
 
-  private static PduPart constructPartFromUri(Context context, Uri uri)
-      throws IOException, MediaTooLargeException
+  private static PduPart constructPartFromUri(Context context, Uri uri, String contentType)
+      throws IOException, MediaTooLargeException 
   {
-    PduPart         part     = new PduPart();
-    ContentResolver resolver = context.getContentResolver();
-    Cursor          cursor   = null;
-
-    try {
-      cursor = resolver.query(uri, new String[] {MediaStore.Video.Media.MIME_TYPE}, null, null, null);
-      if (cursor != null && cursor.moveToFirst()) {
-        Log.w("VideoSlide", "Setting mime type: " + cursor.getString(0));
-        part.setContentType(cursor.getString(0).getBytes());
-      }
-    } finally {
-      if (cursor != null)
-        cursor.close();
-    }
+    PduPart part  = new PduPart();
 
     assertMediaSize(context, uri);
+
+    if (contentType == null || ContentType.isUnspecified(contentType))
+      contentType = getContentTypeFromUri(context, uri, Video.Media.MIME_TYPE);
+
+    Log.w(TAG, "Setting mime type: " + contentType);
+    part.setContentType(contentType.getBytes());
+
     part.setDataUri(uri);
     part.setContentId((System.currentTimeMillis()+"").getBytes());
     part.setName(("Video" + System.currentTimeMillis()).getBytes());


### PR DESCRIPTION
For images this works without handing the content type through the intents, as it is set to `ContentType.IMAGE_JPEG` hardcoded.
This also unifies AudioSlide's and VideoSlide's `constructPartFromUri` as they were edited anyway.

Fixes #1362 and #1914 

I strongly recommend merging #2234 and #2232 as without them forwarding message is not funny...