### PR TITLE
Quick fix to clear the current text box when deleting a thread with a draft

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -535,6 +535,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       public void onClick(DialogInterface dialog, int which) {
         if (threadId > 0) {
           DatabaseFactory.getThreadDatabase(ConversationActivity.this).deleteConversation(threadId);
+          composeText.getText().clear();
           threadId = -1;
           finish();
         }


### PR DESCRIPTION
Otherwise the draft will be immediately re-saved (preventing thread deletion)

before: https://www.dropbox.com/s/h9nlgsv76d59f3m/deleting-draft-from-within-thread-view-fails.mov
after: https://www.dropbox.com/s/c36qs34f437qoxp/textsecure-delete-fix.mov

fixes https://github.com/WhisperSystems/TextSecure/issues/2473

// FREEBIE