### PR TITLE
settings preference group summaries

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -719,6 +719,7 @@
     <string name="preferences__change_my_passphrase">Change my passphrase</string>
     <string name="preferences__complete_key_exchanges">Complete key exchanges</string>
     <string name="preferences__enable_passphrase">Enable passphrase</string>
+    <string name="preferences__passphrase">Passphrase</string>
     <string name="preferences__enable_local_encryption_of_messages_and_keys">Enable local encryption of messages and keys</string>
     <string name="preferences__screen_security">Screen security</string>
     <string name="preferences__automatically_complete_key_exchanges_for_new_sessions_or_for_existing_sessions_with_the_same_identity_key">Automatically complete key exchanges for new sessions or for existing sessions with the same identity key</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -39,8 +39,8 @@
     <string name="ApplicationPreferencesActivity_partial">partial</string>
     <string name="ApplicationPreferencesActivity_sms">SMS</string>
     <string name="ApplicationPreferencesActivity_mms">MMS</string>
-    <string name="ApplicationPreferencesActivity_incoming_sms">Incoming</string>
-    <string name="ApplicationPreferencesActivity_outgoing_sms">outgoing</string>
+    <string name="ApplicationPreferencesActivity_incoming_sms_summary">Incoming %s</string>
+    <string name="ApplicationPreferencesActivity_outgoing_sms_summary">outgoing %s</string>
 
     <!-- AppProtectionPreferenceFragment -->
     <string name="AppProtectionPreferenceFragment_minutes">%d minutes</string>
@@ -719,9 +719,10 @@
     <string name="preferences__change_my_passphrase">Change my passphrase</string>
     <string name="preferences__complete_key_exchanges">Complete key exchanges</string>
     <string name="preferences__enable_passphrase">Enable passphrase</string>
-    <string name="preferences__passphrase">Passphrase</string>
+    <string name="preferences__passphrase_summary">Passphrase %s</string>
     <string name="preferences__enable_local_encryption_of_messages_and_keys">Enable local encryption of messages and keys</string>
     <string name="preferences__screen_security">Screen security</string>
+    <string name="preferences__screen_security_summary">Screen security %s</string>
     <string name="preferences__automatically_complete_key_exchanges_for_new_sessions_or_for_existing_sessions_with_the_same_identity_key">Automatically complete key exchanges for new sessions or for existing sessions with the same identity key</string>
     <string name="preferences__disable_screen_security_to_allow_screen_shots">Block screenshots in the recents list and inside the app</string>
     <string name="preferences__forget_passphrase_from_memory_after_some_interval">Forget passphrase from memory after some interval</string>
@@ -786,8 +787,10 @@
     <string name="preferences__dark_theme">Dark</string>
     <string name="preferences__appearance">Appearance</string>
     <string name="preferences__theme">Theme</string>
+    <string name="preferences__theme_summary">Theme %s</string>
     <string name="preferences__default">Default</string>
     <string name="preferences__language">Language</string>
+    <string name="preferences__language_summary">Language %s</string>
     <string name="preferences__make_default_sms_app">Set as default SMS app</string>
     <string name="preferences__make_textsecure_the_default_sms_mms_app">Make TextSecure the default SMS/MMS application for your system.</string>
     <string name="preferences__use_data_channel">Push messages</string>

--- a/src/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
@@ -153,21 +153,25 @@ public class AppProtectionPreferenceFragment extends PreferenceFragment {
   }
 
   private static CharSequence getPassphraseSummary(Context context) {
-    final int passphraseResId = R.string.preferences__passphrase;
-    final int onResId         = R.string.ApplicationPreferencesActivity_on;
-    final int offResId        = R.string.ApplicationPreferencesActivity_off;
+    final int    passphraseResId = R.string.preferences__passphrase_summary;
+    final String onRes           = context.getString(R.string.ApplicationPreferencesActivity_on);
+    final String offRes          = context.getString(R.string.ApplicationPreferencesActivity_off);
 
-    return context.getString(passphraseResId) + " " +
-           context.getString((TextSecurePreferences.isPasswordDisabled(context) ? offResId : onResId));
+    if (TextSecurePreferences.isPasswordDisabled(context))
+      return context.getString(passphraseResId, offRes);
+
+    return context.getString(passphraseResId, onRes);
   }
 
   private static CharSequence getScreenSecuritySummary(Context context) {
-    final int screenSecurityResId = R.string.preferences__screen_security;
-    final int onResId             = R.string.ApplicationPreferencesActivity_on;
-    final int offResId            = R.string.ApplicationPreferencesActivity_off;
+    final int    screenSecurityResId = R.string.preferences__screen_security_summary;
+    final String onRes               = context.getString(R.string.ApplicationPreferencesActivity_on);
+    final String offRes              = context.getString(R.string.ApplicationPreferencesActivity_off);
 
-    return context.getString(screenSecurityResId) + " " +
-           context.getString((TextSecurePreferences.isScreenSecurityEnabled(context) ? onResId : offResId));
+    if (TextSecurePreferences.isScreenSecurityEnabled(context))
+      return context.getString(screenSecurityResId, onRes);
+
+    return context.getString(screenSecurityResId, offRes);
   }
 
   public static CharSequence getSummary(Context context) {

--- a/src/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
@@ -157,10 +157,11 @@ public class AppProtectionPreferenceFragment extends PreferenceFragment {
     final String onRes           = context.getString(R.string.ApplicationPreferencesActivity_on);
     final String offRes          = context.getString(R.string.ApplicationPreferencesActivity_off);
 
-    if (TextSecurePreferences.isPasswordDisabled(context))
+    if (TextSecurePreferences.isPasswordDisabled(context)) {
       return context.getString(passphraseResId, offRes);
-
-    return context.getString(passphraseResId, onRes);
+    } else {
+      return context.getString(passphraseResId, onRes);
+    }
   }
 
   private static CharSequence getScreenSecuritySummary(Context context) {
@@ -168,10 +169,11 @@ public class AppProtectionPreferenceFragment extends PreferenceFragment {
     final String onRes               = context.getString(R.string.ApplicationPreferencesActivity_on);
     final String offRes              = context.getString(R.string.ApplicationPreferencesActivity_off);
 
-    if (TextSecurePreferences.isScreenSecurityEnabled(context))
+    if (TextSecurePreferences.isScreenSecurityEnabled(context)) {
       return context.getString(screenSecurityResId, onRes);
-
-    return context.getString(screenSecurityResId, offRes);
+    } else {
+      return context.getString(screenSecurityResId, offRes);
+    }
   }
 
   public static CharSequence getSummary(Context context) {

--- a/src/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
@@ -11,7 +11,6 @@ import android.preference.CheckBoxPreference;
 import android.preference.Preference;
 import android.preference.PreferenceScreen;
 import android.support.v4.preference.PreferenceFragment;
-import android.util.Log;
 import android.widget.Toast;
 
 import com.doomonafireball.betterpickers.hmspicker.HmsPickerBuilder;
@@ -153,10 +152,25 @@ public class AppProtectionPreferenceFragment extends PreferenceFragment {
     }
   }
 
-  public static CharSequence getSummary(Context context) {
-    final int onCapsResId  = R.string.ApplicationPreferencesActivity_On;
-    final int offCapsResId = R.string.ApplicationPreferencesActivity_Off;
+  private static CharSequence getPassphraseSummary(Context context) {
+    final int passphraseResId = R.string.preferences__passphrase;
+    final int onResId         = R.string.ApplicationPreferencesActivity_on;
+    final int offResId        = R.string.ApplicationPreferencesActivity_off;
 
-    return context.getString(TextSecurePreferences.isPasswordDisabled(context) ? offCapsResId : onCapsResId);
+    return context.getString(passphraseResId) + " " +
+           context.getString((TextSecurePreferences.isPasswordDisabled(context) ? offResId : onResId));
+  }
+
+  private static CharSequence getScreenSecuritySummary(Context context) {
+    final int screenSecurityResId = R.string.preferences__screen_security;
+    final int onResId             = R.string.ApplicationPreferencesActivity_on;
+    final int offResId            = R.string.ApplicationPreferencesActivity_off;
+
+    return context.getString(screenSecurityResId) + " " +
+           context.getString((TextSecurePreferences.isScreenSecurityEnabled(context) ? onResId : offResId));
+  }
+
+  public static CharSequence getSummary(Context context) {
+    return getPassphraseSummary(context) + ", " + getScreenSecuritySummary(context);
   }
 }

--- a/src/org/thoughtcrime/securesms/preferences/AppearancePreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AppearancePreferenceFragment.java
@@ -50,7 +50,7 @@ public class AppearancePreferenceFragment extends ListSummaryPreferenceFragment 
     int langIndex  = Arrays.asList(languageEntryValues).indexOf(TextSecurePreferences.getLanguage(context));
     int themeIndex = Arrays.asList(themeEntryValues).indexOf(TextSecurePreferences.getTheme(context));
 
-    return context.getString(R.string.preferences__theme)    + ": " + themeEntries[themeIndex] + ", " +
-           context.getString(R.string.preferences__language) + ": " + languageEntries[langIndex];
+    return context.getString(R.string.preferences__theme)    + " " + themeEntries[themeIndex] + ", " +
+           context.getString(R.string.preferences__language) + " " + languageEntries[langIndex];
   }
 }

--- a/src/org/thoughtcrime/securesms/preferences/AppearancePreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AppearancePreferenceFragment.java
@@ -50,7 +50,7 @@ public class AppearancePreferenceFragment extends ListSummaryPreferenceFragment 
     int langIndex  = Arrays.asList(languageEntryValues).indexOf(TextSecurePreferences.getLanguage(context));
     int themeIndex = Arrays.asList(themeEntryValues).indexOf(TextSecurePreferences.getTheme(context));
 
-    return context.getString(R.string.preferences__theme)    + " " + themeEntries[themeIndex] + ", " +
-           context.getString(R.string.preferences__language) + " " + languageEntries[langIndex];
+    return context.getString(R.string.preferences__theme_summary,    themeEntries[themeIndex]) + ", " +
+           context.getString(R.string.preferences__language_summary, languageEntries[langIndex]);
   }
 }

--- a/src/org/thoughtcrime/securesms/preferences/SmsMmsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/SmsMmsPreferenceFragment.java
@@ -146,7 +146,7 @@ public class SmsMmsPreferenceFragment extends PreferenceFragment {
     final int offResId         = R.string.ApplicationPreferencesActivity_off;
     final int smsResId         = R.string.ApplicationPreferencesActivity_sms;
     final int mmsResId         = R.string.ApplicationPreferencesActivity_mms;
-    final int incomingSmsResId = R.string.ApplicationPreferencesActivity_incoming_sms;
+    final int incomingSmsResId = R.string.ApplicationPreferencesActivity_incoming_sms_summary;
 
     final int incomingSmsSummary;
     boolean postKitkatSMS = Util.isDefaultSmsProvider(context);
@@ -161,14 +161,14 @@ public class SmsMmsPreferenceFragment extends PreferenceFragment {
       else if (!preKitkatSMS && preKitkatMMS) incomingSmsSummary = mmsResId;
       else                                    incomingSmsSummary = offResId;
     }
-    return context.getString(incomingSmsResId) + " " + context.getString(incomingSmsSummary);
+    return context.getString(incomingSmsResId, context.getString(incomingSmsSummary));
   }
 
   private static CharSequence getOutgoingSmsSummary(Context context) {
     final int onResId          = R.string.ApplicationPreferencesActivity_on;
     final int offResId         = R.string.ApplicationPreferencesActivity_off;
     final int partialResId     = R.string.ApplicationPreferencesActivity_partial;
-    final int outgoingSmsResId = R.string.ApplicationPreferencesActivity_outgoing_sms;
+    final int outgoingSmsResId = R.string.ApplicationPreferencesActivity_outgoing_sms_summary;
 
     final int outgoingSmsSummary;
     if (TextSecurePreferences.isFallbackSmsAllowed(context) && TextSecurePreferences.isDirectSmsAllowed(context)) {
@@ -178,6 +178,6 @@ public class SmsMmsPreferenceFragment extends PreferenceFragment {
     } else {
       outgoingSmsSummary = offResId;
     }
-    return context.getString(outgoingSmsResId) + " " + context.getString(outgoingSmsSummary);
+    return context.getString(outgoingSmsResId, context.getString(outgoingSmsSummary));
   }
 }

--- a/src/org/thoughtcrime/securesms/preferences/SmsMmsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/SmsMmsPreferenceFragment.java
@@ -161,7 +161,7 @@ public class SmsMmsPreferenceFragment extends PreferenceFragment {
       else if (!preKitkatSMS && preKitkatMMS) incomingSmsSummary = mmsResId;
       else                                    incomingSmsSummary = offResId;
     }
-    return context.getString(incomingSmsResId) + ": " + context.getString(incomingSmsSummary);
+    return context.getString(incomingSmsResId) + " " + context.getString(incomingSmsSummary);
   }
 
   private static CharSequence getOutgoingSmsSummary(Context context) {
@@ -178,6 +178,6 @@ public class SmsMmsPreferenceFragment extends PreferenceFragment {
     } else {
       outgoingSmsSummary = offResId;
     }
-    return context.getString(outgoingSmsResId) + ": " + context.getString(outgoingSmsSummary);
+    return context.getString(outgoingSmsResId) + " " + context.getString(outgoingSmsSummary);
   }
 }


### PR DESCRIPTION
1) created a new string constant for *Passphrase*.
2) modified *App protection* preference group summary to be more verbose.
3) dropped the colons from *Appearance* preference group summary.
4) dropped the colons from and *SMS and MMS* preference group summary.

turns out we didn't have a *Passphrase* string in `strings.xml`, the closest match I found was *Enable passphrase* but the *App protection* preferences group summary doesn't read as nicely, eg...

*Enable passphrase on, Screen security on*
vs
*Passphrase on, Screen security on*

Could revert to using the existing *Enable passphrase* string constant if we really wanna avoid adding a new one, lemme know.

Fixes #2395 