### PR TITLE
Fix NPE when encrypted MMS has bad base64 encoding

### DIFF
--- a/src/org/thoughtcrime/securesms/crypto/MmsCipher.java
+++ b/src/org/thoughtcrime/securesms/crypto/MmsCipher.java
@@ -61,6 +61,10 @@ public class MmsCipher {
       byte[] decodedCiphertext = textTransport.getDecodedMessage(ciphertext.get());
       byte[] plaintext;
 
+      if (decodedCiphertext == null) {
+        throw new InvalidMessageException("failed to decode ciphertext");
+      }
+
       try {
         plaintext = sessionCipher.decrypt(new WhisperMessage(decodedCiphertext));
       } catch (InvalidMessageException e) {


### PR DESCRIPTION
Traced a crash back to this issue.