### PR TITLE
update message timestamps onResume

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -81,6 +81,15 @@ public class ConversationFragment extends ListFragment
     this.listener = (ConversationFragmentListener)activity;
   }
 
+  @Override
+  public void onResume() {
+    super.onResume();
+
+    if (getListAdapter() != null) {
+      ((ConversationListAdapter) getListAdapter()).notifyDataSetChanged();
+    }
+  }
+
   public void onNewIntent() {
     if (actionMode != null) {
       actionMode.finish();

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -109,6 +109,7 @@ public class ConversationListFragment extends ListFragment
     super.onResume();
 
     initializeReminders();
+    ((ConversationListAdapter)getListAdapter()).notifyDataSetChanged();
   }
 
   @Override


### PR DESCRIPTION
modified ConversationFragment and ConversationListFragment to update message timesamps on resume.

Fixes #2519.
// FREEBIE