### PR TITLE
display the phone number in the confirm-AlertDialog during registration

### DIFF
--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -197,8 +197,8 @@ public class RegistrationActivity extends BaseActionBarActivity {
       }
 
       AlertDialog.Builder dialog = new AlertDialog.Builder(self);
-      dialog.setMessage(String.format(getString(R.string.RegistrationActivity_we_will_now_verify_that_the_following_number_is_associated_with_your_device_s),
-                                      PhoneNumberFormatter.getInternationalFormatFromE164(e164number)));
+      dialog.setTitle(PhoneNumberFormatter.getInternationalFormatFromE164(e164number));
+      dialog.setMessage(R.string.RegistrationActivity_we_will_now_verify_that_the_following_number_is_associated_with_your_device_s);
       dialog.setPositiveButton(getString(R.string.RegistrationActivity_continue),
                                new DialogInterface.OnClickListener() {
                                  @Override


### PR DESCRIPTION
The confirmation dialog in the `RegistrationActivity` currently doesn't show the phonenumber although `String.format` is used. The `%s` was missing in the string...