### PR TITLE
group notification improvements

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -177,7 +177,7 @@ public class MessageNotifier {
 
     List<NotificationItem>notifications = notificationState.getNotifications();
     NotificationCompat.Builder builder  = new NotificationCompat.Builder(context);
-    Recipient recipient                 = notifications.get(0).getIndividualRecipient();
+    Recipient recipient                 = notifications.get(0).getPrimaryRecipient();
 
     builder.setSmallIcon(R.drawable.icon_notification);
     builder.setLargeIcon(recipient.getContactPhoto());
@@ -221,6 +221,7 @@ public class MessageNotifier {
   {
     List<NotificationItem> notifications = notificationState.getNotifications();
     NotificationCompat.Builder builder   = new NotificationCompat.Builder(context);
+    Recipient recipient                  = notifications.get(0).getPrimaryRecipient();
 
     builder.setSmallIcon(R.drawable.icon_notification);
     builder.setLargeIcon(BitmapFactory.decodeResource(context.getResources(),
@@ -228,9 +229,8 @@ public class MessageNotifier {
     builder.setContentTitle(String.format(context.getString(R.string.MessageNotifier_d_new_messages),
                                           notificationState.getMessageCount()));
     builder.setContentText(String.format(context.getString(R.string.MessageNotifier_most_recent_from_s),
-                                         notifications.get(0).getIndividualRecipientName()));
+                                         recipient.toShortString()));
     builder.setContentIntent(PendingIntent.getActivity(context, 0, new Intent(context, ConversationListActivity.class), 0));
-    
     builder.setContentInfo(String.valueOf(notificationState.getMessageCount()));
     builder.setNumber(notificationState.getMessageCount());
 

--- a/src/org/thoughtcrime/securesms/notifications/NotificationItem.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationItem.java
@@ -32,12 +32,17 @@ public class NotificationItem {
     this.threadId            = threadId;
   }
 
-  public Recipient getIndividualRecipient() {
-    return individualRecipient;
+  private Recipient getGroupRecipient() {
+    if (threadRecipients != null && threadRecipients.isGroupRecipient()) {
+      return threadRecipients.getPrimaryRecipient();
+    } else {
+      return null;
+    }
   }
 
-  public String getIndividualRecipientName() {
-    return individualRecipient.toShortString();
+  public Recipient getPrimaryRecipient() {
+    if  (getGroupRecipient() != null) return getGroupRecipient();
+    else                              return individualRecipient;
   }
 
   public CharSequence getText() {
@@ -57,12 +62,23 @@ public class NotificationItem {
   }
 
   public CharSequence getBigStyleSummary() {
-    return (text == null) ? "" : text;
+    SpannableStringBuilder bigSummary = new SpannableStringBuilder();
+
+    if (getGroupRecipient() != null) {
+      bigSummary.append(Util.getBoldedString(individualRecipient.toShortString() + ": "));
+    }
+
+    return (text == null) ? bigSummary : bigSummary.append(text);
   }
 
   public CharSequence getTickerText() {
     SpannableStringBuilder builder = new SpannableStringBuilder();
-    builder.append(Util.getBoldedString(getIndividualRecipientName()));
+
+    if (getGroupRecipient() != null) {
+      builder.append(Util.getBoldedString(getGroupRecipient().toShortString()));
+    } else {
+      builder.append(Util.getBoldedString(individualRecipient.toShortString()));
+    }
     builder.append(": ");
     builder.append(getText());
 

--- a/src/org/thoughtcrime/securesms/notifications/NotificationState.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationState.java
@@ -3,7 +3,6 @@ package org.thoughtcrime.securesms.notifications;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.graphics.Bitmap;
 import android.util.Log;
 
 import org.thoughtcrime.securesms.crypto.MasterSecret;
@@ -36,10 +35,6 @@ public class NotificationState {
 
   public List<NotificationItem> getNotifications() {
     return notifications;
-  }
-
-  public Bitmap getContactPhoto() {
-    return notifications.get(0).getIndividualRecipient().getContactPhoto();
   }
 
   public PendingIntent getMarkAsReadIntent(Context context, MasterSecret masterSecret) {


### PR DESCRIPTION
1) replaced NotificationItem getIndividualRecipient() with getPrimaryRecipient() to favor group information in notifications.
2) fixed NotificationItem getBigStyleSummary() and getTickerText() methods to allow for display of group information in notifications.
3) updated MessageNotifier to work with NotificationItem changes.
4) removed unused method from NotificationState that relied on old version of NotificationItem.

Fixes #1033
Fixes #2558
// FREEBIE

## single thread group notification format
```
__________
| group  | <group  name>
|  icon  | <contact name>: <message text>
---------- <contact name>: <message text>
```

## multiple thread notification where one is from a group
```
____________
|  notify  | 2 new messages
|  icon    | <group name>: <message text>
------------ <contact name>: <message text>
```