### PR TITLE
fix DeliveryReceiptJobTes.testDelivery()

### DIFF
--- a/androidTest/java/org/thoughtcrime/securesms/jobs/DeliveryReceiptJobTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/jobs/DeliveryReceiptJobTest.java
@@ -39,7 +39,7 @@ public class DeliveryReceiptJobTest extends TextSecureTestCase {
     ArgumentCaptor<TextSecureAddress> captor = ArgumentCaptor.forClass(TextSecureAddress.class);
     verify(textSecureMessageSender).sendDeliveryReceipt(captor.capture(), eq(timestamp));
 
-    assertTrue(captor.getValue().getRelay().equals("foo"));
+    assertTrue(captor.getValue().getRelay().get().equals("foo"));
     assertTrue(captor.getValue().getNumber().equals("+14152222222"));
   }
 


### PR DESCRIPTION
String should not be compared with an Optional in DeliveryReceiptJobTes.testDelivery(). Test previously failed, now passed.

someone hasn't been testing their releases :P 

// FREEBIE