### PR TITLE
Fix reacting to messages when not the default SMS provider

### DIFF
--- a/src/org/thoughtcrime/securesms/service/SmsListener.java
+++ b/src/org/thoughtcrime/securesms/service/SmsListener.java
@@ -119,7 +119,7 @@ public class SmsListener extends BroadcastReceiver {
       return true;
     }
 
-    return WirePrefix.isEncryptedMessage(messageBody) || WirePrefix.isKeyExchange(messageBody);
+    return false;
   }
 
   private boolean isChallenge(Context context, Intent intent) {


### PR DESCRIPTION
Since TextSecure no longer supports encrypted SMS, it shouldn't grab all incoming SMS messages and check them for encryption unless it's the default SMS provider.

This commit changes the behaviour of the app on KitKat and up to not intercept encrypted messages or key exchange messages unless it's set as the default SMS provider.

The number verification SMS still goes through in all cases.

This would allow other applications that use the TextSecure encryption protocol over SMS to coexist on the same phone as TextSecure without having TextSecure showing it's "Received a message encrypted with an old version..." every time an encrypted message is received.