### PR TITLE
fix empty group update messages

### DIFF
--- a/src/org/thoughtcrime/securesms/util/GroupUtil.java
+++ b/src/org/thoughtcrime/securesms/util/GroupUtil.java
@@ -51,7 +51,11 @@ public class GroupUtil {
         description.append(context.getString(R.string.GroupUtil_title_is_now, title));
       }
 
-      return description.toString();
+      if (description.length() > 0) {
+        return description.toString();
+      } else {
+        return context.getString(R.string.GroupUtil_group_updated);
+      }
     } catch (InvalidProtocolBufferException e) {
       Log.w("GroupUtil", e);
       return context.getString(R.string.GroupUtil_group_updated);


### PR DESCRIPTION
In the case that only the avatar was updated (or nothing was updated at all), the group update text would be blank. This changes it to the generic "group updated" text.