### PR TITLE
Changing appearance settings keeps the user on the same screen

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -75,6 +75,8 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
 
   private static final String PUSH_MESSAGING_PREF = "pref_toggle_push_messaging";
 
+  private static final String DISPLAY_PREFERENCE_CATEGORY_APPEARANCE = "display_preference_category_appearance";
+
   private final DynamicTheme    dynamicTheme    = new DynamicTheme();
   private final DynamicLanguage dynamicLanguage = new DynamicLanguage();
 
@@ -91,6 +93,15 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
     FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
     fragmentTransaction.replace(android.R.id.content, fragment);
     fragmentTransaction.commit();
+
+    if (getIntent().getBooleanExtra(DISPLAY_PREFERENCE_CATEGORY_APPEARANCE, false)) {
+      fragment            = new AppearancePreferenceFragment();
+      fragmentTransaction = fragmentManager.beginTransaction();
+      fragmentTransaction.replace(android.R.id.content, fragment);
+      fragmentTransaction.addToBackStack(null);
+      fragmentTransaction.commit();
+      getIntent().removeExtra(DISPLAY_PREFERENCE_CATEGORY_APPEARANCE);
+    }
   }
 
   @Override
@@ -131,8 +142,10 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
   @Override
   public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
     if (key.equals(TextSecurePreferences.THEME_PREF)) {
+      getIntent().putExtra(DISPLAY_PREFERENCE_CATEGORY_APPEARANCE, true);
       dynamicTheme.onResume(this);
     } else if (key.equals(TextSecurePreferences.LANGUAGE_PREF)) {
+      getIntent().putExtra(DISPLAY_PREFERENCE_CATEGORY_APPEARANCE, true);
       dynamicLanguage.onResume(this);
 
       Intent intent = new Intent(this, KeyCachingService.class);


### PR DESCRIPTION
Hi, this is my first time contributing here. I am part of a student group from the Delft University of Technology, following a course on Software Architecture. We have picked TextSecure as our Open Source project of interest and are at the moment tasked to try to contribute something. Which brings me to this pull request.

Changing the theme or language returns the user to the main settings screen, which can be jarring for the user. If you accidentally tapped on the wrong language this also makes it harder find your way back. This PR keeps the user at the appearance screen by redisplaying that Fragment after the Activity is recreated, when this scenario applies. 

Possibly a fix for #2476.

// FREEBIE