### PR TITLE
prevent zero length password

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -251,6 +251,7 @@
     <!-- PassphraseChangeActivity -->
     <string name="PassphraseChangeActivity_passphrases_dont_match_exclamation">Passphrases don\'t match!</string>
     <string name="PassphraseChangeActivity_incorrect_old_passphrase_exclamation">Incorrect old passphrase!</string>
+    <string name="PassphraseChangeActivity_passphrase_cannot_be_empty">Passphrase cannot be empty!</string>
 
     <!-- DeviceProvisioningActivity -->
     <string name="DeviceProvisioningActivity_link_this_device">Link this device?</string>

--- a/src/org/thoughtcrime/securesms/PassphraseChangeActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphraseChangeActivity.java
@@ -18,6 +18,7 @@ package org.thoughtcrime.securesms;
 
 import android.os.Bundle;
 import android.text.Editable;
+import android.text.TextUtils;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
@@ -96,6 +97,10 @@ public class PassphraseChangeActivity extends PassphraseActivity {
                        Toast.LENGTH_SHORT).show();
         this.newPassphrase.setText("");
         this.repeatPassphrase.setText("");
+      } else if (TextUtils.isEmpty(passphrase)) {
+        Toast.makeText(getApplicationContext(),
+                       R.string.PassphraseChangeActivity_passphrase_cannot_be_empty,
+                       Toast.LENGTH_SHORT).show();
       } else {
         MasterSecret masterSecret = MasterSecretUtil.changeMasterSecretPassphrase(this, original, passphrase);
         TextSecurePreferences.setPasswordDisabled(this, false);


### PR DESCRIPTION
PassphraseChangeActivity now reads 'Passphrase cannot be empty!' if user attempts to set a passphrase with 0 length.

Fixes #2751
// FREEBIE