### PR TITLE
Fix white-on-white ActionMode popup in dark theme

### DIFF
--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -101,6 +101,7 @@
         <item name="logo">@drawable/actionbar_icon_holo_dark</item>
         <item name="actionBarStyle">@style/TextSecure.DarkActionBar</item>
         <item name="actionBarTabBarStyle">@style/TextSecure.DarkActionBar.TabBar</item>
+        <item name="actionBarPopupTheme">@style/ThemeOverlay.AppCompat.Dark</item>
         <item name="android:textColor">@color/text_color_dark_theme</item>
         <item name="android:textColorSecondary">@color/text_color_secondary_dark_theme</item>
         <item name="conversation_list_item_background_read">@drawable/conversation_list_item_background_read_dark</item>


### PR DESCRIPTION
After going through a seemingly infinite number of actionbar and actionmode-related theming attributes, this one for some reason is the right one.

For people searching, no it's not `actionModeStyle`, `popupMenuStyle`, `actionDropDownStyle`, or `actionModeBackground` in either your main theme or your ActionBar custom theme.