### PR TITLE
Fix loop when activity routes to itself

### DIFF
--- a/src/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
@@ -90,10 +90,16 @@ public abstract class PassphraseRequiredActionBarActivity extends BaseActionBarA
 
   private void routeApplicationState(MasterSecret masterSecret) {
     Intent intent = getIntentForState(masterSecret, getApplicationState(masterSecret));
-    if (intent != null) {
+    if (intent != null && !isSelfIntent(intent)) {
       startActivity(intent);
       finish();
     }
+  }
+
+  private boolean isSelfIntent(Intent intent) {
+    return intent != null &&
+           intent.getComponent() != null &&
+           intent.getComponent().getClassName().equals(this.getClass().getName());
   }
 
   private Intent getIntentForState(MasterSecret masterSecret, int state) {


### PR DESCRIPTION
Could have reverted, but I think it still makes sense for RegistrationActivity to be in the PassphraseRequired realm, we just don't want activities ever routing to themselves.

Fixes #2868
