### PR TITLE
Prevent NPE in PassphraseChangeActivity

### DIFF
--- a/src/org/thoughtcrime/securesms/PassphraseChangeActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphraseChangeActivity.java
@@ -77,6 +77,8 @@ public class PassphraseChangeActivity extends PassphraseActivity {
   }
 
   private void verifyAndSavePassphrases() {
+    this.okButton.setEnabled(false);
+    this.cancelButton.setEnabled(false);
     Editable originalText = this.originalPassphrase.getText();
     Editable newText      = this.newPassphrase.getText();
     Editable repeatText   = this.repeatPassphrase.getText();
@@ -107,6 +109,8 @@ public class PassphraseChangeActivity extends PassphraseActivity {
         setMasterSecret(masterSecret);
       }
     } catch (InvalidPassphraseException e) {
+      this.okButton.setEnabled(true);
+      this.cancelButton.setEnabled(true);
       Toast.makeText(this, R.string.PassphraseChangeActivity_incorrect_old_passphrase_exclamation,
                      Toast.LENGTH_LONG).show();
       this.originalPassphrase.setText("");


### PR DESCRIPTION
The issue's reproducible by tapping OK like a crazed lunatic (or just tapping it twice I guess) when changing your password.