### PR TITLE
message timestamps update onResume()

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -91,6 +91,18 @@ public class ConversationFragment extends ListFragment
     getLoaderManager().restartLoader(0, null, this);
   }
 
+  @Override
+  public void onResume() {
+    super.onResume();
+    getLoaderManager().initLoader(0, null, this);
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    getLoaderManager().destroyLoader(0);
+  }
+
   private void initializeResources() {
     this.masterSecret = this.getActivity().getIntent().getParcelableExtra("master_secret");
     this.recipients   = RecipientFactory.getRecipientsForIds(getActivity(), getActivity().getIntent().getLongArrayExtra("recipients"), true);
@@ -103,7 +115,6 @@ public class ConversationFragment extends ListFragment
                                                   (!this.recipients.isSingleRecipient()) || this.recipients.isGroupRecipient(),
                                                   DirectoryHelper.isPushDestination(getActivity(), this.recipients)));
       getListView().setRecyclerListener((ConversationAdapter)getListAdapter());
-      getLoaderManager().initLoader(0, null, this);
     }
   }
 
@@ -159,6 +170,7 @@ public class ConversationFragment extends ListFragment
     this.threadId   = threadId;
 
     initializeListAdapter();
+    getLoaderManager().restartLoader(0, null, this);
   }
 
   public void scrollToBottom() {
@@ -268,12 +280,16 @@ public class ConversationFragment extends ListFragment
 
   @Override
   public void onLoadFinished(Loader<Cursor> arg0, Cursor cursor) {
-    ((CursorAdapter)getListAdapter()).changeCursor(cursor);
+    if (this.recipients != null && this.threadId != -1) {
+      ((CursorAdapter) getListAdapter()).changeCursor(cursor);
+    }
   }
 
   @Override
   public void onLoaderReset(Loader<Cursor> arg0) {
-    ((CursorAdapter)getListAdapter()).changeCursor(null);
+    if (this.recipients != null && this.threadId != -1) {
+      ((CursorAdapter) getListAdapter()).changeCursor(null);
+    }
   }
 
   public interface ConversationFragmentListener {

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -100,15 +100,19 @@ public class ConversationListFragment extends ListFragment
     });
     initializeListAdapter();
     initializeBatchListener();
-
-    getLoaderManager().initLoader(0, null, this);
   }
 
   @Override
   public void onResume() {
     super.onResume();
-
+    getLoaderManager().initLoader(0, null, this);
     initializeReminders();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    getLoaderManager().destroyLoader(0);
   }
 
   @Override
@@ -143,7 +147,6 @@ public class ConversationListFragment extends ListFragment
   public void setMasterSecret(MasterSecret masterSecret) {
     if (this.masterSecret != masterSecret) {
       this.masterSecret = masterSecret;
-      initializeListAdapter();
     }
   }
 
@@ -191,7 +194,6 @@ public class ConversationListFragment extends ListFragment
   private void initializeListAdapter() {
     this.setListAdapter(new ConversationListAdapter(getActivity(), null, masterSecret));
     getListView().setRecyclerListener((ConversationListAdapter)getListAdapter());
-    getLoaderManager().restartLoader(0, null, this);
   }
 
   private void handleDeleteAllSelected() {


### PR DESCRIPTION
Modified conversation view and conversation list view to update message timestamps onResume.

The basics of this is that `LoaderManager.initLoader()` is now called `onResume()` instead of `onCreate()` and `LoaderManager.destroyLoader()` is now called `onPause()` so that a new loader will be created `onResume()` which will force the timestamps to update.

The null check and `-1` check on `this.recipients` and `this.threadId` is to handle the case of a new conversation thread where the list of messages would be empty-- in this case no `ListAdapter` is set so these checks prevent an NPE within two of the `LoaderManager` callbacks.

Fixes #2519