### PR TITLE
Add first Espresso interaction test

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -329,6 +329,5 @@
             <action android:name="org.thoughtcrime.securesms.MessageNotifier.DELETE_REMINDER_ACTION"/>
         </intent-filter>
     </receiver>
-       <uses-library android:name="android.test.runner" />
 </application>
 </manifest>

--- a/androidTest/java/org/thoughtcrime/securesms/RegistrationActivityTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/RegistrationActivityTest.java
@@ -1,0 +1,24 @@
+package org.thoughtcrime.securesms;
+
+import static android.support.test.espresso.Espresso.*;
+import static android.support.test.espresso.action.ViewActions.*;
+import static android.support.test.espresso.matcher.ViewMatchers.*;
+import static android.support.test.espresso.assertion.ViewAssertions.*;
+
+import android.test.suitebuilder.annotation.LargeTest;
+
+@LargeTest
+public class RegistrationActivityTest extends RoutedInstrumentationTestCase {
+  private final static String TAG = RegistrationActivityTest.class.getSimpleName();
+
+  public RegistrationActivityTest() {
+    super();
+  }
+
+  @SuppressWarnings("unchecked")
+  public void testRegistrationButtons() throws Exception {
+    waitOn(RegistrationActivity.class);
+    onView(withId(R.id.registerButton)).check(matches(isDisplayed()));
+    onView(withId(R.id.skipButton)).check(matches(isDisplayed())).perform(click());
+  }
+}

--- a/androidTest/java/org/thoughtcrime/securesms/RoutedInstrumentationTestCase.java
+++ b/androidTest/java/org/thoughtcrime/securesms/RoutedInstrumentationTestCase.java
@@ -1,0 +1,37 @@
+package org.thoughtcrime.securesms;
+
+import android.app.Activity;
+import android.app.Instrumentation.ActivityMonitor;
+import android.preference.PreferenceManager;
+import android.test.ActivityInstrumentationTestCase2;
+import android.util.Log;
+
+import org.thoughtcrime.securesms.crypto.MasterSecretUtil;
+
+public class RoutedInstrumentationTestCase extends ActivityInstrumentationTestCase2<RoutingActivity> {
+  private static final String TAG = RoutedInstrumentationTestCase.class.getSimpleName();
+
+  public RoutedInstrumentationTestCase() {
+    super(RoutingActivity.class);
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    System.setProperty("dexmaker.dexcache", getInstrumentation().getTargetContext().getCacheDir().getPath());
+    super.setUp();
+    clearSharedPrefs();
+    getActivity();
+  }
+
+  protected void clearSharedPrefs() {
+    PreferenceManager.getDefaultSharedPreferences(getInstrumentation().getTargetContext())
+                     .edit().clear().commit();
+    getInstrumentation().getTargetContext().getSharedPreferences(MasterSecretUtil.PREFERENCES_NAME, 0)
+                                           .edit().clear().commit();
+  }
+
+  protected static void waitOn(Class<? extends Activity> clazz) {
+    Log.w(TAG, "waiting for " + clazz.getName());
+    new ActivityMonitor(clazz.getName(), null, true).waitForActivityWithTimeout(10000);
+  }
+}

--- a/androidTest/java/org/thoughtcrime/securesms/database/CanonicalAddressDatabaseTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/database/CanonicalAddressDatabaseTest.java
@@ -2,7 +2,7 @@ package org.thoughtcrime.securesms.database;
 
 import org.thoughtcrime.securesms.TextSecureTestCase;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CanonicalAddressDatabaseTest extends TextSecureTestCase {
   private static final String AMBIGUOUS_NUMBER = "222-3333";

--- a/androidTest/java/org/thoughtcrime/securesms/util/PhoneNumberFormatterTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/util/PhoneNumberFormatterTest.java
@@ -7,7 +7,8 @@ import junit.framework.AssertionFailedError;
 import org.thoughtcrime.securesms.TextSecureTestCase;
 import org.whispersystems.textsecure.api.util.InvalidNumberException;
 import org.whispersystems.textsecure.api.util.PhoneNumberFormatter;
-import static org.fest.assertions.api.Assertions.assertThat;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PhoneNumberFormatterTest extends TextSecureTestCase {
   private static final String LOCAL_NUMBER = "+15555555555";

--- a/androidTest/java/org/thoughtcrime/securesms/util/UtilTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/util/UtilTest.java
@@ -1,9 +1,0 @@
-package org.thoughtcrime.securesms.util;
-
-import android.test.AndroidTestCase;
-
-import static org.fest.assertions.api.Assertions.assertThat;
-
-public class UtilTest extends AndroidTestCase {
-
-}

--- a/build.gradle
+++ b/build.gradle
@@ -59,9 +59,19 @@ dependencies {
     compile 'org.whispersystems:jobmanager:0.10.0'
     compile 'org.whispersystems:libpastelog:1.0.4'
 
-    androidTestCompile 'com.squareup:fest-android:1.0.8'
-    androidTestCompile 'com.google.dexmaker:dexmaker:1.1'
-    androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.1'
+    androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
+    androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
+
+    androidTestCompile ('org.assertj:assertj-core:1.7.1') {
+        exclude group: 'org.hamcrest', module: 'hamcrest-core'
+    }
+    androidTestCompile ('com.squareup.assertj:assertj-android:1.0.0') {
+        exclude group: 'org.hamcrest', module: 'hamcrest-core'
+    }
+    androidTestCompile ('com.android.support.test.espresso:espresso-core:2.0') {
+        exclude group: 'javax.inject'
+    }
+    androidTestCompile 'com.android.support.test:testing-support-lib:0.1'
 
     compile project(':libtextsecure')
 }
@@ -112,12 +122,20 @@ android {
         minSdkVersion 9
         targetSdkVersion 19
 
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         buildConfigField "long", "BUILD_TIMESTAMP", System.currentTimeMillis() + "L"
     }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
+    }
+
+    packagingOptions {
+        exclude 'LICENSE.txt'
+        exclude 'LICENSE'
+        exclude 'NOTICE'
+        exclude 'asm-license.txt'
     }
 
     signingConfigs {


### PR DESCRIPTION
Put the instrumentation in place to run Espresso 2 tests, plus an example test that a clean start and verifies the Register and Skip buttons are displayed.