### PR TITLE
fix picture message batch selection behavior

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationAdapter.java
+++ b/src/org/thoughtcrime/securesms/ConversationAdapter.java
@@ -18,7 +18,6 @@ package org.thoughtcrime.securesms;
 
 import android.content.Context;
 import android.database.Cursor;
-import android.os.Handler;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -66,10 +65,11 @@ public class ConversationAdapter extends CursorAdapter implements AbsListView.Re
   private final MasterSecret           masterSecret;
   private final boolean                groupThread;
   private final boolean                pushDestination;
+  private final Set<Integer>           itemTouchActions;
   private final LayoutInflater         inflater;
 
   public ConversationAdapter(Context context, MasterSecret masterSecret, SelectionClickListener selectionClickListener,
-                             boolean groupThread, boolean pushDestination)
+                             boolean groupThread, boolean pushDestination, Set<Integer> itemTouchActions)
   {
     super(context, null, 0);
     this.context                = context;
@@ -77,6 +77,7 @@ public class ConversationAdapter extends CursorAdapter implements AbsListView.Re
     this.selectionClickListener = selectionClickListener;
     this.groupThread            = groupThread;
     this.pushDestination        = pushDestination;
+    this.itemTouchActions       = itemTouchActions;
     this.inflater               = LayoutInflater.from(context);
   }
 
@@ -88,7 +89,7 @@ public class ConversationAdapter extends CursorAdapter implements AbsListView.Re
     MessageRecord messageRecord = getMessageRecord(id, cursor, type);
 
     item.set(masterSecret, messageRecord, batchSelected, selectionClickListener,
-             groupThread, pushDestination);
+             groupThread, pushDestination, itemTouchActions);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -32,6 +32,7 @@ import android.provider.ContactsContract.QuickContact;
 import android.support.annotation.NonNull;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.view.MotionEvent;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
@@ -115,6 +116,7 @@ public class ConversationItem extends LinearLayout {
   private SelectionClickListener          selectionClickListener;
   private View                            mmsContainer;
   private ImageView                       mmsThumbnail;
+  private Set<Integer>                    mmsThumbnailActions;
   private Button                          mmsDownloadButton;
   private TextView                        mmsDownloadingLabel;
   private ListenableFutureTask<SlideDeck> slideDeck;
@@ -167,7 +169,7 @@ public class ConversationItem extends LinearLayout {
                   @NonNull MessageRecord messageRecord,
                   @NonNull Set<MessageRecord> batchSelected,
                   @NonNull SelectionClickListener selectionClickListener,
-                  boolean groupThread, boolean pushDestination)
+                  boolean groupThread, boolean pushDestination, Set<Integer> mmsThumbnailActions)
   {
     this.masterSecret           = masterSecret;
     this.messageRecord          = messageRecord;
@@ -175,6 +177,7 @@ public class ConversationItem extends LinearLayout {
     this.selectionClickListener = selectionClickListener;
     this.groupThread            = groupThread;
     this.pushDestination        = pushDestination;
+    this.mmsThumbnailActions    = mmsThumbnailActions;
 
     setConversationBackgroundDrawables(messageRecord);
     setSelectionBackgroundDrawables(messageRecord);
@@ -394,6 +397,14 @@ public class ConversationItem extends LinearLayout {
       mmsThumbnail.setVisibility(View.GONE);
       mmsContainer.setVisibility(View.GONE);
     }
+
+    mmsThumbnail.setOnTouchListener(new OnTouchListener() {
+      @Override
+      public boolean onTouch(View view, MotionEvent event) {
+        mmsThumbnailActions.add(event.getAction());
+        return false;
+      }
+    });
 
     slideDeck = messageRecord.getSlideDeckFuture();
     slideDeckListener = new FutureTaskListener<SlideDeck>() {

--- a/src/org/thoughtcrime/securesms/MessageDetailsActivity.java
+++ b/src/org/thoughtcrime/securesms/MessageDetailsActivity.java
@@ -153,7 +153,7 @@ public class MessageDetailsActivity extends PassphraseRequiredActionBarActivity 
     toFrom.setText(toFromRes);
     conversationItem.set(masterSecret, messageRecord, new HashSet<MessageRecord>(), new NullSelectionListener(),
                          recipients != messageRecord.getRecipients(),
-                         DirectoryHelper.isPushDestination(this, recipients));
+                         DirectoryHelper.isPushDestination(this, recipients), new HashSet<Integer>());
     recipientsList.setAdapter(new MessageDetailsRecipientAdapter(this, masterSecret, messageRecord,
                                                                  recipients, isPushGroup));
   }


### PR DESCRIPTION
1) discovered that a spurious onItemClick callback occurs when moving left or right across an image before releasing a long click.
2) prevented the false onItemClick from occuring by curating the list view and item view onTouch actions.

nothing else prevents this, I tried everything. thoroughly tested.

Fixes #2488
// FREEBIE