### PR TITLE
prevent ghost thread on batch delete of all messages in a thread

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1234,6 +1234,11 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   @Override
+  public void setThreadId(long threadId) {
+    this.threadId = threadId;
+  }
+
+  @Override
   public void onAttachmentChanged() {
     initializeSecurity();
   }

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -29,6 +29,7 @@ import android.widget.Toast;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.MmsSmsDatabase;
+import org.thoughtcrime.securesms.database.ThreadDatabase;
 import org.thoughtcrime.securesms.database.loaders.ConversationLoader;
 import org.thoughtcrime.securesms.database.model.MediaMmsMessageRecord;
 import org.thoughtcrime.securesms.database.model.MessageRecord;
@@ -204,6 +205,14 @@ public class ConversationFragment extends ListFragment
         {
           @Override
           protected Void doInBackground(MessageRecord... messageRecords) {
+            ThreadDatabase threadDatabase = DatabaseFactory.getThreadDatabase(getActivity());
+            if (threadDatabase.getMessageCountForThreadId(threadId) == messageRecords.length) {
+              threadDatabase.deleteConversation(threadId);
+              threadId = -1;
+              listener.setThreadId(threadId);
+              return null;
+            }
+
             for (MessageRecord messageRecord : messageRecords) {
               if (messageRecord.isMms()) {
                 DatabaseFactory.getMmsDatabase(getActivity()).delete(messageRecord.getId());
@@ -287,6 +296,8 @@ public class ConversationFragment extends ListFragment
 
   public interface ConversationFragmentListener {
     public void setComposeText(String text);
+
+    public void setThreadId(long threadId);
   }
 
   public class SelectionClickListener

--- a/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -378,6 +378,24 @@ public class ThreadDatabase extends Database {
     return null;
   }
 
+  public long getMessageCountForThreadId(long threadId) {
+    SQLiteDatabase db = databaseHelper.getReadableDatabase();
+    Cursor cursor     = null;
+
+    try {
+      cursor = db.query(TABLE_NAME, null, ID + " = ?", new String[] {threadId+""}, null, null, null);
+
+      if (cursor != null && cursor.moveToFirst()) {
+        return cursor.getLong(cursor.getColumnIndexOrThrow(MESSAGE_COUNT));
+      }
+    } finally {
+      if (cursor != null)
+        cursor.close();
+    }
+
+    return -1L;
+  }
+
   public void update(long threadId) {
     MmsSmsDatabase mmsSmsDatabase = DatabaseFactory.getMmsSmsDatabase(context);
     long count                    = mmsSmsDatabase.getConversationCount(threadId);


### PR DESCRIPTION
when deleting all messages in a thread ConversationFragment now explicitly deletes the thread and resets 'threadId' to -1.

Fixes #2262
// FREEBIE