### PR TITLE
media type hints in message notifications

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/NotificationItem.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationItem.java
@@ -6,9 +6,15 @@ import android.content.Intent;
 import android.net.Uri;
 import android.text.SpannableStringBuilder;
 
+import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.RoutingActivity;
+import org.thoughtcrime.securesms.mms.Slide;
+import org.thoughtcrime.securesms.mms.SlideDeck;
+import org.thoughtcrime.securesms.notifications.MessageNotifier.NotificationStateChangeListener;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.Recipients;
+import org.thoughtcrime.securesms.util.FutureTaskListener;
+import org.thoughtcrime.securesms.util.ListenableFutureTask;
 import org.thoughtcrime.securesms.util.Util;
 
 public class NotificationItem {
@@ -17,19 +23,26 @@ public class NotificationItem {
   private final Recipient    individualRecipient;
   private final Recipients   threadRecipients;
   private final long         threadId;
-  private final CharSequence text;
-  private final Uri          image;
+  private       CharSequence text;
+  private final Context      context;
+  private final NotificationStateChangeListener listener;
 
   public NotificationItem(Recipient individualRecipient, Recipients recipients,
-                          Recipients threadRecipients, long threadId,
-                          CharSequence text, Uri image)
+                          Recipients threadRecipients, long threadId, CharSequence text,
+                          Context context, ListenableFutureTask<SlideDeck> slideDeckFuture,
+                          NotificationStateChangeListener listener)
   {
     this.individualRecipient = individualRecipient;
     this.recipients          = recipients;
     this.threadRecipients    = threadRecipients;
     this.text                = text;
-    this.image               = image;
     this.threadId            = threadId;
+    this.context             = context;
+    this.listener            = listener;
+
+    if (slideDeckFuture != null) {
+      slideDeckFuture.addListener(new SlideDeckListener());
+    }
   }
 
   public Recipient getIndividualRecipient() {
@@ -44,12 +57,14 @@ public class NotificationItem {
     return text;
   }
 
-  public Uri getImage() {
-    return image;
-  }
+  private void setText(int resId, Object... formatArgs) {
+    if (formatArgs != null) {
+      this.text = context.getString(resId, formatArgs);
+    } else {
+      this.text = context.getString(resId);
+    }
 
-  public boolean hasImage() {
-    return image != null;
+    listener.onNotificationStateChanged();
   }
 
   public long getThreadId() {
@@ -85,4 +100,28 @@ public class NotificationItem {
     return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
   }
 
+  private class SlideDeckListener implements FutureTaskListener<SlideDeck> {
+    @Override
+    public void onSuccess(SlideDeck slideDeck) {
+      if (NotificationItem.this.getText().length() > 0) {
+        return;
+      }
+
+      for (Slide slide : slideDeck.getSlides()) {
+        if (slide.hasImage()) {
+          NotificationItem.this.setText(R.string.DraftDatabase_Draft_image_snippet);
+          return;
+        } else if (slide.hasAudio()) {
+          NotificationItem.this.setText(R.string.DraftDatabase_Draft_audio_snippet);
+          return;
+        } else if (slide.hasVideo()) {
+          NotificationItem.this.setText(R.string.DraftDatabase_Draft_video_snippet);
+          return;
+        }
+      }
+    }
+
+    @Override
+    public void onFailure(Throwable error) { }
+  }
 }

--- a/src/org/thoughtcrime/securesms/notifications/NotificationState.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationState.java
@@ -7,6 +7,7 @@ import android.graphics.Bitmap;
 import android.util.Log;
 
 import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.notifications.MessageNotifier.NotificationStateChangeListener;
 
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -18,7 +19,21 @@ public class NotificationState {
   private final LinkedList<NotificationItem> notifications = new LinkedList<NotificationItem>();
   private final Set<Long>                    threads       = new HashSet<Long>();
 
-  private int notificationCount = 0;
+  private final boolean signal;
+  private final int     reminderCount;
+  private       int     notificationCount = 0;
+
+  private NotificationStateChangeListener stateChangeListener;
+
+  public NotificationState(Context      context,
+                           MasterSecret masterSecret,
+                           boolean      signal,
+                           int          reminderCount)
+  {
+    this.signal              = signal;
+    this.reminderCount       = reminderCount;
+    this.stateChangeListener = new NotificationStateChangeListener(context, masterSecret);
+  }
 
   public void addNotification(NotificationItem item) {
     notifications.addFirst(item);
@@ -40,6 +55,18 @@ public class NotificationState {
 
   public Bitmap getContactPhoto() {
     return notifications.get(0).getIndividualRecipient().getContactPhoto();
+  }
+
+  public boolean getSignal() {
+    return signal;
+  }
+
+  public int getReminderCount() {
+    return reminderCount;
+  }
+
+  public NotificationStateChangeListener getListener() {
+    return stateChangeListener;
   }
 
   public PendingIntent getMarkAsReadIntent(Context context, MasterSecret masterSecret) {


### PR DESCRIPTION
1) changed NotificationItem to provide content type hints for media messages that contain no text
2) changed NotificationState to hold more state so that state can be easily restored on resolve of NotificationItem's SlideDeck future
3) NotificationItem and NotificationState related updates to MessageNotifier

the path to notification media previews is now pretty straightforward.

Fixes #1639
// FREEBIE