### PR TITLE
Only initialise EmojiGrid when not in edit mode (fixes NPE in edit mode)

### DIFF
--- a/src/org/thoughtcrime/securesms/components/EmojiDrawer.java
+++ b/src/org/thoughtcrime/securesms/components/EmojiDrawer.java
@@ -74,7 +74,8 @@ public class EmojiDrawer extends KeyboardAwareLinearLayout {
     inflater.inflate(R.layout.emoji_drawer, this, true);
 
     initializeResources();
-    initializeEmojiGrid();
+    if(!this.isInEditMode())
+      initializeEmojiGrid();
   }
 
   private void initializeResources() {


### PR DESCRIPTION
Android Studio keeps showing this message:

![](http://i.imgur.com/pVM3iz2.png)

Suppress initialisation of the emoji_grid_layout.xml when the EmojiDrawer is
being used in a layout where the editor is shown, to prevent an NPE when an
editor is being used.

// FREEBIE