### PR TITLE
Fix crash when username is null in mms auth

### DIFF
--- a/src/org/thoughtcrime/securesms/mms/LegacyMmsConnection.java
+++ b/src/org/thoughtcrime/securesms/mms/LegacyMmsConnection.java
@@ -241,7 +241,7 @@ public abstract class LegacyMmsConnection {
     }
 
     public boolean hasAuthentication() {
-      return !TextUtils.isEmpty(username) || !TextUtils.isEmpty(password);
+      return !TextUtils.isEmpty(username);
     }
 
     public String getUsername() {


### PR DESCRIPTION
Looking at the apache source, http://www.docjar.com/html/api/org/apache/http/auth/UsernamePasswordCredentials.java.html, it requires only that the username not be null. Setting our constraints based on that one. I'm guessing this is from people setting custom MMS params.

Fixes #2850
