### PR TITLE
disconnect radio regardless of MMS exception

### DIFF
--- a/src/org/thoughtcrime/securesms/jobs/MmsDownloadJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/MmsDownloadJob.java
@@ -110,30 +110,31 @@ public class MmsDownloadJob extends MasterSecretJob {
       Log.w(TAG, "Changing radio to MMS mode..");
       radio.connect();
 
-      Log.w(TAG, "Downloading in MMS mode with proxy...");
-
       try {
-        retrieveAndStore(masterSecret, radio, messageId, threadId, contentLocation,
-                         transactionId, true, true);
-        radio.disconnect();
-        return;
-      } catch (IOException e) {
-        Log.w(TAG, e);
-      }
+        Log.w(TAG, "Downloading in MMS mode with proxy...");
 
-      Log.w(TAG, "Downloading in MMS mode without proxy...");
+        try {
+          retrieveAndStore(masterSecret, radio, messageId, threadId, contentLocation,
+                           transactionId, true, true);
+          return;
+        } catch (IOException e) {
+          Log.w(TAG, e);
+        }
 
-      try {
-        retrieveAndStore(masterSecret, radio, messageId, threadId,
-                         contentLocation, transactionId, true, false);
+        Log.w(TAG, "Downloading in MMS mode without proxy...");
+
+        try {
+          retrieveAndStore(masterSecret, radio, messageId, threadId,
+                           contentLocation, transactionId, true, false);
+        } catch (IOException e) {
+          Log.w(TAG, e);
+          handleDownloadError(masterSecret, messageId, threadId,
+                              MmsDatabase.Status.DOWNLOAD_SOFT_FAILURE,
+                              context.getString(R.string.MmsDownloader_error_connecting_to_mms_provider),
+                              automatic);
+        }
+      } finally {
         radio.disconnect();
-      } catch (IOException e) {
-        Log.w(TAG, e);
-        radio.disconnect();
-        handleDownloadError(masterSecret, messageId, threadId,
-                            MmsDatabase.Status.DOWNLOAD_SOFT_FAILURE,
-                            context.getString(R.string.MmsDownloader_error_connecting_to_mms_provider),
-                            automatic);
       }
 
     } catch (ApnUnavailableException e) {

--- a/src/org/thoughtcrime/securesms/jobs/MmsSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/MmsSendJob.java
@@ -117,23 +117,22 @@ public class MmsSendJob extends SendJob {
       radio.connect();
 
       try {
-        MmsSendResult result = sendMms(masterSecret, radio, message, true, true);
-        radio.disconnect();
-        return result;
-      } catch (IOException e) {
-        Log.w(TAG, e);
-      }
+        try {
+          return sendMms(masterSecret, radio, message, true, true);
+        } catch (IOException e) {
+          Log.w(TAG, e);
+        }
 
-      Log.w(TAG, "Sending MMS with radio change and without proxy...");
+        Log.w(TAG, "Sending MMS with radio change and without proxy...");
 
-      try {
-        MmsSendResult result = sendMms(masterSecret, radio, message, true, false);
+        try {
+          return sendMms(masterSecret, radio, message, true, false);
+        } catch (IOException ioe) {
+          Log.w(TAG, ioe);
+          throw new UndeliverableMessageException(ioe);
+        }
+      } finally {
         radio.disconnect();
-        return result;
-      } catch (IOException ioe) {
-        Log.w(TAG, ioe);
-        radio.disconnect();
-        throw new UndeliverableMessageException(ioe);
       }
 
     } catch (MmsRadioException mre) {


### PR DESCRIPTION
While there are no logs to confirm it was the cause of #2498, looking at the code we see any exceptions thrown in `retrieveAndStore()` or `sendMms()` that aren't IOException will bypass the call to `radio.disconnect()`, leaving the phone in a permanent wakelock.

This plays it much safer by wrapping all the code using the radio with a try-finally to ensure disconnect happens.