### PR TITLE
Close keyboard when entering message detail view

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -123,7 +123,7 @@
 
     <activity android:name=".MessageDetailsActivity"
               android:label="Message Details"
-              android:windowSoftInputMode="stateUnchanged"
+              android:windowSoftInputMode="stateHidden"
               android:launchMode="singleTask"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 


### PR DESCRIPTION
Should be the solution with lowest impact.
Only downside is, that you have to tap the compose field again when going back to conversation

Tested on 🍭 and GB