### PR TITLE
fix ghost thread on batch delete of all messages in thread

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1169,6 +1169,11 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   @Override
+  public void setThreadId(long threadId) {
+    this.threadId = threadId;
+  }
+
+  @Override
   public void onAttachmentChanged() {
     initializeSecurity();
   }

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -210,10 +210,16 @@ public class ConversationFragment extends ListFragment
           @Override
           protected Void doInBackground(MessageRecord... messageRecords) {
             for (MessageRecord messageRecord : messageRecords) {
+              boolean threadDeleted = false;
               if (messageRecord.isMms()) {
-                DatabaseFactory.getMmsDatabase(getActivity()).delete(messageRecord.getId());
+                threadDeleted = DatabaseFactory.getMmsDatabase(getActivity()).delete(messageRecord.getId());
               } else {
-                DatabaseFactory.getSmsDatabase(getActivity()).deleteMessage(messageRecord.getId());
+                threadDeleted = DatabaseFactory.getSmsDatabase(getActivity()).deleteMessage(messageRecord.getId());
+              }
+
+              if (threadDeleted) {
+                threadId = -1;
+                listener.setThreadId(threadId);
               }
             }
 
@@ -291,6 +297,8 @@ public class ConversationFragment extends ListFragment
 
   public interface ConversationFragmentListener {
     public void setComposeText(String text);
+
+    public void setThreadId(long threadId);
   }
 
   public interface SelectionClickListener extends

--- a/src/org/thoughtcrime/securesms/database/MmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MmsDatabase.java
@@ -760,7 +760,7 @@ public class MmsDatabase extends MessagingDatabase {
     return messageId;
   }
 
-  public void delete(long messageId) {
+  public boolean delete(long messageId) {
     long threadId                   = getThreadIdForMessage(messageId);
     MmsAddressDatabase addrDatabase = DatabaseFactory.getMmsAddressDatabase(context);
     PartDatabase partDatabase       = DatabaseFactory.getPartDatabase(context);
@@ -769,8 +769,9 @@ public class MmsDatabase extends MessagingDatabase {
 
     SQLiteDatabase database = databaseHelper.getWritableDatabase();
     database.delete(TABLE_NAME, ID_WHERE, new String[] {messageId+""});
-    DatabaseFactory.getThreadDatabase(context).update(threadId);
+    boolean threadDeleted = DatabaseFactory.getThreadDatabase(context).update(threadId);
     notifyConversationListeners(threadId);
+    return threadDeleted;
   }
 
   public void deleteThread(long threadId) {

--- a/src/org/thoughtcrime/securesms/database/SmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/SmsDatabase.java
@@ -482,13 +482,14 @@ public class SmsDatabase extends MessagingDatabase {
     return cursor;
   }
 
-  public void deleteMessage(long messageId) {
+  public boolean deleteMessage(long messageId) {
     Log.w("MessageDatabase", "Deleting: " + messageId);
     SQLiteDatabase db = databaseHelper.getWritableDatabase();
     long threadId     = getThreadIdForMessage(messageId);
     db.delete(TABLE_NAME, ID_WHERE, new String[] {messageId+""});
-    DatabaseFactory.getThreadDatabase(context).update(threadId);
+    boolean threadDeleted = DatabaseFactory.getThreadDatabase(context).update(threadId);
     notifyConversationListeners(threadId);
+    return threadDeleted;
   }
 
   /*package */void deleteThread(long threadId) {

--- a/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -378,17 +378,18 @@ public class ThreadDatabase extends Database {
     return null;
   }
 
-  public void update(long threadId) {
+  public boolean update(long threadId) {
     MmsSmsDatabase mmsSmsDatabase = DatabaseFactory.getMmsSmsDatabase(context);
     long count                    = mmsSmsDatabase.getConversationCount(threadId);
 
     if (count == 0) {
       deleteThread(threadId);
       notifyConversationListListeners();
-      return;
+      return true;
     }
 
-    MmsSmsDatabase.Reader reader = null;
+    MmsSmsDatabase.Reader reader        = null;
+    boolean               threadDeleted = false;
 
     try {
       reader = mmsSmsDatabase.readerFor(mmsSmsDatabase.getConversationSnippet(threadId));
@@ -403,6 +404,7 @@ public class ThreadDatabase extends Database {
         updateThread(threadId, count, record.getBody().getBody(), timestamp, record.getType());
       } else {
         deleteThread(threadId);
+        threadDeleted = true;
       }
     } finally {
       if (reader != null)
@@ -410,6 +412,7 @@ public class ThreadDatabase extends Database {
     }
 
     notifyConversationListListeners();
+    return threadDeleted;
   }
 
   public static interface ProgressListener {

--- a/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -401,6 +401,8 @@ public class ThreadDatabase extends Database {
         else                 timestamp = record.getDateReceived();
 
         updateThread(threadId, count, record.getBody().getBody(), timestamp, record.getType());
+        notifyConversationListListeners();
+        return false;
       } else {
         deleteThread(threadId);
         notifyConversationListListeners();
@@ -410,9 +412,6 @@ public class ThreadDatabase extends Database {
       if (reader != null)
         reader.close();
     }
-
-    notifyConversationListListeners();
-    return false;
   }
 
   public static interface ProgressListener {

--- a/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -388,8 +388,7 @@ public class ThreadDatabase extends Database {
       return true;
     }
 
-    MmsSmsDatabase.Reader reader        = null;
-    boolean               threadDeleted = false;
+    MmsSmsDatabase.Reader reader = null;
 
     try {
       reader = mmsSmsDatabase.readerFor(mmsSmsDatabase.getConversationSnippet(threadId));
@@ -404,7 +403,8 @@ public class ThreadDatabase extends Database {
         updateThread(threadId, count, record.getBody().getBody(), timestamp, record.getType());
       } else {
         deleteThread(threadId);
-        threadDeleted = true;
+        notifyConversationListListeners();
+        return true;
       }
     } finally {
       if (reader != null)
@@ -412,7 +412,7 @@ public class ThreadDatabase extends Database {
     }
 
     notifyConversationListListeners();
-    return threadDeleted;
+    return false;
   }
 
   public static interface ProgressListener {


### PR DESCRIPTION
1) ThreadDatabase.update() now returns boolean indicating whether or not the thread was deleted by the update.
2) SmsDatabase.deleteMessage() now returns boolean indicating whether or not deleting the message caused the message thread to be deleted.
3) MmsDatatabse.delete() now returns boolean indicating whether or not deleting the message caused the message thread to be deleted.
4) when deleting all messages in a thread, ConversationFragment now resets its own threadId along with the threadId of its parent activity ConversationActivity such that a 'new thread' state is detected.

Fixes #2262
// FREEBIE