### PR TITLE
created a set of basic espresso tests.

### DIFF
--- a/androidTest/java/org/thoughtcrime/securesms/ApplicationPreferencesActivityTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/ApplicationPreferencesActivityTest.java
@@ -1,0 +1,59 @@
+package org.thoughtcrime.securesms;
+
+import android.content.Context;
+import android.test.suitebuilder.annotation.LargeTest;
+
+import org.hamcrest.Matchers;
+
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.PreferenceMatchers.withKey;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+
+/**
+ * rhodey
+ */
+@LargeTest
+public class ApplicationPreferencesActivityTest extends SkipRegistrationInstrumentationTestCase {
+
+  public ApplicationPreferencesActivityTest() {
+    super();
+  }
+
+  public ApplicationPreferencesActivityTest(Context context) {
+    super(context);
+  }
+
+  private void checkAllPreferencesDisplayed() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("preference_category_sms_mms")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("preference_category_notifications")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("preference_category_app_protection")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("preference_category_appearance")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("preference_category_storage")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("preference_category_advanced")))
+          .check(matches(isDisplayed()));
+  }
+
+  private void clickSettingsAndTestState() throws Exception {
+    new ConversationListActivityTest(getContext()).testClickSettings();
+    waitOn(ApplicationPreferencesActivity.class);
+    checkAllPreferencesDisplayed();
+  }
+
+  public void testClickNotificationsSetting() throws Exception {
+    clickSettingsAndTestState();
+    onData(Matchers.<Object>allOf(withKey("preference_category_notifications"))).perform(click());
+  }
+
+  public void testClickAppProtectionSetting() throws Exception {
+    clickSettingsAndTestState();
+    onData(Matchers.<Object>allOf(withKey("preference_category_app_protection"))).perform(click());
+  }
+
+}

--- a/androidTest/java/org/thoughtcrime/securesms/ApplicationPreferencesActivityTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/ApplicationPreferencesActivityTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.thoughtcrime.securesms;
 
 import android.content.Context;
@@ -11,9 +27,6 @@ import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.PreferenceMatchers.withKey;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 
-/**
- * rhodey
- */
 @LargeTest
 public class ApplicationPreferencesActivityTest extends SkipRegistrationInstrumentationTestCase {
 

--- a/androidTest/java/org/thoughtcrime/securesms/ConversationListActivityTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/ConversationListActivityTest.java
@@ -1,0 +1,147 @@
+package org.thoughtcrime.securesms;
+
+import android.content.Context;
+import android.test.suitebuilder.annotation.LargeTest;
+import android.util.Log;
+
+import org.thoughtcrime.securesms.components.DefaultSmsReminder;
+import org.thoughtcrime.securesms.components.ExpiredBuildReminder;
+import org.thoughtcrime.securesms.components.PushRegistrationReminder;
+import org.thoughtcrime.securesms.components.SystemSmsImportReminder;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static android.support.test.espresso.Espresso.pressBack;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static android.support.test.espresso.action.ViewActions.click;
+
+@LargeTest
+public class ConversationListActivityTest extends SkipRegistrationInstrumentationTestCase {
+  private final static String TAG = ConversationListActivityTest.class.getSimpleName();
+
+  public ConversationListActivityTest() {
+    super();
+  }
+
+  public ConversationListActivityTest(Context context) {
+    super(context);
+  }
+
+  private void checkOptionsMenuItemsDisplayed() throws Exception {
+    onView(withContentDescription(getContext().getString(R.string.conversation_list__menu_search)))
+          .check(matches(isDisplayed()));
+
+    openActionBarOverflowOrOptionsMenu(getContext());
+    onView(withText(R.string.text_secure_normal__menu_new_group)).check(matches(isDisplayed()));
+    onView(withText(R.string.text_secure_normal__mark_all_as_read)).check(matches(isDisplayed()));
+    onView(withText(R.string.arrays__import_export)).check(matches(isDisplayed()));
+    onView(withText(R.string.arrays__my_identity_key)).check(matches(isDisplayed()));
+    onView(withText(R.string.text_secure_normal__menu_settings)).check(matches(isDisplayed()));
+
+    if (!TextSecurePreferences.isPasswordDisabled(getContext())) {
+      onView(withText(R.string.text_secure_normal__menu_clear_passphrase))
+            .check(matches(isDisplayed()));
+    }
+
+    pressBack();
+  }
+
+  private boolean checkReminderIsDisplayed() throws Exception {
+    boolean reminderVisible    = true;
+    Integer reminderTitleResId = null;
+    Integer reminderTextResId  = null;
+
+    if (ExpiredBuildReminder.isEligible(getContext())) {
+      reminderTitleResId = R.string.reminder_header_expired_build;
+      reminderTextResId  = R.string.reminder_header_expired_build_details;
+    } else if (DefaultSmsReminder.isEligible(getContext())) {
+      reminderTitleResId = R.string.reminder_header_sms_default_title;
+      reminderTextResId  = R.string.reminder_header_sms_default_text;
+    } else if (SystemSmsImportReminder.isEligible(getContext())) {
+      reminderTitleResId = R.string.reminder_header_sms_import_title;
+      reminderTextResId  = R.string.reminder_header_sms_import_text;
+    } else if (PushRegistrationReminder.isEligible(getContext())) {
+      reminderTitleResId = R.string.reminder_header_push_title;
+      reminderTextResId  = R.string.reminder_header_push_text;
+    } else {
+      reminderVisible = false;
+    }
+
+    if (reminderVisible) {
+      onView(withId(R.id.reminder_title)).check(matches(isDisplayed()));
+      onView(withId(R.id.reminder_title)).check(matches(withText(reminderTitleResId)));
+      onView(withId(R.id.reminder_text)).check(matches(isDisplayed()));
+      onView(withId(R.id.reminder_text)).check(matches(withText(reminderTextResId)));
+    }
+
+    return reminderVisible;
+  }
+
+  private void handleTestState() throws Exception {
+    waitOn(ConversationListActivity.class);
+    checkOptionsMenuItemsDisplayed();
+    checkReminderIsDisplayed();
+  }
+
+  public void testDismissAllReminders() throws Exception {
+    handleTestState();
+
+    int expectedReminders = 0;
+    if (ExpiredBuildReminder.isEligible(getContext()))    expectedReminders++;
+    if (DefaultSmsReminder.isEligible(getContext()))      expectedReminders++;
+    if (SystemSmsImportReminder.isEligible(getContext())) expectedReminders++;
+
+    Log.d(TAG, "expecting to see " + expectedReminders + " reminders");
+    while (expectedReminders > 0) {
+      if (!checkReminderIsDisplayed()) {
+        throw new IllegalStateException("expected to see " + expectedReminders + " more reminders");
+      }
+
+      Log.d(TAG, "found reminder, dismissing now");
+      onView(withId(R.id.cancel)).perform(click());
+      expectedReminders--;
+
+      openActionBarOverflowOrOptionsMenu(getContext());
+      onView(withText(R.string.text_secure_normal__menu_settings)).perform(click());
+      pressBack();
+    }
+
+    if (checkReminderIsDisplayed() && !PushRegistrationReminder.isEligible(getContext())) {
+      throw new IllegalStateException("only expected to see " + expectedReminders + " reminders");
+    }
+  }
+
+  public void testClickNewGroup() throws Exception {
+    handleTestState();
+
+    openActionBarOverflowOrOptionsMenu(getContext());
+    onView(withText(R.string.text_secure_normal__menu_new_group)).perform(click());
+  }
+
+  public void testClickImportExport() throws Exception {
+    handleTestState();
+
+    openActionBarOverflowOrOptionsMenu(getContext());
+    onView(withText(R.string.arrays__import_export)).perform(click());
+  }
+
+  public void testClickMyIdentity() throws Exception {
+    handleTestState();
+
+    openActionBarOverflowOrOptionsMenu(getContext());
+    onView(withText(R.string.arrays__my_identity_key)).perform(click());
+  }
+
+  public void testClickSettings() throws Exception {
+    handleTestState();
+
+    openActionBarOverflowOrOptionsMenu(getContext());
+    onView(withText(R.string.text_secure_normal__menu_settings)).perform(click());
+  }
+
+}

--- a/androidTest/java/org/thoughtcrime/securesms/ConversationListActivityTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/ConversationListActivityTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.thoughtcrime.securesms;
 
 import android.content.Context;

--- a/androidTest/java/org/thoughtcrime/securesms/GroupCreateActivityTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/GroupCreateActivityTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.thoughtcrime.securesms;
 
 import android.test.suitebuilder.annotation.LargeTest;
@@ -8,9 +24,6 @@ import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
-/**
- * rhodey
- */
 @LargeTest
 public class GroupCreateActivityTest extends SkipRegistrationInstrumentationTestCase {
 

--- a/androidTest/java/org/thoughtcrime/securesms/GroupCreateActivityTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/GroupCreateActivityTest.java
@@ -1,0 +1,32 @@
+package org.thoughtcrime.securesms;
+
+import android.test.suitebuilder.annotation.LargeTest;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+/**
+ * rhodey
+ */
+@LargeTest
+public class GroupCreateActivityTest extends SkipRegistrationInstrumentationTestCase {
+
+  public GroupCreateActivityTest() {
+    super();
+  }
+
+  public void testLayout() throws Exception {
+    new ConversationListActivityTest(getContext()).testClickNewGroup();
+    waitOn(GroupCreateActivity.class);
+
+    onView(withId(R.id.push_disabled)).check(matches(isDisplayed()));
+    onView(withId(R.id.push_disabled_reason))
+          .check(matches(withText(R.string.GroupCreateActivity_you_dont_support_push)));
+
+    waitOn(GroupCreateActivity.class);
+  }
+
+}

--- a/androidTest/java/org/thoughtcrime/securesms/ImportExportActivityTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/ImportExportActivityTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.thoughtcrime.securesms;
 
 import android.test.suitebuilder.annotation.LargeTest;
@@ -9,9 +25,6 @@ import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 
-/**
- * rhodey
- */
 @LargeTest
 public class ImportExportActivityTest extends SkipRegistrationInstrumentationTestCase {
 

--- a/androidTest/java/org/thoughtcrime/securesms/ImportExportActivityTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/ImportExportActivityTest.java
@@ -1,0 +1,42 @@
+package org.thoughtcrime.securesms;
+
+import android.test.suitebuilder.annotation.LargeTest;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.swipeLeft;
+import static android.support.test.espresso.action.ViewActions.swipeRight;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+
+/**
+ * rhodey
+ */
+@LargeTest
+public class ImportExportActivityTest extends SkipRegistrationInstrumentationTestCase {
+
+  public ImportExportActivityTest() {
+    super();
+  }
+
+  private void checkImportLayout() throws Exception {
+    onView(withId(R.id.import_sms)).check(matches(isDisplayed()));
+    onView(withId(R.id.import_encrypted_backup)).check(matches(isDisplayed()));
+    onView(withId(R.id.import_plaintext_backup)).check(matches(isDisplayed()));
+  }
+
+  private void checkExportLayout() throws Exception {
+    onView(withId(R.id.export_plaintext_backup)).check(matches(isDisplayed()));
+  }
+
+  public void testLayout() throws Exception {
+    new ConversationListActivityTest(getContext()).testClickImportExport();
+    waitOn(ImportExportActivity.class);
+
+    checkImportLayout();
+    onView(withId(R.id.import_sms)).perform(swipeLeft());
+    checkExportLayout();
+    onView(withId(R.id.export_plaintext_backup)).perform(swipeRight());
+  }
+
+}

--- a/androidTest/java/org/thoughtcrime/securesms/RegistrationActivityTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/RegistrationActivityTest.java
@@ -1,11 +1,11 @@
 package org.thoughtcrime.securesms;
 
-import static android.support.test.espresso.Espresso.*;
-import static android.support.test.espresso.action.ViewActions.*;
-import static android.support.test.espresso.matcher.ViewMatchers.*;
-import static android.support.test.espresso.assertion.ViewAssertions.*;
-
 import android.test.suitebuilder.annotation.LargeTest;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
 
 @LargeTest
 public class RegistrationActivityTest extends RoutedInstrumentationTestCase {
@@ -16,9 +16,9 @@ public class RegistrationActivityTest extends RoutedInstrumentationTestCase {
   }
 
   @SuppressWarnings("unchecked")
-  public void testRegistrationButtons() throws Exception {
+  public void testLayout() throws Exception {
     waitOn(RegistrationActivity.class);
     onView(withId(R.id.registerButton)).check(matches(isDisplayed()));
-    onView(withId(R.id.skipButton)).check(matches(isDisplayed())).perform(click());
   }
+
 }

--- a/androidTest/java/org/thoughtcrime/securesms/RegistrationActivityTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/RegistrationActivityTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.thoughtcrime.securesms;
 
 import android.test.suitebuilder.annotation.LargeTest;
@@ -15,7 +31,6 @@ public class RegistrationActivityTest extends RoutedInstrumentationTestCase {
     super();
   }
 
-  @SuppressWarnings("unchecked")
   public void testLayout() throws Exception {
     waitOn(RegistrationActivity.class);
     onView(withId(R.id.registerButton)).check(matches(isDisplayed()));

--- a/androidTest/java/org/thoughtcrime/securesms/RoutedInstrumentationTestCase.java
+++ b/androidTest/java/org/thoughtcrime/securesms/RoutedInstrumentationTestCase.java
@@ -2,36 +2,69 @@ package org.thoughtcrime.securesms;
 
 import android.app.Activity;
 import android.app.Instrumentation.ActivityMonitor;
+import android.content.Context;
 import android.preference.PreferenceManager;
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.ViewInteraction;
 import android.test.ActivityInstrumentationTestCase2;
 import android.util.Log;
 
 import org.thoughtcrime.securesms.crypto.MasterSecretUtil;
 
+import static android.support.test.espresso.action.ViewActions.typeText;
+
 public class RoutedInstrumentationTestCase extends ActivityInstrumentationTestCase2<RoutingActivity> {
   private static final String TAG = RoutedInstrumentationTestCase.class.getSimpleName();
 
+  private Context context;
+
   public RoutedInstrumentationTestCase() {
     super(RoutingActivity.class);
+  }
+
+  public RoutedInstrumentationTestCase(Context context) {
+    super(RoutingActivity.class);
+    this.context = context;
+  }
+
+  protected void initAppState() throws Exception {
+    PreferenceManager.getDefaultSharedPreferences(getContext()).edit().clear().commit();
+    getContext().getSharedPreferences(MasterSecretUtil.PREFERENCES_NAME, 0).edit().clear().commit();
+    getContext().getSharedPreferences("SecureSMS", 0).edit().clear().commit();
   }
 
   @Override
   public void setUp() throws Exception {
     System.setProperty("dexmaker.dexcache", getInstrumentation().getTargetContext().getCacheDir().getPath());
     super.setUp();
-    clearSharedPrefs();
+    initAppState();
     getActivity();
   }
 
-  protected void clearSharedPrefs() {
-    PreferenceManager.getDefaultSharedPreferences(getInstrumentation().getTargetContext())
-                     .edit().clear().commit();
-    getInstrumentation().getTargetContext().getSharedPreferences(MasterSecretUtil.PREFERENCES_NAME, 0)
-                                           .edit().clear().commit();
+  @Override
+  public void tearDown() throws Exception {
+    actuallyCloseSoftKeyboard();
+    super.tearDown();
+  }
+
+  protected Context getContext() {
+    if (context != null) return context;
+    else                 return getInstrumentation().getTargetContext();
   }
 
   protected static void waitOn(Class<? extends Activity> clazz) {
     Log.w(TAG, "waiting for " + clazz.getName());
     new ActivityMonitor(clazz.getName(), null, true).waitForActivityWithTimeout(10000);
   }
+
+  public static void actuallyCloseSoftKeyboard() throws Exception {
+    Espresso.closeSoftKeyboard();
+    Thread.sleep(800);
+  }
+
+  public static void typeTextAndClose(ViewInteraction view, String text) throws Exception {
+    view.perform(typeText(text));
+    actuallyCloseSoftKeyboard();
+  }
+
 }

--- a/androidTest/java/org/thoughtcrime/securesms/RoutedInstrumentationTestCase.java
+++ b/androidTest/java/org/thoughtcrime/securesms/RoutedInstrumentationTestCase.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.thoughtcrime.securesms;
 
 import android.app.Activity;

--- a/androidTest/java/org/thoughtcrime/securesms/SkipRegistrationInstrumentationTestCase.java
+++ b/androidTest/java/org/thoughtcrime/securesms/SkipRegistrationInstrumentationTestCase.java
@@ -1,0 +1,24 @@
+package org.thoughtcrime.securesms;
+
+import android.content.Context;
+
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
+
+public class SkipRegistrationInstrumentationTestCase extends RoutedInstrumentationTestCase {
+  private static final String TAG = SkipRegistrationInstrumentationTestCase.class.getSimpleName();
+
+  public SkipRegistrationInstrumentationTestCase() {
+    super();
+  }
+
+  public SkipRegistrationInstrumentationTestCase(Context context) {
+    super(context);
+  }
+
+  @Override
+  public void initAppState() throws Exception {
+    super.initAppState();
+    TextSecurePreferences.setPromptedPushRegistration(getContext(), true);
+  }
+
+}

--- a/androidTest/java/org/thoughtcrime/securesms/SkipRegistrationInstrumentationTestCase.java
+++ b/androidTest/java/org/thoughtcrime/securesms/SkipRegistrationInstrumentationTestCase.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.thoughtcrime.securesms;
 
 import android.content.Context;

--- a/androidTest/java/org/thoughtcrime/securesms/ViewLocalIdentityActivityTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/ViewLocalIdentityActivityTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.thoughtcrime.securesms;
 
 import android.test.suitebuilder.annotation.LargeTest;
@@ -10,9 +26,6 @@ import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
-/**
- * rhodey
- */
 @LargeTest
 public class ViewLocalIdentityActivityTest extends SkipRegistrationInstrumentationTestCase {
 

--- a/androidTest/java/org/thoughtcrime/securesms/ViewLocalIdentityActivityTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/ViewLocalIdentityActivityTest.java
@@ -1,0 +1,31 @@
+package org.thoughtcrime.securesms;
+
+import android.test.suitebuilder.annotation.LargeTest;
+
+import org.thoughtcrime.securesms.crypto.IdentityKeyUtil;
+import org.whispersystems.libaxolotl.IdentityKey;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+/**
+ * rhodey
+ */
+@LargeTest
+public class ViewLocalIdentityActivityTest extends SkipRegistrationInstrumentationTestCase {
+
+  public ViewLocalIdentityActivityTest() {
+    super();
+  }
+
+  public void testLayout() throws Exception {
+    new ConversationListActivityTest(getContext()).testClickMyIdentity();
+    waitOn(ViewLocalIdentityActivity.class);
+
+    final IdentityKey idKey = IdentityKeyUtil.getIdentityKey(getContext());
+    onView(withId(R.id.identity_fingerprint)).check(matches(withText(idKey.getFingerprint())));
+  }
+
+}

--- a/androidTest/java/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragmentTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragmentTest.java
@@ -1,0 +1,110 @@
+package org.thoughtcrime.securesms.preferences;
+
+import android.os.Build;
+import android.test.suitebuilder.annotation.LargeTest;
+
+import org.hamcrest.Matchers;
+import org.thoughtcrime.securesms.ApplicationPreferencesActivity;
+import org.thoughtcrime.securesms.ApplicationPreferencesActivityTest;
+import org.thoughtcrime.securesms.PassphraseChangeActivity;
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.SkipRegistrationInstrumentationTestCase;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
+
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.PreferenceMatchers.withKey;
+import static android.support.test.espresso.matcher.ViewMatchers.isChecked;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isNotChecked;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+/**
+ * rhodey
+ */
+@LargeTest
+public class AppProtectionPreferenceFragmentTest extends SkipRegistrationInstrumentationTestCase {
+
+  public AppProtectionPreferenceFragmentTest() {
+    super();
+  }
+
+  private void checkAllPreferencesDisplayed() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_enable_passphrase_temporary"))).check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("pref_change_passphrase"))).check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("pref_timeout_passphrase"))).check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("pref_timeout_interval"))).check(matches(isDisplayed()));
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+      onData(Matchers.<Object>allOf(withKey("pref_screen_security")))
+            .check(matches(isDisplayed()));
+    }
+  }
+
+  private void checkViewsMatchPreferences() throws Exception {
+    if (!TextSecurePreferences.isPasswordDisabled(getContext())) {
+      isChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_enable_passphrase_temporary"))));
+    } else {
+      isNotChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_enable_passphrase_temporary"))));
+    }
+
+    if (TextSecurePreferences.isPassphraseTimeoutEnabled(getContext())) {
+      isChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_timeout_passphrase"))));
+    } else {
+      isNotChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_timeout_passphrase"))));
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+      if (TextSecurePreferences.isScreenSecurityEnabled(getContext())) {
+        isChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_screen_security"))));
+      } else {
+        isNotChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_screen_security"))));
+      }
+    }
+  }
+
+  private void clickAppProtectionSettingAndTestState() throws Exception {
+    new ApplicationPreferencesActivityTest(getContext()).testClickAppProtectionSetting();
+    checkAllPreferencesDisplayed();
+    checkViewsMatchPreferences();
+  }
+
+  public void testEnablePassphrase() throws Exception {
+    clickAppProtectionSettingAndTestState();
+
+    onData(Matchers.<Object>allOf(withKey("pref_enable_passphrase_temporary"))).perform(click());
+    waitOn(PassphraseChangeActivity.class);
+    typeTextAndClose(onView(withId(R.id.new_passphrase)),    "bad_pass");
+    typeTextAndClose(onView(withId(R.id.repeat_passphrase)), "bad_pass");
+    onView(withId(R.id.ok_button)).perform(click());
+
+    waitOn(ApplicationPreferencesActivity.class);
+    isChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_enable_passphrase_temporary"))));
+  }
+
+  public void testChangePassphrase() throws Exception {
+    testEnablePassphrase();
+
+    onData(Matchers.<Object>allOf(withKey("pref_change_passphrase"))).perform(click());
+    waitOn(PassphraseChangeActivity.class);
+    typeTextAndClose(onView(withId(R.id.old_passphrase)),    "bad_pass");
+    typeTextAndClose(onView(withId(R.id.new_passphrase)),    "still_bad_pass");
+    typeTextAndClose(onView(withId(R.id.repeat_passphrase)), "still_bad_pass");
+    onView(withId(R.id.ok_button)).perform(click());
+
+    waitOn(ApplicationPreferencesActivity.class);
+    isChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_enable_passphrase_temporary"))));
+  }
+
+  public void testDisablePassphrase() throws Exception {
+    testEnablePassphrase();
+
+    onData(Matchers.<Object>allOf(withKey("pref_enable_passphrase_temporary"))).perform(click());
+    onView(withText(R.string.ApplicationPreferencesActivity_disable)).perform(click());
+    isNotChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_enable_passphrase_temporary"))));
+  }
+
+}

--- a/androidTest/java/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragmentTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragmentTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.thoughtcrime.securesms.preferences;
 
 import android.os.Build;
@@ -22,9 +38,6 @@ import static android.support.test.espresso.matcher.ViewMatchers.isNotChecked;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
-/**
- * rhodey
- */
 @LargeTest
 public class AppProtectionPreferenceFragmentTest extends SkipRegistrationInstrumentationTestCase {
 

--- a/androidTest/java/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragmentTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragmentTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.thoughtcrime.securesms.preferences;
 
 import android.test.suitebuilder.annotation.LargeTest;
@@ -15,9 +31,6 @@ import static android.support.test.espresso.matcher.ViewMatchers.isChecked;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.isNotChecked;
 
-/**
- * rhodey
- */
 @LargeTest
 public class NotificationsPreferenceFragmentTest extends SkipRegistrationInstrumentationTestCase {
 

--- a/androidTest/java/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragmentTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragmentTest.java
@@ -1,0 +1,83 @@
+package org.thoughtcrime.securesms.preferences;
+
+import android.test.suitebuilder.annotation.LargeTest;
+
+import org.hamcrest.Matchers;
+import org.thoughtcrime.securesms.ApplicationPreferencesActivityTest;
+import org.thoughtcrime.securesms.SkipRegistrationInstrumentationTestCase;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
+
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.PreferenceMatchers.withKey;
+import static android.support.test.espresso.matcher.ViewMatchers.isChecked;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isNotChecked;
+
+/**
+ * rhodey
+ */
+@LargeTest
+public class NotificationsPreferenceFragmentTest extends SkipRegistrationInstrumentationTestCase {
+
+  public NotificationsPreferenceFragmentTest() {
+    super();
+  }
+
+  private void checkAllPreferencesDisplayed() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_key_enable_notifications")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("pref_key_ringtone")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("pref_key_vibrate")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("pref_led_color")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("pref_led_blink")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("pref_key_inthread_notifications")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("pref_repeat_alerts")))
+          .check(matches(isDisplayed()));
+  }
+
+  private void checkViewsMatchPreferences() throws Exception {
+    if (TextSecurePreferences.isNotificationsEnabled(getContext())) {
+      isChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_key_enable_notifications"))));
+    } else {
+      isNotChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_key_enable_notifications"))));
+    }
+
+    if (TextSecurePreferences.isNotificationVibrateEnabled(getContext())) {
+      isChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_key_vibrate"))));
+    } else {
+      isNotChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_key_vibrate"))));
+    }
+
+    if (TextSecurePreferences.isInThreadNotifications(getContext())) {
+      isChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_key_inthread_notifications"))));
+    } else {
+      isNotChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_key_inthread_notifications"))));
+    }
+  }
+
+  private void clickNotificationsSettingAndTestState() throws Exception {
+    new ApplicationPreferencesActivityTest(getContext()).testClickNotificationsSetting();
+    checkAllPreferencesDisplayed();
+    checkViewsMatchPreferences();
+  }
+
+  public void testEnableNotifications() throws Exception {
+    clickNotificationsSettingAndTestState();
+
+    if (!TextSecurePreferences.isNotificationsEnabled(getContext())) {
+      onData(Matchers.<Object>allOf(withKey("pref_key_enable_notifications")))
+            .perform(click());
+      isChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_key_enable_notifications"))));
+    } else {
+      isNotChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_key_enable_notifications"))));
+    }
+  }
+
+}


### PR DESCRIPTION
Created a set of basic espresso tests.
// FREEBIE

All these espresso tests pass on my Nexus One running Android 2.3.6 and Nexus 5 running Android 5.1 (with animations disabled). Some notes from my experience with the espresso testing framework:

## out-of-app activities
The display of any activities or prompts that come from outside the app being tested trigger a failure of the current test. This means that through espresso it is not possible to set TextSecure as the default SMS app (post Kit-Kat) and depending on device, opening the notification sound preference also results in test failure. Choosing media for attachments and group images also currently shouldn't work, however, I expect that the future in-app media capture will be testable by espresso.

## Espresso.closeSoftKeyboard()
At the moment this method doesn't block, this sometimes leads to tests failing because the keyboard is covering a view under test. On emulators this reportedly isn't a problem but on real devices it is a definite confirmed issue. Two workarounds exist:

1) Thread.sleep()
2) install any 3rd party soft keyboard

Both are gross, but I think `1` is less gross. To avoid sporadic test failues use the `actuallyCloseSoftKeyboard()` method in place of `closeSoftKeyboard()` and `typeTextAndClose()` in place of `typeText()`.

## RoutingActivity makes stuff weird
Espresso kinda has this 'one activity one test' idea built in where you parameterize `ActivityInstrumentationTestCase2` with the activity you plan on testing. Then you can use this instance method `getActivity()` that returns an instance of the activity under test **and** creates it if necessary. The bummer of `RoutingActivity` is that when `getActivity()` is called you get a handle to a newly created `RoutingActivity` and not the activity you've been routed to, also if you've been routed to a new activity that activity will be destroyed. Having a handle to the activity under test is cool because it allows you to manipulate and test the activity lifecycle and get references to actual views, so, in conclusion, we can't do that stuff.

## options menus
All options menu items have to be matched using `withText()`, the more concrete `withId()` method simply doesn't work here.

## probably shouldn't fake push registration
An espresso test could be written to go through a valid registration flow but many test devices don't have SIM cards and I'm not sure we should count on internet access for anything either. Additionally I don't think we should attempt to fake a push registration state because keeping up with exactly what that state should look like with every new release is complicated and I also think it is outside the intent of espresso tests. I could be wrong about faking this state though, if it's trivial then it would definitely increase the # of things we could test, maybe this will get easier with the end of RoutingActivity.