### PR TITLE
Fix registration routing loop

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -69,16 +69,7 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
   @Override
   protected void onCreate(Bundle icicle, @NonNull MasterSecret masterSecret) {
     this.getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-
-    Bundle   fragmentArgs = new Bundle();
-    Fragment fragment     = new ApplicationPreferenceFragment();
-
-    fragmentArgs.putParcelable("master_secret", masterSecret);
-    fragment.setArguments(fragmentArgs);
-
-    getSupportFragmentManager().beginTransaction()
-                               .replace(android.R.id.content, fragment)
-                               .commit();
+    initFragment(android.R.id.content, new ApplicationPreferenceFragment(), masterSecret);
   }
 
   @Override
@@ -185,10 +176,7 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
           fragment = new NotificationsPreferenceFragment();
           break;
         case PREFERENCE_CATEGORY_APP_PROTECTION:
-          Bundle args = new Bundle();
-          args.putParcelable("master_secret", masterSecret);
           fragment = new AppProtectionPreferenceFragment();
-          fragment.setArguments(args);
           break;
         case PREFERENCE_CATEGORY_APPEARANCE:
           fragment = new AppearancePreferenceFragment();
@@ -202,6 +190,10 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
         default:
           throw new AssertionError();
         }
+
+        Bundle args = new Bundle();
+        args.putParcelable("master_secret", masterSecret);
+        fragment.setArguments(args);
 
         FragmentManager     fragmentManager     = getActivity().getSupportFragmentManager();
         FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();

--- a/src/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
@@ -103,7 +103,7 @@ public abstract class PassphraseRequiredActionBarActivity extends BaseActionBarA
       case STATE_CREATE_PASSPHRASE:        return getCreatePassphraseIntent();
       case STATE_PROMPT_PASSPHRASE:        return getPromptPassphraseIntent();
       case STATE_UPGRADE_DATABASE:         return getUpgradeDatabaseIntent(masterSecret);
-      case STATE_PROMPT_PUSH_REGISTRATION: return getPushRegistrationIntent();
+      case STATE_PROMPT_PUSH_REGISTRATION: return getPushRegistrationIntent(masterSecret);
       default:                             return null;
     }
   }
@@ -134,12 +134,12 @@ public abstract class PassphraseRequiredActionBarActivity extends BaseActionBarA
     return getRoutedIntent(DatabaseUpgradeActivity.class,
                            TextSecurePreferences.hasPromptedPushRegistration(this)
                                ? getConversationListIntent()
-                               : getPushRegistrationIntent(),
+                               : getPushRegistrationIntent(masterSecret),
                            masterSecret);
   }
 
-  private Intent getPushRegistrationIntent() {
-    return getRoutedIntent(RegistrationActivity.class, getConversationListIntent(), null);
+  private Intent getPushRegistrationIntent(MasterSecret masterSecret) {
+    return getRoutedIntent(RegistrationActivity.class, getConversationListIntent(), masterSecret);
   }
 
   private Intent getRoutedIntent(Class<?> destination, @Nullable Intent nextIntent, @Nullable MasterSecret masterSecret) {

--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.telephony.TelephonyManager;
 import android.text.Editable;
 import android.text.TextUtils;
@@ -39,7 +38,7 @@ import org.whispersystems.textsecure.api.util.PhoneNumberFormatter;
  * @author Moxie Marlinspike
  *
  */
-public class RegistrationActivity extends PassphraseRequiredActionBarActivity {
+public class RegistrationActivity extends BaseActionBarActivity {
 
   private static final int PICK_COUNTRY = 1;
 
@@ -54,8 +53,8 @@ public class RegistrationActivity extends PassphraseRequiredActionBarActivity {
   private MasterSecret masterSecret;
 
   @Override
-  protected void onCreate(Bundle icicle, @NonNull MasterSecret masterSecret) {
-    this.masterSecret = masterSecret;
+  public void onCreate(Bundle icicle) {
+    super.onCreate(icicle);
     setContentView(R.layout.registration_activity);
 
     getSupportActionBar().setTitle(getString(R.string.RegistrationActivity_connect_with_textsecure));
@@ -75,6 +74,7 @@ public class RegistrationActivity extends PassphraseRequiredActionBarActivity {
   }
 
   private void initializeResources() {
+    this.masterSecret   = getIntent().getParcelableExtra("master_secret");
     this.countrySpinner = (Spinner)findViewById(R.id.country_spinner);
     this.countryCode    = (TextView)findViewById(R.id.country_code);
     this.number         = (TextView)findViewById(R.id.number);

--- a/src/org/thoughtcrime/securesms/RegistrationProgressActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationProgressActivity.java
@@ -13,7 +13,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.Message;
-import android.support.annotation.NonNull;
+import android.support.v7.app.ActionBarActivity;
 import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.TextUtils;
@@ -30,8 +30,10 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.push.TextSecureCommunicationFactory;
+import org.thoughtcrime.securesms.service.KeyCachingService;
 import org.thoughtcrime.securesms.service.RegistrationService;
 import org.thoughtcrime.securesms.util.Dialogs;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
@@ -45,7 +47,7 @@ import java.io.IOException;
 
 import static org.thoughtcrime.securesms.service.RegistrationService.RegistrationState;
 
-public class RegistrationProgressActivity extends PassphraseRequiredActionBarActivity {
+public class RegistrationProgressActivity extends BaseActionBarActivity {
 
   private static final int FOCUSED_COLOR   = Color.parseColor("#ff333333");
   private static final int UNFOCUSED_COLOR = Color.parseColor("#ff808080");
@@ -90,7 +92,8 @@ public class RegistrationProgressActivity extends PassphraseRequiredActionBarAct
   private volatile boolean visible;
 
   @Override
-  protected void onCreate(Bundle bundle, @NonNull MasterSecret masterSecret) {
+  public void onCreate(Bundle bundle) {
+    super.onCreate(bundle);
     getSupportActionBar().setTitle(getString(R.string.RegistrationProgressActivity_verifying_number));
     setContentView(R.layout.registration_progress_activity);
 

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -186,10 +186,12 @@ public class AdvancedPreferenceFragment extends PreferenceFragment {
         builder.show();
       } else {
         Intent nextIntent = new Intent(getActivity(), ApplicationPreferencesActivity.class);
+        nextIntent.putExtra("master_secret", getActivity().getIntent().getParcelableExtra("master_secret"));
 
         Intent intent = new Intent(getActivity(), RegistrationActivity.class);
         intent.putExtra("cancel_button", true);
         intent.putExtra("next_intent", nextIntent);
+        intent.putExtra("master_secret", getActivity().getIntent().getParcelableExtra("master_secret"));
         startActivity(intent);
       }
 

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -22,6 +22,7 @@ import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.RegistrationActivity;
 import org.thoughtcrime.securesms.contacts.ContactAccessor;
 import org.thoughtcrime.securesms.contacts.ContactIdentityManager;
+import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.push.TextSecureCommunicationFactory;
 import org.thoughtcrime.securesms.util.ProgressDialogAsyncTask;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
@@ -39,9 +40,12 @@ public class AdvancedPreferenceFragment extends PreferenceFragment {
 
   private static final int PICK_IDENTITY_CONTACT = 1;
 
+  private MasterSecret masterSecret;
+
   @Override
   public void onCreate(Bundle paramBundle) {
     super.onCreate(paramBundle);
+    masterSecret = getArguments().getParcelable("master_secret");
     addPreferencesFromResource(R.xml.preferences_advanced);
 
     initializePushMessagingToggle();
@@ -186,12 +190,11 @@ public class AdvancedPreferenceFragment extends PreferenceFragment {
         builder.show();
       } else {
         Intent nextIntent = new Intent(getActivity(), ApplicationPreferencesActivity.class);
-        nextIntent.putExtra("master_secret", getActivity().getIntent().getParcelableExtra("master_secret"));
 
         Intent intent = new Intent(getActivity(), RegistrationActivity.class);
         intent.putExtra("cancel_button", true);
         intent.putExtra("next_intent", nextIntent);
-        intent.putExtra("master_secret", getActivity().getIntent().getParcelableExtra("master_secret"));
+        intent.putExtra("master_secret", masterSecret);
         startActivity(intent);
       }
 


### PR DESCRIPTION
Revert the change that caused the issue, fix within the fragments. I'll revisit moving RegistrationActivity to a PassphraseRequiredActionBarActivity, but this is the smallest diff to get back to functional first.