### PR TITLE
Also crop contact photos in ShareList

### DIFF
--- a/res/layout/share_list_item_view.xml
+++ b/res/layout/share_list_item_view.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <org.thoughtcrime.securesms.ShareListItem
         xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-    <org.thoughtcrime.securesms.components.ForegroundImageView
+    <com.makeramen.RoundedImageView
         android:id="@+id/contact_photo_image"
         android:foreground="@drawable/contact_photo_background"
         android:layout_width="50dp"
@@ -17,6 +18,7 @@
         android:layout_marginRight="10dp"
         android:cropToPadding="true"
         android:scaleType="centerCrop"
+        app:riv_oval="true"
         android:contentDescription="@string/SingleContactSelectionActivity_contact_photo" />
 
     <LinearLayout

--- a/src/org/thoughtcrime/securesms/ShareListItem.java
+++ b/src/org/thoughtcrime/securesms/ShareListItem.java
@@ -31,9 +31,10 @@ import android.text.TextUtils;
 import android.text.style.StyleSpan;
 import android.util.AttributeSet;
 import android.view.View;
-import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
+
+import com.makeramen.RoundedImageView;
 
 import org.thoughtcrime.securesms.database.model.ThreadRecord;
 import org.thoughtcrime.securesms.recipients.Recipient;
@@ -59,7 +60,7 @@ public class ShareListItem extends RelativeLayout
   private long       threadId;
   private TextView   fromView;
 
-  private ImageView contactPhotoImage;
+  private RoundedImageView contactPhotoImage;
 
   private final Handler handler = new Handler();
   private int distributionType;
@@ -77,7 +78,7 @@ public class ShareListItem extends RelativeLayout
   @Override
   protected void onFinishInflate() {
     this.fromView          = (TextView)  findViewById(R.id.from);
-    this.contactPhotoImage = (ImageView) findViewById(R.id.contact_photo_image);
+    this.contactPhotoImage = (RoundedImageView) findViewById(R.id.contact_photo_image);
   }
 
   public void set(ThreadRecord thread) {


### PR DESCRIPTION
Commit 62816ee51ac80b446c788ec50bbd94d967ebddbb forgot to switch the ShareListActivity (which appears when sharing from another App) to the RoundedImageView.
Only group icons that were still stored cropped were shown correctly, contact photos were shown as squares. This commit fixes this.