### PR TITLE
remove ConfirmIdentityActivity

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -90,10 +90,6 @@
               android:windowSoftInputMode="stateUnchanged"              
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
-    <activity android:name=".ConfirmIdentityActivity"
-              android:theme="@style/TextSecure.Light.Dialog"
-              android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
-
     <activity android:name=".DeviceProvisioningActivity"
               android:theme="@style/TextSecure.DialogActivity"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize">


### PR DESCRIPTION
`ConfirmIdentityActivity` was added in https://github.com/WhisperSystems/TextSecure/commit/d2e188ee62da6fc27eb203732ec3b423c16efa08 but I couldn't find a `ConfirmIdentityActivity`.

lint output:
````
 ../../AndroidManifest.xml:93: Class referenced in the manifest, org.thoughtcrime.securesms.ConfirmIdentityActivity, was not found in the project or the libraries

  90               android:windowSoftInputMode="stateUnchanged"              
  91               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
  92 
  93     <activity android:name=".ConfirmIdentityActivity"

  94               android:theme="@style/TextSecure.Light.Dialog"
  95               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>

Priority: 8 / 10
Category: Correctness
Severity: Error
Explanation: Missing registered class.
If a class is referenced in the manifest, it must also exist in the project (or in one of the libraries included by the project. This check helps uncover typos in registration names, or attempts to rename or move classes without updating the manifest file properly.

More info: http://developer.android.com/guide/topics/manifest/manifest-intro.html 
````

 Am I missing something?
