### PR TITLE
Fix re-registering missing MasterSecret

### DIFF
--- a/src/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
@@ -103,7 +103,7 @@ public abstract class PassphraseRequiredActionBarActivity extends BaseActionBarA
       case STATE_CREATE_PASSPHRASE:        return getCreatePassphraseIntent();
       case STATE_PROMPT_PASSPHRASE:        return getPromptPassphraseIntent();
       case STATE_UPGRADE_DATABASE:         return getUpgradeDatabaseIntent(masterSecret);
-      case STATE_PROMPT_PUSH_REGISTRATION: return getPushRegistrationIntent(masterSecret);
+      case STATE_PROMPT_PUSH_REGISTRATION: return getPushRegistrationIntent();
       default:                             return null;
     }
   }
@@ -134,12 +134,12 @@ public abstract class PassphraseRequiredActionBarActivity extends BaseActionBarA
     return getRoutedIntent(DatabaseUpgradeActivity.class,
                            TextSecurePreferences.hasPromptedPushRegistration(this)
                                ? getConversationListIntent()
-                               : getPushRegistrationIntent(masterSecret),
+                               : getPushRegistrationIntent(),
                            masterSecret);
   }
 
-  private Intent getPushRegistrationIntent(MasterSecret masterSecret) {
-    return getRoutedIntent(RegistrationActivity.class, getConversationListIntent(), masterSecret);
+  private Intent getPushRegistrationIntent() {
+    return getRoutedIntent(RegistrationActivity.class, getConversationListIntent(), null);
   }
 
   private Intent getRoutedIntent(Class<?> destination, @Nullable Intent nextIntent, @Nullable MasterSecret masterSecret) {

--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.telephony.TelephonyManager;
 import android.text.Editable;
 import android.text.TextUtils;
@@ -38,7 +39,7 @@ import org.whispersystems.textsecure.api.util.PhoneNumberFormatter;
  * @author Moxie Marlinspike
  *
  */
-public class RegistrationActivity extends BaseActionBarActivity {
+public class RegistrationActivity extends PassphraseRequiredActionBarActivity {
 
   private static final int PICK_COUNTRY = 1;
 
@@ -53,8 +54,8 @@ public class RegistrationActivity extends BaseActionBarActivity {
   private MasterSecret masterSecret;
 
   @Override
-  public void onCreate(Bundle icicle) {
-    super.onCreate(icicle);
+  protected void onCreate(Bundle icicle, @NonNull MasterSecret masterSecret) {
+    this.masterSecret = masterSecret;
     setContentView(R.layout.registration_activity);
 
     getSupportActionBar().setTitle(getString(R.string.RegistrationActivity_connect_with_textsecure));
@@ -74,7 +75,6 @@ public class RegistrationActivity extends BaseActionBarActivity {
   }
 
   private void initializeResources() {
-    this.masterSecret   = getIntent().getParcelableExtra("master_secret");
     this.countrySpinner = (Spinner)findViewById(R.id.country_spinner);
     this.countryCode    = (TextView)findViewById(R.id.country_code);
     this.number         = (TextView)findViewById(R.id.number);

--- a/src/org/thoughtcrime/securesms/RegistrationProgressActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationProgressActivity.java
@@ -13,7 +13,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.Message;
-import android.support.v7.app.ActionBarActivity;
+import android.support.annotation.NonNull;
 import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.TextUtils;
@@ -30,10 +30,8 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
-
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.push.TextSecureCommunicationFactory;
-import org.thoughtcrime.securesms.service.KeyCachingService;
 import org.thoughtcrime.securesms.service.RegistrationService;
 import org.thoughtcrime.securesms.util.Dialogs;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
@@ -47,7 +45,7 @@ import java.io.IOException;
 
 import static org.thoughtcrime.securesms.service.RegistrationService.RegistrationState;
 
-public class RegistrationProgressActivity extends BaseActionBarActivity {
+public class RegistrationProgressActivity extends PassphraseRequiredActionBarActivity {
 
   private static final int FOCUSED_COLOR   = Color.parseColor("#ff333333");
   private static final int UNFOCUSED_COLOR = Color.parseColor("#ff808080");
@@ -92,8 +90,7 @@ public class RegistrationProgressActivity extends BaseActionBarActivity {
   private volatile boolean visible;
 
   @Override
-  public void onCreate(Bundle bundle) {
-    super.onCreate(bundle);
+  protected void onCreate(Bundle bundle, @NonNull MasterSecret masterSecret) {
     getSupportActionBar().setTitle(getString(R.string.RegistrationProgressActivity_verifying_number));
     setContentView(R.layout.registration_progress_activity);
 

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -186,12 +186,10 @@ public class AdvancedPreferenceFragment extends PreferenceFragment {
         builder.show();
       } else {
         Intent nextIntent = new Intent(getActivity(), ApplicationPreferencesActivity.class);
-        nextIntent.putExtra("master_secret", getActivity().getIntent().getParcelableExtra("master_secret"));
 
         Intent intent = new Intent(getActivity(), RegistrationActivity.class);
         intent.putExtra("cancel_button", true);
         intent.putExtra("next_intent", nextIntent);
-        intent.putExtra("master_secret", getActivity().getIntent().getParcelableExtra("master_secret"));
         startActivity(intent);
       }
 


### PR DESCRIPTION
There shouldn't be a scenario where one registers and the MasterSecret isn't available, so it seems best to just make it a PassphraseRequiredActionBarActivity.