### PR TITLE
Workaround for LGE-related NPEs

### DIFF
--- a/src/org/thoughtcrime/securesms/AutoInitiateActivity.java
+++ b/src/org/thoughtcrime/securesms/AutoInitiateActivity.java
@@ -16,7 +16,6 @@
  */
 package org.thoughtcrime.securesms;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
@@ -44,7 +43,7 @@ import org.whispersystems.textsecure.api.push.PushAddress;
  * @author Moxie Marlinspike
  *
  */
-public class AutoInitiateActivity extends Activity {
+public class AutoInitiateActivity extends BaseActivity {
 
   private long threadId;
   private Recipient recipient;

--- a/src/org/thoughtcrime/securesms/BaseActionBarActivity.java
+++ b/src/org/thoughtcrime/securesms/BaseActionBarActivity.java
@@ -1,0 +1,22 @@
+package org.thoughtcrime.securesms;
+
+import android.support.annotation.NonNull;
+import android.support.v7.app.ActionBarActivity;
+import android.view.KeyEvent;
+
+
+public abstract class BaseActionBarActivity extends ActionBarActivity {
+  @Override
+  public boolean onKeyDown(int keyCode, KeyEvent event) {
+    return BaseActivity.isKeyCodeWorkaroundRequired(keyCode) || super.onKeyDown(keyCode, event);
+  }
+
+  @Override
+  public boolean onKeyUp(int keyCode, @NonNull KeyEvent event) {
+    if (BaseActivity.isKeyCodeWorkaroundRequired(keyCode)) {
+      openOptionsMenu();
+      return true;
+    }
+    return super.onKeyUp(keyCode, event);
+  }
+}

--- a/src/org/thoughtcrime/securesms/BaseActivity.java
+++ b/src/org/thoughtcrime/securesms/BaseActivity.java
@@ -1,0 +1,28 @@
+package org.thoughtcrime.securesms;
+
+import android.os.Build;
+import android.support.annotation.NonNull;
+import android.support.v4.app.FragmentActivity;
+import android.view.KeyEvent;
+
+public abstract class BaseActivity extends FragmentActivity {
+  @Override
+  public boolean onKeyDown(int keyCode, KeyEvent event) {
+    return isKeyCodeWorkaroundRequired(keyCode) || super.onKeyDown(keyCode, event);
+  }
+
+  @Override
+  public boolean onKeyUp(int keyCode, @NonNull KeyEvent event) {
+    if (isKeyCodeWorkaroundRequired(keyCode)) {
+      openOptionsMenu();
+      return true;
+    }
+    return super.onKeyUp(keyCode, event);
+  }
+
+  public static boolean isKeyCodeWorkaroundRequired(int keyCode) {
+    return (keyCode == KeyEvent.KEYCODE_MENU) &&
+           (Build.VERSION.SDK_INT == 16)      &&
+           ("LGE".equalsIgnoreCase(Build.MANUFACTURER));
+  }
+}

--- a/src/org/thoughtcrime/securesms/CountrySelectionActivity.java
+++ b/src/org/thoughtcrime/securesms/CountrySelectionActivity.java
@@ -5,9 +5,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
 
-import org.thoughtcrime.securesms.util.DynamicTheme;
-
-public class CountrySelectionActivity extends FragmentActivity
+public class CountrySelectionActivity extends BaseActivity
     implements CountrySelectionFragment.CountrySelectedListener
 
 {

--- a/src/org/thoughtcrime/securesms/DatabaseUpgradeActivity.java
+++ b/src/org/thoughtcrime/securesms/DatabaseUpgradeActivity.java
@@ -17,7 +17,6 @@
 
 package org.thoughtcrime.securesms;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -49,7 +48,7 @@ import java.io.File;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-public class DatabaseUpgradeActivity extends Activity {
+public class DatabaseUpgradeActivity extends BaseActivity {
 
   public static final int NO_MORE_KEY_EXCHANGE_PREFIX_VERSION  = 46;
   public static final int MMS_BODY_VERSION                     = 46;

--- a/src/org/thoughtcrime/securesms/LogSubmitActivity.java
+++ b/src/org/thoughtcrime/securesms/LogSubmitActivity.java
@@ -11,7 +11,7 @@ import org.whispersystems.libpastelog.SubmitLogFragment;
 /**
  * Activity for submitting logcat logs to a pastebin service.
  */
-public class LogSubmitActivity extends ActionBarActivity implements SubmitLogFragment.OnLogSubmittedListener {
+public class LogSubmitActivity extends BaseActionBarActivity implements SubmitLogFragment.OnLogSubmittedListener {
   private static final String TAG = LogSubmitActivity.class.getSimpleName();
 
   @Override

--- a/src/org/thoughtcrime/securesms/PassphraseActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphraseActivity.java
@@ -33,7 +33,7 @@ import org.thoughtcrime.securesms.util.MemoryCleaner;
  *
  * @author Moxie Marlinspike
  */
-public abstract class PassphraseActivity extends ActionBarActivity {
+public abstract class PassphraseActivity extends BaseActionBarActivity {
 
   private KeyCachingService keyCachingService;
   private MasterSecret masterSecret;

--- a/src/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
@@ -1,11 +1,10 @@
 package org.thoughtcrime.securesms;
 
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
 
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 
-public class PassphraseRequiredActionBarActivity extends ActionBarActivity implements PassphraseRequiredActivity {
+public class PassphraseRequiredActionBarActivity extends BaseActionBarActivity implements PassphraseRequiredActivity {
 
   private final PassphraseRequiredMixin delegate = new PassphraseRequiredMixin();
 
@@ -40,5 +39,4 @@ public class PassphraseRequiredActionBarActivity extends ActionBarActivity imple
 
   @Override
   public void onNewMasterSecret(MasterSecret masterSecret) {}
-
 }

--- a/src/org/thoughtcrime/securesms/ReceiveKeyActivity.java
+++ b/src/org/thoughtcrime/securesms/ReceiveKeyActivity.java
@@ -16,7 +16,6 @@
  */
 package org.thoughtcrime.securesms;
 
-import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
@@ -68,7 +67,7 @@ import java.io.IOException;
  * @author Moxie Marlinspike
  */
 
-public class ReceiveKeyActivity extends Activity {
+public class ReceiveKeyActivity extends BaseActivity {
 
   private TextView descriptionText;
 

--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -39,7 +39,7 @@ import org.whispersystems.textsecure.api.util.PhoneNumberFormatter;
  * @author Moxie Marlinspike
  *
  */
-public class RegistrationActivity extends ActionBarActivity {
+public class RegistrationActivity extends BaseActionBarActivity {
 
   private static final int PICK_COUNTRY = 1;
 

--- a/src/org/thoughtcrime/securesms/RegistrationProblemsActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationProblemsActivity.java
@@ -6,7 +6,7 @@ import android.view.View;
 import android.widget.Button;
 
 
-public class RegistrationProblemsActivity extends ActionBarActivity {
+public class RegistrationProblemsActivity extends BaseActionBarActivity {
 
   @Override
   public void onCreate(Bundle bundle) {

--- a/src/org/thoughtcrime/securesms/RegistrationProgressActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationProgressActivity.java
@@ -46,7 +46,7 @@ import java.io.IOException;
 
 import static org.thoughtcrime.securesms.service.RegistrationService.RegistrationState;
 
-public class RegistrationProgressActivity extends ActionBarActivity {
+public class RegistrationProgressActivity extends BaseActionBarActivity {
 
   private static final int FOCUSED_COLOR   = Color.parseColor("#ff333333");
   private static final int UNFOCUSED_COLOR = Color.parseColor("#ff808080");


### PR DESCRIPTION
I didn't see this crash during my most recent AppThwack iterations on LG devices, but it appears it's still in the wild. Below is a proposed fix, limited in scope based on comments in the android project bug. That final comment seems to suggest that while Build.BRAND may not accurately filter buggy devices, Build.MANUFACTURER will.

See: https://code.google.com/p/android/issues/detail?id=78154
