### PR TITLE
media constraints model

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -73,6 +73,7 @@ import org.thoughtcrime.securesms.database.ThreadDatabase;
 import org.thoughtcrime.securesms.mms.AttachmentManager;
 import org.thoughtcrime.securesms.mms.AttachmentTypeSelectorAdapter;
 import org.thoughtcrime.securesms.mms.MediaTooLargeException;
+import org.thoughtcrime.securesms.mms.MmsMediaConstraints;
 import org.thoughtcrime.securesms.mms.OutgoingGroupMediaMessage;
 import org.thoughtcrime.securesms.mms.OutgoingMediaMessage;
 import org.thoughtcrime.securesms.mms.OutgoingMmsConnection;
@@ -848,8 +849,9 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       Log.w("ComposeMessageActivity", e);
     } catch (MediaTooLargeException e) {
       attachmentManager.clear();
+
       Toast.makeText(this, getString(R.string.ConversationActivity_sorry_the_selected_video_exceeds_message_size_restrictions,
-                                     (Slide.MAX_MESSAGE_SIZE/1024)),
+                                     (MmsMediaConstraints.MAX_MESSAGE_SIZE/1024)),
                      Toast.LENGTH_LONG).show();
       Log.w("ComposeMessageActivity", e);
     }
@@ -866,7 +868,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     } catch (MediaTooLargeException e) {
       attachmentManager.clear();
       Toast.makeText(this, getString(R.string.ConversationActivity_sorry_the_selected_audio_exceeds_message_size_restrictions,
-                                     (Slide.MAX_MESSAGE_SIZE/1024)),
+                                     (MmsMediaConstraints.MAX_MESSAGE_SIZE/1024)),
                      Toast.LENGTH_LONG).show();
       Log.w("ComposeMessageActivity", e);
     }

--- a/src/org/thoughtcrime/securesms/jobs/MmsSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/MmsSendJob.java
@@ -13,7 +13,6 @@ import org.thoughtcrime.securesms.database.NoSuchMessageException;
 import org.thoughtcrime.securesms.jobs.requirements.MasterSecretRequirement;
 import org.thoughtcrime.securesms.mms.ApnUnavailableException;
 import org.thoughtcrime.securesms.mms.MediaConstraints;
-import org.thoughtcrime.securesms.mms.MmsMediaConstraints;
 import org.thoughtcrime.securesms.mms.MmsRadio;
 import org.thoughtcrime.securesms.mms.MmsRadioException;
 import org.thoughtcrime.securesms.mms.MmsSendResult;
@@ -24,7 +23,6 @@ import org.thoughtcrime.securesms.recipients.Recipients;
 import org.thoughtcrime.securesms.transport.InsecureFallbackApprovalException;
 import org.thoughtcrime.securesms.transport.UndeliverableMessageException;
 import org.thoughtcrime.securesms.util.Hex;
-import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.NumberUtil;
 import org.whispersystems.jobqueue.JobParameters;
 import org.whispersystems.jobqueue.requirements.NetworkRequirement;
@@ -160,7 +158,7 @@ public class MmsSendJob extends SendJob {
       message.setFrom(new EncodedStringValue(number));
     }
 
-    MediaUtil.prepareMessageMedia(context, masterSecret, message, MediaConstraints.MMS_CONSTRAINTS, true);
+    prepareMessageMedia(masterSecret, message, MediaConstraints.MMS_CONSTRAINTS, true);
 
     try {
       OutgoingMmsConnection connection = new OutgoingMmsConnection(context, radio.getApnInformation(), new PduComposer(context, message).make());

--- a/src/org/thoughtcrime/securesms/jobs/PushSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushSendJob.java
@@ -6,7 +6,10 @@ import android.util.Log;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.jobs.requirements.MasterSecretRequirement;
+import org.thoughtcrime.securesms.mms.MmsMediaConstraints;
 import org.thoughtcrime.securesms.mms.PartAuthority;
+import org.thoughtcrime.securesms.mms.MediaConstraints;
+import org.thoughtcrime.securesms.mms.PushMediaConstraints;
 import org.thoughtcrime.securesms.notifications.MessageNotifier;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.Recipients;
@@ -21,7 +24,6 @@ import org.thoughtcrime.securesms.database.TextSecureDirectory;
 import org.whispersystems.textsecure.api.push.PushAddress;
 import org.whispersystems.textsecure.api.util.InvalidNumberException;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.LinkedList;

--- a/src/org/thoughtcrime/securesms/jobs/SendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/SendJob.java
@@ -1,14 +1,28 @@
 package org.thoughtcrime.securesms.jobs;
 
 import android.content.Context;
+import android.util.Log;
 
 import org.thoughtcrime.securesms.BuildConfig;
 import org.thoughtcrime.securesms.TextSecureExpiredException;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.database.DatabaseFactory;
+import org.thoughtcrime.securesms.database.PartDatabase;
+import org.thoughtcrime.securesms.mms.MediaConstraints;
+import org.thoughtcrime.securesms.transport.UndeliverableMessageException;
+import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.Util;
 import org.whispersystems.jobqueue.JobParameters;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import ws.com.google.android.mms.MmsException;
+import ws.com.google.android.mms.pdu.PduPart;
+import ws.com.google.android.mms.pdu.SendReq;
+
 public abstract class SendJob extends MasterSecretJob {
+  private final static String TAG = SendJob.class.getSimpleName();
 
   public SendJob(Context context, JobParameters parameters) {
     super(context, parameters);
@@ -26,4 +40,46 @@ public abstract class SendJob extends MasterSecretJob {
   }
 
   protected abstract void onSend(MasterSecret masterSecret) throws Exception;
+
+  protected void prepareMessageMedia(MasterSecret masterSecret, SendReq message,
+                                            MediaConstraints constraints, boolean toMemory)
+      throws IOException, UndeliverableMessageException {
+    try {
+      for (int i = 0; i < message.getBody().getPartsNum(); i++) {
+        preparePart(masterSecret, constraints, message.getBody().getPart(i), toMemory);
+      }
+    } catch (MmsException me) {
+      throw new UndeliverableMessageException(me);
+    }
+  }
+
+  private void preparePart(MasterSecret masterSecret, MediaConstraints constraints,
+                                    PduPart part, boolean toMemory)
+      throws IOException, MmsException, UndeliverableMessageException {
+    byte[] resizedData = null;
+    if (!constraints.isSatisfied(context, masterSecret, part)) {
+      if (!constraints.canResize(part)) {
+        throw new UndeliverableMessageException("Size constraints could not be satisfied.");
+      }
+      resizedData = resizePart(masterSecret, constraints, part);
+    }
+    if (toMemory) {
+      part.setData(resizedData != null ? resizedData : MediaUtil.getPartData(context, masterSecret, part));
+    }
+    if (resizedData != null) {
+      part.setDataSize(resizedData.length);
+    }
+  }
+
+  private byte[] resizePart(MasterSecret masterSecret, MediaConstraints constraints,
+                              PduPart part)
+      throws IOException, MmsException
+  {
+    Log.w(TAG, "resizing part " + part.getId());
+    final long oldSize = part.getDataSize();
+    final byte[] data = constraints.getResizedMedia(context, masterSecret, part);
+    DatabaseFactory.getPartDatabase(context).updatePartData(masterSecret, part, new ByteArrayInputStream(data));
+    Log.w(TAG, String.format("Resized part %.1fkb => %.1fkb", oldSize / 1024.0, part.getDataSize() / 1024.0));
+    return data;
+  }
 }

--- a/src/org/thoughtcrime/securesms/mms/MediaConstraints.java
+++ b/src/org/thoughtcrime/securesms/mms/MediaConstraints.java
@@ -1,0 +1,72 @@
+package org.thoughtcrime.securesms.mms;
+
+import android.content.Context;
+import android.net.Uri;
+import android.util.Log;
+import android.util.Pair;
+
+import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.util.BitmapDecodingException;
+import org.thoughtcrime.securesms.util.BitmapUtil;
+import org.thoughtcrime.securesms.util.MediaUtil;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import ws.com.google.android.mms.pdu.PduPart;
+
+public abstract class MediaConstraints {
+  private static final String TAG = MediaConstraints.class.getSimpleName();
+
+  public static MediaConstraints MMS_CONSTRAINTS  = new MmsMediaConstraints();
+  public static MediaConstraints PUSH_CONSTRAINTS = new PushMediaConstraints();
+
+  public abstract int getImageMaxWidth();
+  public abstract int getImageMaxHeight();
+  public abstract int getImageMaxSize();
+
+  public abstract int getVideoMaxSize();
+
+  public abstract int getAudioMaxSize();
+
+  public boolean isSatisfied(Context context, MasterSecret masterSecret, PduPart part) {
+    try {
+      return (MediaUtil.isImage(part) && part.getDataSize() <= getImageMaxSize() && isWithinBounds(context, masterSecret, part.getDataUri())) ||
+             (MediaUtil.isAudio(part) && part.getDataSize() <= getAudioMaxSize()) ||
+             (MediaUtil.isVideo(part) && part.getDataSize() <= getVideoMaxSize()) ||
+             (!MediaUtil.isImage(part) && !MediaUtil.isAudio(part) && !MediaUtil.isVideo(part));
+    } catch (IOException ioe) {
+      Log.w(TAG, "Failed to determine if media's constraints are satisfied.", ioe);
+      return false;
+    }
+  }
+
+  public boolean isWithinBounds(Context context, MasterSecret masterSecret, Uri uri) throws IOException {
+    InputStream is = PartAuthority.getPartStream(context, masterSecret, uri);
+    Pair<Integer, Integer> dimensions = BitmapUtil.getDimensions(is);
+    return dimensions.first  > 0 && dimensions.first  <= getImageMaxWidth() &&
+           dimensions.second > 0 && dimensions.second <= getImageMaxHeight();
+  }
+
+  public boolean canResize(PduPart part) {
+    return part != null && MediaUtil.isImage(part);
+  }
+
+  public byte[] getResizedMedia(Context context, MasterSecret masterSecret, PduPart part)
+      throws IOException
+  {
+    if (!canResize(part) || part.getDataUri() == null) {
+      throw new UnsupportedOperationException("Cannot resize this content type");
+    }
+
+    try {
+      return BitmapUtil.createScaledBytes(context, masterSecret, part.getDataUri(),
+                                          getImageMaxWidth(),
+                                          getImageMaxHeight(),
+                                          getImageMaxSize());
+    } catch (BitmapDecodingException bde) {
+      throw new IOException(bde);
+    }
+  }
+
+}

--- a/src/org/thoughtcrime/securesms/mms/MmsMediaConstraints.java
+++ b/src/org/thoughtcrime/securesms/mms/MmsMediaConstraints.java
@@ -1,0 +1,31 @@
+package org.thoughtcrime.securesms.mms;
+
+public class MmsMediaConstraints extends MediaConstraints {
+  private static final int MAX_IMAGE_DIMEN  = 1280;
+  public  static final int MAX_MESSAGE_SIZE = 280 * 1024;
+
+  @Override
+  public int getImageMaxWidth() {
+    return MAX_IMAGE_DIMEN;
+  }
+
+  @Override
+  public int getImageMaxHeight() {
+    return MAX_IMAGE_DIMEN;
+  }
+
+  @Override
+  public int getImageMaxSize() {
+    return MAX_MESSAGE_SIZE;
+  }
+
+  @Override
+  public int getVideoMaxSize() {
+    return MAX_MESSAGE_SIZE;
+  }
+
+  @Override
+  public int getAudioMaxSize() {
+    return MAX_MESSAGE_SIZE;
+  }
+}

--- a/src/org/thoughtcrime/securesms/mms/PushMediaConstraints.java
+++ b/src/org/thoughtcrime/securesms/mms/PushMediaConstraints.java
@@ -1,0 +1,32 @@
+package org.thoughtcrime.securesms.mms;
+
+public class PushMediaConstraints extends MediaConstraints {
+  private static final int MAX_IMAGE_DIMEN  = 1280;
+  private static final int KB               = 1024;
+  private static final int MB               = 1024 * KB;
+
+  @Override
+  public int getImageMaxWidth() {
+    return MAX_IMAGE_DIMEN;
+  }
+
+  @Override
+  public int getImageMaxHeight() {
+    return MAX_IMAGE_DIMEN;
+  }
+
+  @Override
+  public int getImageMaxSize() {
+    return 300 * KB;
+  }
+
+  @Override
+  public int getVideoMaxSize() {
+    return MmsMediaConstraints.MAX_MESSAGE_SIZE;
+  }
+
+  @Override
+  public int getAudioMaxSize() {
+    return MmsMediaConstraints.MAX_MESSAGE_SIZE;
+  }
+}

--- a/src/org/thoughtcrime/securesms/mms/Slide.java
+++ b/src/org/thoughtcrime/securesms/mms/Slide.java
@@ -36,8 +36,6 @@ import ws.com.google.android.mms.pdu.PduPart;
 
 public abstract class Slide {
 
-  public static final int MAX_MESSAGE_SIZE = 280 * 1024;
-
   protected final PduPart      part;
   protected final Context      context;
   protected       MasterSecret masterSecret;
@@ -124,7 +122,7 @@ public abstract class Slide {
 
     while ((read = in.read(buffer)) != -1) {
       size += read;
-      if (size > MAX_MESSAGE_SIZE) throw new MediaTooLargeException("Media exceeds maximum message size.");
+      if (size > MmsMediaConstraints.MAX_MESSAGE_SIZE) throw new MediaTooLargeException("Media exceeds maximum message size.");
     }
   }
 }

--- a/src/org/thoughtcrime/securesms/mms/VideoSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/VideoSlide.java
@@ -75,10 +75,12 @@ public class VideoSlide extends Slide {
     return SmilUtil.createMediaElement("video", document, new String(getPart().getName()));
   }
 
-  private static PduPart constructPartFromUri(Context context, Uri uri) throws IOException, MediaTooLargeException {
-    PduPart part             = new PduPart();
+  private static PduPart constructPartFromUri(Context context, Uri uri)
+      throws IOException, MediaTooLargeException
+  {
+    PduPart         part     = new PduPart();
     ContentResolver resolver = context.getContentResolver();
-    Cursor cursor            = null;
+    Cursor          cursor   = null;
 
     try {
       cursor = resolver.query(uri, new String[] {MediaStore.Video.Media.MIME_TYPE}, null, null, null);

--- a/src/org/thoughtcrime/securesms/transport/UndeliverableMessageException.java
+++ b/src/org/thoughtcrime/securesms/transport/UndeliverableMessageException.java
@@ -1,6 +1,6 @@
 package org.thoughtcrime.securesms.transport;
 
-public class UndeliverableMessageException extends Throwable {
+public class UndeliverableMessageException extends Exception {
   public UndeliverableMessageException() {
   }
 

--- a/src/org/thoughtcrime/securesms/util/BitmapUtil.java
+++ b/src/org/thoughtcrime/securesms/util/BitmapUtil.java
@@ -6,13 +6,10 @@ import android.graphics.Bitmap.CompressFormat;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.Matrix;
-import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.PorterDuff;
-import android.graphics.PorterDuff.Mode;
 import android.graphics.PorterDuffXfermode;
 import android.graphics.Rect;
-import android.graphics.RectF;
 import android.net.Uri;
 import android.util.Log;
 import android.util.Pair;
@@ -28,9 +25,6 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import com.android.gallery3d.data.Exif;
-
-import org.thoughtcrime.securesms.crypto.MasterSecret;
-import org.thoughtcrime.securesms.mms.PartAuthority;
 
 public class BitmapUtil {
   private static final String TAG = BitmapUtil.class.getSimpleName();
@@ -60,6 +54,8 @@ public class BitmapUtil {
 
       quality = Math.max((quality * maxSize) / baos.size(), MIN_COMPRESSION_QUALITY);
     } while (baos.size() > maxSize && attempts++ < MAX_COMPRESSION_ATTEMPTS);
+
+    Log.w(TAG, "createScaledBytes(" + uri + ") -> quality " + Math.min(quality, MAX_COMPRESSION_QUALITY) + ", " + attempts + " attempt(s)");
 
     bitmap.recycle();
 
@@ -214,6 +210,11 @@ public class BitmapUtil {
       Log.w(TAG, "failed to close the InputStream after reading image dimensions");
     }
     return options;
+  }
+
+  public static Pair<Integer, Integer> getDimensions(InputStream inputStream) {
+    BitmapFactory.Options options = getImageDimensions(inputStream);
+    return new Pair<>(options.outWidth, options.outHeight);
   }
 
   public static Bitmap getCircleCroppedBitmap(Bitmap bitmap) {

--- a/src/org/thoughtcrime/securesms/util/MediaUtil.java
+++ b/src/org/thoughtcrime/securesms/util/MediaUtil.java
@@ -9,7 +9,12 @@ import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.PartDatabase;
+import org.thoughtcrime.securesms.mms.MediaConstraints;
+import org.thoughtcrime.securesms.mms.PartAuthority;
+import org.thoughtcrime.securesms.transport.UndeliverableMessageException;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -18,6 +23,7 @@ import java.util.concurrent.Callable;
 import ws.com.google.android.mms.ContentType;
 import ws.com.google.android.mms.MmsException;
 import ws.com.google.android.mms.pdu.PduPart;
+import ws.com.google.android.mms.pdu.SendReq;
 
 public class MediaUtil {
   private static final String TAG = MediaUtil.class.getSimpleName();
@@ -44,6 +50,61 @@ public class MediaUtil {
   {
     int maxSize = context.getResources().getDimensionPixelSize(R.dimen.thumbnail_max_size);
     return BitmapUtil.createScaledBitmap(context, masterSecret, uri, maxSize, maxSize);
+  }
+
+  public static void prepareMessageMedia(Context context, MasterSecret masterSecret, SendReq message,
+                                         MediaConstraints constraints, boolean toMemory)
+      throws IOException, UndeliverableMessageException
+  {
+    for (int i=0;i<message.getBody().getPartsNum();i++) {
+      final PduPart part = message.getBody().getPart(i);
+      Log.w(TAG, "Sending MMS part of content-type: " + Util.toIsoString(part.getContentType()));
+
+      if (!constraints.isSatisfied(context, masterSecret, part)) {
+        if (constraints.canResize(part)) resizePart(context, masterSecret, constraints, part, toMemory);
+        else                                       throw new UndeliverableMessageException("Size constraints could not be satisfied.");
+      } else if (toMemory) {
+        ByteArrayOutputStream os = part.getDataSize() > 0 && part.getDataSize() < Integer.MAX_VALUE
+            ? new ByteArrayOutputStream((int)part.getDataSize())
+            : new ByteArrayOutputStream();
+        Util.copy(PartAuthority.getPartStream(context, masterSecret, part.getDataUri()), os);
+        byte[] data = os.toByteArray();
+        part.setData(data);
+        part.setDataSize(data.length);
+      }
+    }
+  }
+
+  public static void resizePart(Context context, MasterSecret masterSecret, MediaConstraints constraints,
+                                PduPart part, boolean toMemory)
+      throws IOException, UndeliverableMessageException
+  {
+    Log.w(TAG, "resizing part " + part.getId() + (toMemory ? " (storing in memory)" : ""));
+    final long   oldSize = part.getDataSize();
+    final byte[] data    = constraints.getResizedMedia(context, masterSecret, part);
+    if (toMemory) {
+      part.setData(data);
+      part.setDataSize(data.length);
+    }
+    try {
+      PartDatabase database = DatabaseFactory.getPartDatabase(context);
+      database.updatePartData(masterSecret, part, new ByteArrayInputStream(data));
+    } catch (MmsException me) {
+      throw new UndeliverableMessageException(me);
+    }
+    Log.w(TAG, String.format("Resized part %.1fkb => %.1fkb", oldSize/1024.0, part.getDataSize()/1024.0));
+  }
+
+  public static boolean isImage(PduPart part) {
+    return ContentType.isImageType(Util.toIsoString(part.getContentType()));
+  }
+
+  public static boolean isAudio(PduPart part) {
+    return ContentType.isAudioType(Util.toIsoString(part.getContentType()));
+  }
+
+  public static boolean isVideo(PduPart part) {
+    return ContentType.isVideoType(Util.toIsoString(part.getContentType()));
   }
 
   public static class ThumbnailData {

--- a/src/org/thoughtcrime/securesms/util/MediaUtil.java
+++ b/src/org/thoughtcrime/securesms/util/MediaUtil.java
@@ -45,54 +45,21 @@ public class MediaUtil {
     return data;
   }
 
+  public static byte[] getPartData(Context context, MasterSecret masterSecret, PduPart part)
+      throws IOException
+  {
+    ByteArrayOutputStream os = part.getDataSize() > 0 && part.getDataSize() < Integer.MAX_VALUE
+        ? new ByteArrayOutputStream((int) part.getDataSize())
+        : new ByteArrayOutputStream();
+    Util.copy(PartAuthority.getPartStream(context, masterSecret, part.getDataUri()), os);
+    return os.toByteArray();
+  }
+
   private static Bitmap generateImageThumbnail(Context context, MasterSecret masterSecret, Uri uri)
       throws IOException, BitmapDecodingException, OutOfMemoryError
   {
     int maxSize = context.getResources().getDimensionPixelSize(R.dimen.thumbnail_max_size);
     return BitmapUtil.createScaledBitmap(context, masterSecret, uri, maxSize, maxSize);
-  }
-
-  public static void prepareMessageMedia(Context context, MasterSecret masterSecret, SendReq message,
-                                         MediaConstraints constraints, boolean toMemory)
-      throws IOException, UndeliverableMessageException
-  {
-    for (int i=0;i<message.getBody().getPartsNum();i++) {
-      final PduPart part = message.getBody().getPart(i);
-      Log.w(TAG, "Sending MMS part of content-type: " + Util.toIsoString(part.getContentType()));
-
-      if (!constraints.isSatisfied(context, masterSecret, part)) {
-        if (constraints.canResize(part)) resizePart(context, masterSecret, constraints, part, toMemory);
-        else                                       throw new UndeliverableMessageException("Size constraints could not be satisfied.");
-      } else if (toMemory) {
-        ByteArrayOutputStream os = part.getDataSize() > 0 && part.getDataSize() < Integer.MAX_VALUE
-            ? new ByteArrayOutputStream((int)part.getDataSize())
-            : new ByteArrayOutputStream();
-        Util.copy(PartAuthority.getPartStream(context, masterSecret, part.getDataUri()), os);
-        byte[] data = os.toByteArray();
-        part.setData(data);
-        part.setDataSize(data.length);
-      }
-    }
-  }
-
-  public static void resizePart(Context context, MasterSecret masterSecret, MediaConstraints constraints,
-                                PduPart part, boolean toMemory)
-      throws IOException, UndeliverableMessageException
-  {
-    Log.w(TAG, "resizing part " + part.getId() + (toMemory ? " (storing in memory)" : ""));
-    final long   oldSize = part.getDataSize();
-    final byte[] data    = constraints.getResizedMedia(context, masterSecret, part);
-    if (toMemory) {
-      part.setData(data);
-      part.setDataSize(data.length);
-    }
-    try {
-      PartDatabase database = DatabaseFactory.getPartDatabase(context);
-      database.updatePartData(masterSecret, part, new ByteArrayInputStream(data));
-    } catch (MmsException me) {
-      throw new UndeliverableMessageException(me);
-    }
-    Log.w(TAG, String.format("Resized part %.1fkb => %.1fkb", oldSize/1024.0, part.getDataSize()/1024.0));
   }
 
   public static boolean isImage(PduPart part) {

--- a/src/ws/com/google/android/mms/pdu/PduPart.java
+++ b/src/ws/com/google/android/mms/pdu/PduPart.java
@@ -20,8 +20,13 @@ package ws.com.google.android.mms.pdu;
 import android.graphics.Bitmap;
 import android.net.Uri;
 
+import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.mms.MediaConstraints;
+import org.thoughtcrime.securesms.util.BitmapDecodingException;
+import org.thoughtcrime.securesms.util.BitmapUtil;
 import org.thoughtcrime.securesms.util.Util;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 


### PR DESCRIPTION
This is to solve the problem of how we will support transport fallbacks once we increase the size of media supported in push messaging.

Our new basic media part flow:
1. Copy media to encrypted internal storage without any resizing
2. Send job knows its media constraints and will attempt to resize before failing if media is too large, otherwise send as is
3. Replace original media with sent, resized version to save space