### PR TITLE
Fix sendMessage manual MMS dialog logic

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1000,6 +1000,10 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     return (ConversationFragment)getSupportFragmentManager().findFragmentById(R.id.fragment_content);
   }
 
+  private boolean isMediaMessage() {
+    return attachmentManager.isAttachmentPresent() || !recipients.isSingleRecipient() || recipients.isEmailRecipient();
+  }
+
   private void sendMessage() {
     try {
       Recipients recipients = getRecipients();
@@ -1012,9 +1016,9 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
         throw new RecipientFormattingException("Badly formatted");
       }
 
-      if ((!recipients.isSingleRecipient() || recipients.isEmailRecipient()) && !isMmsEnabled) {
+      if (isMediaMessage() && forceSms && !isMmsEnabled) {
         handleManualMmsRequired();
-      } else if (attachmentManager.isAttachmentPresent() || !recipients.isSingleRecipient() || recipients.isGroupRecipient() || recipients.isEmailRecipient()) {
+      } else if (isMediaMessage() || recipients.isGroupRecipient()) {
         sendMediaMessage(forceSms);
       } else {
         sendTextMessage(forceSms);


### PR DESCRIPTION
Previous logic

1. Didn't request manual MMS settings when there was a single recipient but an attachment was present
2. Did request manual MMS settings before the chance of an upgrade to data was possible.

New logic only requests manual MMS settings when MMS is forced so we know an upgrade isn't possible.