### PR TITLE
Workaround LG-related menu issues, pt. 2

### DIFF
--- a/src/org/thoughtcrime/securesms/BaseActionBarActivity.java
+++ b/src/org/thoughtcrime/securesms/BaseActionBarActivity.java
@@ -1,22 +1,53 @@
 package org.thoughtcrime.securesms;
 
+import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.app.ActionBarActivity;
+import android.util.Log;
 import android.view.KeyEvent;
+import android.view.ViewConfiguration;
+
+import java.lang.reflect.Field;
 
 
 public abstract class BaseActionBarActivity extends ActionBarActivity {
+  private static final String TAG = BaseActionBarActivity.class.getSimpleName();
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    if (BaseActivity.isMenuWorkaroundRequired()) {
+      forceOverflowMenu();
+    }
+    super.onCreate(savedInstanceState);
+  }
+
   @Override
   public boolean onKeyDown(int keyCode, KeyEvent event) {
-    return BaseActivity.isKeyCodeWorkaroundRequired(keyCode) || super.onKeyDown(keyCode, event);
+    return (keyCode == KeyEvent.KEYCODE_MENU && BaseActivity.isMenuWorkaroundRequired()) || super.onKeyDown(keyCode, event);
   }
 
   @Override
   public boolean onKeyUp(int keyCode, @NonNull KeyEvent event) {
-    if (BaseActivity.isKeyCodeWorkaroundRequired(keyCode)) {
+    if (keyCode == KeyEvent.KEYCODE_MENU && BaseActivity.isMenuWorkaroundRequired()) {
       openOptionsMenu();
       return true;
     }
     return super.onKeyUp(keyCode, event);
+  }
+
+  /**
+   * Modified from: http://stackoverflow.com/a/13098824
+   */
+  private void forceOverflowMenu() {
+    try {
+      ViewConfiguration config       = ViewConfiguration.get(this);
+      Field             menuKeyField = ViewConfiguration.class.getDeclaredField("sHasPermanentMenuKey");
+      if(menuKeyField != null) {
+        menuKeyField.setAccessible(true);
+        menuKeyField.setBoolean(config, false);
+      }
+    } catch (IllegalAccessException | NoSuchFieldException e) {
+      Log.w(TAG, "Failed to force overflow menu.");
+    }
   }
 }

--- a/src/org/thoughtcrime/securesms/BaseActivity.java
+++ b/src/org/thoughtcrime/securesms/BaseActivity.java
@@ -1,6 +1,8 @@
 package org.thoughtcrime.securesms;
 
 import android.os.Build;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
 import android.support.annotation.NonNull;
 import android.support.v4.app.FragmentActivity;
 import android.view.KeyEvent;
@@ -8,21 +10,21 @@ import android.view.KeyEvent;
 public abstract class BaseActivity extends FragmentActivity {
   @Override
   public boolean onKeyDown(int keyCode, KeyEvent event) {
-    return isKeyCodeWorkaroundRequired(keyCode) || super.onKeyDown(keyCode, event);
+    return (keyCode == KeyEvent.KEYCODE_MENU && isMenuWorkaroundRequired()) || super.onKeyDown(keyCode, event);
   }
 
   @Override
   public boolean onKeyUp(int keyCode, @NonNull KeyEvent event) {
-    if (isKeyCodeWorkaroundRequired(keyCode)) {
+    if (keyCode == KeyEvent.KEYCODE_MENU && isMenuWorkaroundRequired()) {
       openOptionsMenu();
       return true;
     }
     return super.onKeyUp(keyCode, event);
   }
 
-  public static boolean isKeyCodeWorkaroundRequired(int keyCode) {
-    return (keyCode == KeyEvent.KEYCODE_MENU) &&
-           (Build.VERSION.SDK_INT == 16)      &&
-           ("LGE".equalsIgnoreCase(Build.MANUFACTURER));
+  public static boolean isMenuWorkaroundRequired() {
+    return VERSION.SDK_INT <= VERSION_CODES.JELLY_BEAN      &&
+           VERSION.SDK_INT  > VERSION_CODES.GINGERBREAD_MR1 &&
+           ("LGE".equalsIgnoreCase(Build.MANUFACTURER) || "E6710".equalsIgnoreCase(Build.DEVICE));
   }
 }


### PR DESCRIPTION
Proposal for temporary assurances that people can use the app: loosen criteria for the keycode workaround, and at the same time force the "three dots" overflow menu regardless of hardware on devices running  Android 4.x ROMs which seem to be the problem zone.

Fixes #2444