### PR TITLE
fix forward message to contact for which no conversation exists

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -103,6 +103,10 @@ public class ConversationFragment extends ListFragment
 
     initializeResources();
     initializeListAdapter();
+
+    if (threadId == -1) {
+      getLoaderManager().restartLoader(0, null, this);
+    }
   }
 
   private void initializeResources() {
@@ -117,8 +121,6 @@ public class ConversationFragment extends ListFragment
                                                   DirectoryHelper.isPushDestination(getActivity(), this.recipients)));
       getListView().setRecyclerListener((ConversationAdapter)getListAdapter());
       getLoaderManager().restartLoader(0, null, this);
-    } else {
-      this.setListAdapter(null);
     }
   }
 

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -117,6 +117,8 @@ public class ConversationFragment extends ListFragment
                                                   DirectoryHelper.isPushDestination(getActivity(), this.recipients)));
       getListView().setRecyclerListener((ConversationAdapter)getListAdapter());
       getLoaderManager().restartLoader(0, null, this);
+    } else {
+      this.setListAdapter(null);
     }
   }
 


### PR DESCRIPTION
set list adapter to null when (recipients or threadId == null) to prevent old messages from being displayed when forwarding a message to a recipient for which there is no existing conversation.

Fixes #2883
// FREEBIE