### PR TITLE
Update travis.yml to make builds 'passing' finally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: android
 android:
-  components:
-    - platform-tools
-    - build-tools-19.1.0
+components:
+    - build-tools-21.1.2
     - android-19
     - extra-android-m2repository
+    - sys-img-armeabi-v7a-android-19
+    - add-on
+    - extra
+
+before_script:
+    - echo no | android create avd --force -n test -t android-19 --abi armeabi-v7a
+    - emulator -avd test -no-skin -no-audio -no-window &
+    - android-wait-for-emulator


### PR DESCRIPTION
...as soon as Travis gets activated for the TextSecure we no longer see  [![Build Status](https://travis-ci.org/WhisperSystems/TextSecure.svg?branch=master)](https://travis-ci.org/WhisperSystems/TextSecure) in readme.md but a neat [![Build Status](https://travis-ci.org/McLoo/TextSecure.svg?branch=patch-6)](https://travis-ci.org/WhisperSystems/TextSecure)