### PR TITLE
fix LoaderManager misuse and prevent wasteful view redraws

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -103,7 +103,6 @@ public class ConversationFragment extends ListFragment
 
     initializeResources();
     initializeListAdapter();
-    getLoaderManager().restartLoader(0, null, this);
   }
 
   private void initializeResources() {
@@ -117,7 +116,7 @@ public class ConversationFragment extends ListFragment
                                                   (!this.recipients.isSingleRecipient()) || this.recipients.isGroupRecipient(),
                                                   DirectoryHelper.isPushDestination(getActivity(), this.recipients)));
       getListView().setRecyclerListener((ConversationAdapter)getListAdapter());
-      getLoaderManager().initLoader(0, null, this);
+      getLoaderManager().restartLoader(0, null, this);
     }
   }
 
@@ -127,12 +126,9 @@ public class ConversationFragment extends ListFragment
   }
 
   private void setCorrectMenuVisibility(Menu menu) {
-    ConversationAdapter adapter        = (ConversationAdapter) getListAdapter();
     List<MessageRecord> messageRecords = getSelectedMessageRecords();
 
     if (actionMode != null && messageRecords.size() == 0) {
-      adapter.getBatchSelected().clear();
-      adapter.notifyDataSetChanged();
       actionMode.finish();
       return;
     }
@@ -169,10 +165,14 @@ public class ConversationFragment extends ListFragment
   }
 
   public void reload(Recipients recipients, long threadId) {
+    boolean threadIdChanged = this.threadId != threadId;
+
     this.recipients = recipients;
     this.threadId   = threadId;
 
-    initializeListAdapter();
+    if (threadIdChanged) {
+      initializeListAdapter();
+    }
   }
 
   public void scrollToBottom() {

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -165,12 +165,10 @@ public class ConversationFragment extends ListFragment
   }
 
   public void reload(Recipients recipients, long threadId) {
-    boolean threadIdChanged = this.threadId != threadId;
-
     this.recipients = recipients;
-    this.threadId   = threadId;
 
-    if (threadIdChanged) {
+    if (this.threadId != threadId) {
+      this.threadId = threadId;
       initializeListAdapter();
     }
   }

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -96,8 +96,6 @@ public class ConversationListFragment extends ListFragment
     });
     initializeListAdapter();
     initializeBatchListener();
-
-    getLoaderManager().initLoader(0, null, this);
   }
 
   @Override


### PR DESCRIPTION
modified ConversationFragment and ConversationListFragment to use the LoaderManager more efficiently. dropped wasteful call to notifyDataSetChanged() in ConversationFragment.