### PR TITLE
thread-level media previews

### DIFF
--- a/res/layout/conversation_list_item_view.xml
+++ b/res/layout/conversation_list_item_view.xml
@@ -33,61 +33,71 @@
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:layout_marginTop="4dip"
         android:layout_marginLeft="4dip"
         android:layout_marginRight="8dip"
         android:layout_marginBottom="4dip"
         android:layout_centerVertical="true"
         android:layout_toRightOf="@id/contact_photo_frame"
-        android:orientation="vertical">
+        android:orientation="horizontal">
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:weightSum="1"
-            android:gravity="bottom">
-
-            <TextView android:id="@+id/from"
-                      android:layout_weight="1"
+        <LinearLayout android:layout_weight="1"
                       android:layout_width="0dp"
                       android:layout_height="wrap_content"
-                      android:textAppearance="?android:attr/textAppearanceMedium"
-                      android:textColor="?attr/conversation_list_item_contact_color"
-                      android:singleLine="true"
-                      tools:text="Jules Bonnot"
-                      android:ellipsize="marquee" />
+                      android:orientation="vertical"
+                      android:layout_gravity="center_vertical">
 
-            <ImageView android:id="@+id/error"
-                       android:layout_marginLeft="3dip"
-                       android:layout_height="match_parent"
-                       android:layout_width="20sp"
-                       android:visibility="gone"
-                       android:src="@drawable/ic_action_warning_red"
-                       android:contentDescription="@string/conversation_list_item_view__error_alert" />
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
 
-            <TextView android:id="@+id/date"
-                      android:layout_marginLeft="3dip"
+                <TextView android:id="@+id/from"
+                          android:layout_weight="1"
+                          android:layout_width="0dp"
+                          android:layout_height="wrap_content"
+                          android:textAppearance="?android:attr/textAppearanceMedium"
+                          android:textColor="?attr/conversation_list_item_contact_color"
+                          android:singleLine="true"
+                          tools:text="Jules Bonnot"
+                          android:ellipsize="marquee" />
+
+                <TextView android:id="@+id/date"
+                          android:layout_marginLeft="3dip"
+                          android:layout_height="wrap_content"
+                          android:layout_width="wrap_content"
+                          android:textAppearance="?android:attr/textAppearanceSmall"
+                          android:textColor="?attr/conversation_list_item_date_color"
+                          android:fontFamily="sans-serif-light"
+                          tools:text="30 mins"
+                          android:singleLine="true"
+                          android:layout_gravity="top" />
+                </LinearLayout>
+
+            <TextView android:id="@+id/subject"
+                      android:layout_width="match_parent"
                       android:layout_height="wrap_content"
-                      android:layout_width="wrap_content"
                       android:textAppearance="?android:attr/textAppearanceSmall"
-                      android:textColor="?attr/conversation_list_item_date_color"
+                      android:textColor="?attr/conversation_list_item_subject_color"
                       android:fontFamily="sans-serif-light"
-                      tools:text="30 mins"
                       android:singleLine="true"
-                      android:layout_gravity="top" />
-            </LinearLayout>
+                      tools:text="Wheels arrive at 3pm flat."
+                      android:ellipsize="end" />
 
-        <TextView android:id="@+id/subject"
-                  android:layout_width="match_parent"
-                  android:layout_height="wrap_content"
-                  android:textAppearance="?android:attr/textAppearanceSmall"
-                  android:textColor="?attr/conversation_list_item_subject_color"
-                  android:fontFamily="sans-serif-light"
-                  android:singleLine="true"
-                  tools:text="Wheels arrive at 3pm flat."
-                  android:ellipsize="end" />
+        </LinearLayout>
+
+        <org.thoughtcrime.securesms.components.ForegroundImageView
+            android:id="@+id/media_preview"
+            android:layout_width="70dp"
+            android:layout_height="match_parent"
+            android:layout_marginLeft="4dp"
+            android:gravity="end"
+            android:visibility="gone"
+            android:src="@drawable/ic_image_light"
+            android:scaleType="centerCrop"
+            android:adjustViewBounds="true"
+            android:contentDescription="@string/conversation_item__mms_image_description" />
 
     </LinearLayout>
 </org.thoughtcrime.securesms.ConversationListItem>

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -887,6 +887,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     final long         thisThreadId         = this.threadId;
     final MasterSecret thisMasterSecret     = this.masterSecret.parcelClone();
     final int          thisDistributionType = this.distributionType;
+    final Draft        snippetSlide         = drafts.getDraftForSnippetSlide();
 
     new AsyncTask<Long, Void, Void>() {
       @Override
@@ -898,8 +899,16 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
         if (drafts.size() > 0) {
           if (threadId == -1) threadId = threadDatabase.getThreadIdFor(getRecipients(), thisDistributionType);
 
+          String snippetSlideUri  = null;
+          String snippetSlideType = null;
+
+          if (snippetSlide != null) {
+            snippetSlideUri  = snippetSlide.getValue();
+            snippetSlideType = snippetSlide.getType();
+          }
+
           draftDatabase.insertDrafts(new MasterCipher(thisMasterSecret), threadId, drafts);
-          threadDatabase.updateSnippet(threadId, drafts.getSnippet(ConversationActivity.this), Types.BASE_DRAFT_TYPE);
+          threadDatabase.updateSnippet(threadId, drafts.getSnippet(ConversationActivity.this), Types.BASE_DRAFT_TYPE, snippetSlideUri, snippetSlideType);
         } else if (threadId > 0) {
           threadDatabase.update(threadId);
         }

--- a/src/org/thoughtcrime/securesms/ConversationListAdapter.java
+++ b/src/org/thoughtcrime/securesms/ConversationListAdapter.java
@@ -24,7 +24,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AbsListView;
 
-import org.thoughtcrime.securesms.crypto.MasterCipher;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.ThreadDatabase;
@@ -42,7 +41,7 @@ import java.util.Set;
 public class ConversationListAdapter extends CursorAdapter implements AbsListView.RecyclerListener {
 
   private final ThreadDatabase threadDatabase;
-  private final MasterCipher   masterCipher;
+  private final MasterSecret   masterSecret;
   private final Context        context;
   private final LayoutInflater inflater;
 
@@ -52,9 +51,7 @@ public class ConversationListAdapter extends CursorAdapter implements AbsListVie
   public ConversationListAdapter(Context context, Cursor cursor, MasterSecret masterSecret) {
     super(context, cursor, 0);
 
-    if (masterSecret != null) this.masterCipher = new MasterCipher(masterSecret);
-    else                      this.masterCipher = null;
-
+    this.masterSecret   = masterSecret;
     this.context        = context;
     this.threadDatabase = DatabaseFactory.getThreadDatabase(context);
     this.inflater       = LayoutInflater.from(context);
@@ -67,8 +64,8 @@ public class ConversationListAdapter extends CursorAdapter implements AbsListVie
 
   @Override
   public void bindView(View view, Context context, Cursor cursor) {
-    if (masterCipher != null) {
-      ThreadDatabase.Reader reader = threadDatabase.readerFor(cursor, masterCipher);
+    if (masterSecret != null) {
+      ThreadDatabase.Reader reader = threadDatabase.readerFor(cursor, masterSecret);
       ThreadRecord          record = reader.getCurrent();
 
       ((ConversationListItem)view).set(record, batchSet, batchMode);

--- a/src/org/thoughtcrime/securesms/ShareListAdapter.java
+++ b/src/org/thoughtcrime/securesms/ShareListAdapter.java
@@ -27,7 +27,6 @@ import android.widget.AbsListView;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.ThreadDatabase;
 import org.thoughtcrime.securesms.database.model.ThreadRecord;
-import org.thoughtcrime.securesms.crypto.MasterCipher;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 
 /**
@@ -38,17 +37,15 @@ import org.thoughtcrime.securesms.crypto.MasterSecret;
 public class ShareListAdapter extends CursorAdapter implements AbsListView.RecyclerListener {
 
   private final ThreadDatabase threadDatabase;
-  private final MasterCipher   masterCipher;
+  private final MasterSecret   masterSecret;
   private final Context        context;
   private final LayoutInflater inflater;
 
   public ShareListAdapter(Context context, Cursor cursor, MasterSecret masterSecret) {
     super(context, cursor, 0);
 
-    if (masterSecret != null) this.masterCipher = new MasterCipher(masterSecret);
-    else                      this.masterCipher = null;
-
     this.context        = context;
+    this.masterSecret   = masterSecret;
     this.threadDatabase = DatabaseFactory.getThreadDatabase(context);
     this.inflater       = LayoutInflater.from(context);
   }
@@ -60,8 +57,8 @@ public class ShareListAdapter extends CursorAdapter implements AbsListView.Recyc
 
   @Override
   public void bindView(View view, Context context, Cursor cursor) {
-    if (masterCipher != null) {
-      ThreadDatabase.Reader reader = threadDatabase.readerFor(cursor, masterCipher);
+    if (masterSecret != null) {
+      ThreadDatabase.Reader reader = threadDatabase.readerFor(cursor, masterSecret);
       ThreadRecord          record = reader.getCurrent();
 
       ((ShareListItem)view).set(record);

--- a/src/org/thoughtcrime/securesms/database/DatabaseFactory.java
+++ b/src/org/thoughtcrime/securesms/database/DatabaseFactory.java
@@ -60,7 +60,8 @@ public class DatabaseFactory {
   private static final int INTRODUCED_PART_DATA_SIZE_VERSION  = 14;
   private static final int INTRODUCED_THUMBNAILS_VERSION      = 15;
   private static final int INTRODUCED_IDENTITY_COLUMN_VERSION = 16;
-  private static final int DATABASE_VERSION                   = 16;
+  private static final int INTRODUCED_SNIPPET_PART_VERSION    = 17;
+  private static final int DATABASE_VERSION                   = 17;
 
   private static final String DATABASE_NAME    = "messages.db";
   private static final Object lock             = new Object();
@@ -715,6 +716,11 @@ public class DatabaseFactory {
         db.execSQL("ALTER TABLE sms ADD COLUMN mismatched_identities TEXT");
         db.execSQL("ALTER TABLE mms ADD COLUMN mismatched_identities TEXT");
         db.execSQL("ALTER TABLE mms ADD COLUMN network_failures TEXT");
+      }
+
+      if (oldVersion < INTRODUCED_SNIPPET_PART_VERSION) {
+        db.execSQL("ALTER TABLE thread ADD COLUMN snippet_part_uri TEXT");
+        db.execSQL("ALTER TABLE thread ADD COLUMN snippet_part_type TEXT");
       }
 
       db.setTransactionSuccessful();

--- a/src/org/thoughtcrime/securesms/database/DraftDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/DraftDatabase.java
@@ -136,7 +136,7 @@ public class DraftDatabase extends Database {
   public static class Drafts extends LinkedList<Draft> {
     private Draft getDraftOfType(String type) {
       for (Draft draft : this) {
-        if (Draft.TEXT.equals(draft.getType())) {
+        if (type.equals(draft.getType())) {
           return draft;
         }
       }
@@ -152,6 +152,16 @@ public class DraftDatabase extends Database {
       } else {
         return "";
       }
+    }
+
+    public Draft getDraftForSnippetSlide() {
+      for (Draft draft : this) {
+        if (!draft.getType().equals(Draft.TEXT)) {
+          return draft;
+        }
+      }
+
+      return null;
     }
   }
 }

--- a/src/org/thoughtcrime/securesms/database/PartDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/PartDatabase.java
@@ -482,6 +482,7 @@ public class PartDatabase extends Database {
     thumbnailExecutor.submit(new ThumbnailFetchCallable(masterSecret, partId));
 
     notifyConversationListeners(DatabaseFactory.getMmsDatabase(context).getThreadIdForMessage(messageId));
+    notifyConversationListListeners();
   }
 
   public void updatePartData(MasterSecret masterSecret, PduPart part, InputStream data)

--- a/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
@@ -25,8 +25,10 @@ import android.text.style.StyleSpan;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.database.MmsSmsColumns;
 import org.thoughtcrime.securesms.database.SmsDatabase;
+import org.thoughtcrime.securesms.mms.Slide;
 import org.thoughtcrime.securesms.recipients.Recipients;
 import org.thoughtcrime.securesms.util.GroupUtil;
+import org.thoughtcrime.securesms.util.ListenableFutureTask;
 
 /**
  * The message record model which represents thread heading messages.
@@ -40,16 +42,18 @@ public class ThreadRecord extends DisplayRecord {
   private final long count;
   private final boolean read;
   private final int distributionType;
+  private final ListenableFutureTask<Slide> snippetSlide;
 
   public ThreadRecord(Context context, Body body, Recipients recipients, long date,
                       long count, boolean read, long threadId, long snippetType,
-                      int distributionType)
+                      int distributionType, ListenableFutureTask<Slide> snippetSlide)
   {
     super(context, body, recipients, date, date, threadId, snippetType);
     this.context          = context.getApplicationContext();
     this.count            = count;
     this.read             = read;
     this.distributionType = distributionType;
+    this.snippetSlide     = snippetSlide;
   }
 
   @Override
@@ -109,5 +113,9 @@ public class ThreadRecord extends DisplayRecord {
 
   public int getDistributionType() {
     return distributionType;
+  }
+
+  public ListenableFutureTask<Slide> getSnippetSlide() {
+    return snippetSlide;
   }
 }

--- a/src/org/thoughtcrime/securesms/mms/ImageSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/ImageSlide.java
@@ -53,6 +53,12 @@ public class ImageSlide extends Slide {
     super(context, masterSecret, part);
   }
 
+  public ImageSlide(Context context, MasterSecret masterSecret, Uri uri)
+      throws IOException, BitmapDecodingException
+  {
+    super(context, masterSecret, constructPartFromUri(uri));
+  }
+
   public ImageSlide(Context context, Uri uri) throws IOException, BitmapDecodingException {
     super(context, constructPartFromUri(uri));
   }

--- a/src/org/thoughtcrime/securesms/mms/VideoSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/VideoSlide.java
@@ -24,19 +24,22 @@ import org.thoughtcrime.securesms.util.ListenableFutureTask;
 import org.thoughtcrime.securesms.util.ResUtil;
 
 import ws.com.google.android.mms.pdu.PduPart;
-import android.content.ContentResolver;
 import android.content.Context;
-import android.database.Cursor;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.provider.MediaStore;
-import android.util.Log;
 import android.util.Pair;
 
 public class VideoSlide extends Slide {
 
   public VideoSlide(Context context, Uri uri) throws IOException, MediaTooLargeException {
     super(context, constructPartFromUri(context, uri));
+  }
+
+  public VideoSlide(Context context, MasterSecret masterSecret, Uri uri)
+      throws IOException, MediaTooLargeException
+  {
+    super(context, masterSecret, constructPartFromUri(context, uri));
   }
 
   public VideoSlide(Context context, MasterSecret masterSecret, PduPart part) {
@@ -61,22 +64,15 @@ public class VideoSlide extends Slide {
   private static PduPart constructPartFromUri(Context context, Uri uri)
       throws IOException, MediaTooLargeException
   {
-    PduPart         part     = new PduPart();
-    ContentResolver resolver = context.getContentResolver();
-    Cursor          cursor   = null;
+    PduPart part = new PduPart();
 
-    try {
-      cursor = resolver.query(uri, new String[] {MediaStore.Video.Media.MIME_TYPE}, null, null, null);
-      if (cursor != null && cursor.moveToFirst()) {
-        Log.w("VideoSlide", "Setting mime type: " + cursor.getString(0));
-        part.setContentType(cursor.getString(0).getBytes());
-      }
-    } finally {
-      if (cursor != null)
-        cursor.close();
+    if (isAuthorityPartDb(uri)) {
+      part.setContentType(getContentTypeForPartInDb(context, uri));
+    } else {
+      assertMediaSize(context, uri);
+      part.setContentType(getContentTypeForPartOutsideDb(context, uri, MediaStore.Video.Media.MIME_TYPE));
     }
 
-    assertMediaSize(context, uri);
     part.setDataUri(uri);
     part.setContentId((System.currentTimeMillis()+"").getBytes());
     part.setName(("Video" + System.currentTimeMillis()).getBytes());


### PR DESCRIPTION
1) removed one unused ImageViews from conversation_list_item_view
2) added a ForegroundImageView to conversation_list_item_view for media preview
3) added two new columns ('snippet_part_uri' and 'snippet_part_type') to ThreadDatabase's 'thread' table
4) added appropriate migration to DatabaseFactory
5) added a ListenableFutureTask<Slide> to ThreadRecord updated and ThreadDatabase to populate it
6) updated DraftDatabase and ConversationActivity's draft logic to work with ThreadDatabase changes
7) updated ConversationListAdapter and ShareListAdapter to work with the new ThreadDatabase.readerFor() method
8) fixed AudioSlide, VideoSlide, and ImageSlide to work with content:// Uri's from our part database
9) updated ConversationListItem to make use of the new ForegroundImageView and ListenableFutureTask<Slide>

Fixes #1934