### PR TITLE
Preserve shortcuts to old launcher activity

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -95,14 +95,19 @@
     <activity android:name=".ConversationListActivity"
           android:label="@string/app_name"
           android:launchMode="singleTask"
-          android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize">
+          android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"
+          android:exported="true" />
+
+    <activity-alias android:name=".RoutingActivity"
+                    android:targetActivity=".ConversationListActivity"
+                    android:exported="true">
 
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
 
-    </activity>
+    </activity-alias>
 
     <activity android:name=".ConversationActivity"
               android:windowSoftInputMode="stateUnchanged"


### PR DESCRIPTION
Add an activity alias for RoutingActivity that points to the new launcher activity. Fixes #2878.