### PR TITLE
fix initialization of emoji cache

### DIFF
--- a/src/org/thoughtcrime/securesms/util/Emoji.java
+++ b/src/org/thoughtcrime/securesms/util/Emoji.java
@@ -311,8 +311,6 @@ public class Emoji {
         Log.w(TAG, e);
         recentlyUsed = new LinkedHashSet<>();
       }
-
-      recentlyUsed = new LinkedHashSet<>();
     }
 
     public static String[] getRecentlyUsed(Context context) {


### PR DESCRIPTION
Fix initialization of emoji cache.

Could someone test this on a pre-kitkat phone? I have none. Intuition is that if you force-stop TextSecure on 2.6.4 you should be able to reproduce #2700, might need to clear app cache too but admittedly I have no idea what that button actually does.

Fixes #2700
// FREEBIE