### PR TITLE
"New message to... <phone number>" regardless of default SMS app

### DIFF
--- a/src/org/thoughtcrime/securesms/contacts/ContactsDatabase.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactsDatabase.java
@@ -112,7 +112,7 @@ public class ContactsDatabase {
       androidCursor = null;
     }
 
-    if (includeAndroidContacts && !TextUtils.isEmpty(filter) && NumberUtil.isValidSmsOrEmail(filter)) {
+    if (!TextUtils.isEmpty(filter) && NumberUtil.isValidSmsOrEmail(filter)) {
       newNumberCursor = new MatrixCursor(CONTACTS_PROJECTION, 1);
       newNumberCursor.addRow(new Object[]{-1L, context.getString(R.string.contact_selection_list__unknown_contact),
                              ContactsContract.CommonDataKinds.Phone.TYPE_CUSTOM, "\u21e2", filter, NORMAL_TYPE});


### PR DESCRIPTION
changed ContactsDatabase.query() method to add the 'New message to... <phone number>' cursor row regardless of the 'pushOnly' arg or TextSecurePreferences.isSmsEnabled().

Fixes #2660
// FREEBIE

this method is only ever used by `PushContactSelectionListFragment` (fragment of `NewConversationActivity`)