### PR TITLE
fix media message forwarding

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -233,10 +233,33 @@ public class ConversationFragment extends ListFragment
     startActivity(intent);
   }
 
-  private void handleForwardMessage(MessageRecord message) {
+  private void handleForwardMediaMessage(final MediaMmsMessageRecord message) {
+    message.fetchMediaSlide(new FutureTaskListener<Slide>() {
+      @Override
+      public void onSuccess(Slide result) {
+        Intent composeIntent = new Intent(getActivity(), ShareActivity.class);
+        composeIntent.putExtra(Intent.EXTRA_TEXT, message.getDisplayBody().toString());
+        composeIntent.putExtra(Intent.EXTRA_STREAM, result.getUri());
+        composeIntent.setType(result.getContentType());
+        startActivity(composeIntent);
+      }
+
+      @Override
+      public void onFailure(Throwable error) {
+        handleForwardTextMessage(message);
+      }
+    });
+  }
+
+  private void handleForwardTextMessage(MessageRecord message) {
     Intent composeIntent = new Intent(getActivity(), ShareActivity.class);
     composeIntent.putExtra(Intent.EXTRA_TEXT, message.getDisplayBody().toString());
     startActivity(composeIntent);
+  }
+
+  private void handleForwardMessage(MessageRecord message) {
+    if (message.isMms()) handleForwardMediaMessage((MediaMmsMessageRecord)message);
+    else                 handleForwardTextMessage(message);
   }
 
   private void handleResendMessage(final MessageRecord message) {

--- a/src/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/org/thoughtcrime/securesms/ShareActivity.java
@@ -139,6 +139,8 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity
     if (type == null) {
       String extension = MimeTypeMap.getFileExtensionFromUrl(uri.toString());
       type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
+
+      if (type == null) return getIntent().getType();
     }
 
     return type;

--- a/src/org/thoughtcrime/securesms/mms/AudioSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/AudioSlide.java
@@ -24,8 +24,8 @@ import org.thoughtcrime.securesms.util.ListenableFutureTask;
 import org.thoughtcrime.securesms.util.ResUtil;
 
 import ws.com.google.android.mms.pdu.PduPart;
+
 import android.content.Context;
-import android.database.Cursor;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.provider.MediaStore.Audio;
@@ -59,21 +59,12 @@ public class AudioSlide extends Slide {
   public static PduPart constructPartFromUri(Context context, Uri uri) throws IOException, MediaTooLargeException {
     PduPart part = new PduPart();
 
-    assertMediaSize(context, uri);
-
-    Cursor cursor = null;
-
-    try {
-      cursor = context.getContentResolver().query(uri, new String[]{Audio.Media.MIME_TYPE}, null, null, null);
-
-      if (cursor != null && cursor.moveToFirst())
-        part.setContentType(cursor.getString(0).getBytes());
-      else
-        throw new IOException("Unable to query content type.");
-    } finally {
-      if (cursor != null)
-        cursor.close();
-    } 
+    if (isAuthorityPartDb(uri)) {
+      part.setContentType(getContentTypeForPartInDb(context, uri));
+    } else {
+      assertMediaSize(context, uri);
+      part.setContentType(getContentTypeForPartOutsideDb(context, uri, Audio.Media.MIME_TYPE));
+    }
 
     part.setDataUri(uri);
     part.setContentId((System.currentTimeMillis()+"").getBytes());

--- a/src/org/thoughtcrime/securesms/mms/VideoSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/VideoSlide.java
@@ -24,13 +24,10 @@ import org.thoughtcrime.securesms.util.ListenableFutureTask;
 import org.thoughtcrime.securesms.util.ResUtil;
 
 import ws.com.google.android.mms.pdu.PduPart;
-import android.content.ContentResolver;
 import android.content.Context;
-import android.database.Cursor;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.provider.MediaStore;
-import android.util.Log;
 import android.util.Pair;
 
 public class VideoSlide extends Slide {
@@ -61,22 +58,15 @@ public class VideoSlide extends Slide {
   private static PduPart constructPartFromUri(Context context, Uri uri)
       throws IOException, MediaTooLargeException
   {
-    PduPart         part     = new PduPart();
-    ContentResolver resolver = context.getContentResolver();
-    Cursor          cursor   = null;
+    PduPart part = new PduPart();
 
-    try {
-      cursor = resolver.query(uri, new String[] {MediaStore.Video.Media.MIME_TYPE}, null, null, null);
-      if (cursor != null && cursor.moveToFirst()) {
-        Log.w("VideoSlide", "Setting mime type: " + cursor.getString(0));
-        part.setContentType(cursor.getString(0).getBytes());
-      }
-    } finally {
-      if (cursor != null)
-        cursor.close();
+    if (isAuthorityPartDb(uri)) {
+      part.setContentType(getContentTypeForPartInDb(context, uri));
+    } else {
+      assertMediaSize(context, uri);
+      part.setContentType(getContentTypeForPartOutsideDb(context, uri, MediaStore.Video.Media.MIME_TYPE));
     }
 
-    assertMediaSize(context, uri);
     part.setDataUri(uri);
     part.setContentId((System.currentTimeMillis()+"").getBytes());
     part.setName(("Video" + System.currentTimeMillis()).getBytes());


### PR DESCRIPTION
1) forward media messages using MediaMmsMessageRecord's resolved SlideDeck
2) patch ShareActivity to get type of STREAM_EXTRA from intent when others null
3) patched AudioSlide, VideoSlide, and ImageSlide to work with content:// Uri's from our part database

Fixes #1362
// FREEBIE