### PR TITLE
show message timestamp in the notification

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -186,6 +186,9 @@ public class MessageNotifier {
     builder.setNumber(notificationState.getMessageCount());
     builder.setDeleteIntent(PendingIntent.getBroadcast(context, 0, new Intent(DeleteReceiver.DELETE_REMINDER_ACTION), 0));
 
+    long timestamp = notifications.get(0).getTimestamp();
+    if (timestamp != 0) builder.setWhen(timestamp);
+
     if (masterSecret != null) {
       builder.addAction(R.drawable.check, context.getString(R.string.MessageNotifier_mark_as_read),
                         notificationState.getMarkAsReadIntent(context, masterSecret));
@@ -231,6 +234,9 @@ public class MessageNotifier {
     
     builder.setContentInfo(String.valueOf(notificationState.getMessageCount()));
     builder.setNumber(notificationState.getMessageCount());
+
+    long timestamp = notifications.get(0).getTimestamp();
+    if (timestamp != 0) builder.setWhen(timestamp);
 
     builder.setDeleteIntent(PendingIntent.getBroadcast(context, 0, new Intent(DeleteReceiver.DELETE_REMINDER_ACTION), 0));
 
@@ -316,7 +322,7 @@ public class MessageNotifier {
         SpannableString body       = new SpannableString(context.getString(R.string.MessageNotifier_encrypted_message));
         body.setSpan(new StyleSpan(android.graphics.Typeface.ITALIC), 0, body.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 
-        notificationState.addNotification(new NotificationItem(recipient, recipients, null, threadId, body, null));
+        notificationState.addNotification(new NotificationItem(recipient, recipients, null, threadId, body, null, 0));
       }
     } finally {
       if (reader != null)
@@ -342,6 +348,10 @@ public class MessageNotifier {
       SpannableString body             = record.getDisplayBody();
       Uri             image            = null;
       Recipients      threadRecipients = null;
+      long            timestamp;
+
+      if (record.isPush()) timestamp = record.getDateSent();
+      else                 timestamp = record.getDateReceived();
 
       if (threadId != -1) {
         threadRecipients = DatabaseFactory.getThreadDatabase(context).getRecipientsForThreadId(threadId);
@@ -352,7 +362,7 @@ public class MessageNotifier {
         body.setSpan(new StyleSpan(android.graphics.Typeface.ITALIC), 0, body.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
       }
 
-      notificationState.addNotification(new NotificationItem(recipient, recipients, threadRecipients, threadId, body, image));
+      notificationState.addNotification(new NotificationItem(recipient, recipients, threadRecipients, threadId, body, image, timestamp));
     }
 
     reader.close();

--- a/src/org/thoughtcrime/securesms/notifications/NotificationItem.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationItem.java
@@ -19,10 +19,11 @@ public class NotificationItem {
   private final long         threadId;
   private final CharSequence text;
   private final Uri          image;
+  private final long         timestamp;
 
   public NotificationItem(Recipient individualRecipient, Recipients recipients,
                           Recipients threadRecipients, long threadId,
-                          CharSequence text, Uri image)
+                          CharSequence text, Uri image, long timestamp)
   {
     this.individualRecipient = individualRecipient;
     this.recipients          = recipients;
@@ -30,6 +31,7 @@ public class NotificationItem {
     this.text                = text;
     this.image               = image;
     this.threadId            = threadId;
+    this.timestamp           = timestamp;
   }
 
   public Recipient getIndividualRecipient() {
@@ -42,6 +44,10 @@ public class NotificationItem {
 
   public CharSequence getText() {
     return text;
+  }
+
+  public long getTimestamp() {
+    return timestamp;
   }
 
   public Uri getImage() {


### PR DESCRIPTION
This fixes #2632 

Currently the notification timestamp is the time of the notification creation. This PR changes the timestamp to the message timestamp.

I think there might be a problem if the messages don't arrive in chronological order since the timestamp of the last received message will be displayed I guess. I couldn't test this but I think its still way better than before ;)