### PR TITLE
changeMasterSecretPassphrase is now being called in AsyncTask

### DIFF
--- a/src/org/thoughtcrime/securesms/PassphraseChangeActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphraseChangeActivity.java
@@ -18,6 +18,7 @@ package org.thoughtcrime.securesms;
 
 import android.os.AsyncTask;
 import android.content.Context;
+import android.util.Log;
 import android.os.Bundle;
 import android.text.Editable;
 import android.view.View;
@@ -101,7 +102,7 @@ public class PassphraseChangeActivity extends PassphraseActivity {
                      R.string.PassphraseChangeActivity_enter_new_passphrase_exclamation,
                      Toast.LENGTH_SHORT).show();
     } else {
-      new ChangeMasterSecretPassphrase(this, original, passphrase).execute();
+      new ChangePassphraseTask(this, original, passphrase).execute();
     }
   }
 
@@ -117,12 +118,12 @@ public class PassphraseChangeActivity extends PassphraseActivity {
     }
   }
 
-  private class ChangeMasterSecretPassphrase extends AsyncTask<Void, Void, MasterSecret> {
+  private class ChangePassphraseTask extends AsyncTask<Void, Void, MasterSecret> {
     private final Context context;
     private String original;
     private String passphrase;
 
-    public ChangeMasterSecretPassphrase(Context context, String original, String passphrase) {
+    public ChangePassphraseTask(Context context, String original, String passphrase) {
       this.context    = context;
       this.original   = original;
       this.passphrase = passphrase;
@@ -137,6 +138,7 @@ public class PassphraseChangeActivity extends PassphraseActivity {
         return masterSecret;
 
       } catch (InvalidPassphraseException e) {
+        Log.w(PassphraseChangeActivity.class.getSimpleName(), e);
         return null;
       }
     }
@@ -145,9 +147,7 @@ public class PassphraseChangeActivity extends PassphraseActivity {
     protected void onPostExecute(MasterSecret masterSecret) {
       if (masterSecret != null) {
         setMasterSecret(masterSecret);
-      }
-
-      else {
+      } else {
         Toast.makeText(context, R.string.PassphraseChangeActivity_incorrect_old_passphrase_exclamation,
                        Toast.LENGTH_LONG).show();
         originalPassphrase.setText("");

--- a/src/org/thoughtcrime/securesms/PassphraseChangeActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphraseChangeActivity.java
@@ -117,48 +117,40 @@ public class PassphraseChangeActivity extends PassphraseActivity {
     }
   }
 
-  private class ChangeMasterSecretPassphrase extends AsyncTask<Void, Void, Void> {
-    private MasterSecret masterSecret;
-    private InvalidPassphraseException exception;
-    private EditText originalPassphrase;
-    private Context context;
-    private String original, passphrase;
+  private class ChangeMasterSecretPassphrase extends AsyncTask<Void, Void, MasterSecret> {
+    private final Context context;
+    private String original;
+    private String passphrase;
 
     public ChangeMasterSecretPassphrase(Context context, String original, String passphrase) {
-      this.context = context;
-      this.original = original;
+      this.context    = context;
+      this.original   = original;
       this.passphrase = passphrase;
     }
 
     @Override
-    protected Void doInBackground(Void... params) {
+    protected MasterSecret doInBackground(Void... params) {
       try {
-        this.masterSecret = MasterSecretUtil.changeMasterSecretPassphrase(context, original, passphrase);
+        MasterSecret masterSecret = MasterSecretUtil.changeMasterSecretPassphrase(context, original, passphrase);
         TextSecurePreferences.setPasswordDisabled(context, false);
 
-      } catch (InvalidPassphraseException e) {
-        this.exception = e;
-      }
+        return masterSecret;
 
-      return null;
+      } catch (InvalidPassphraseException e) {
+        return null;
+      }
     }
 
     @Override
-    protected void onPostExecute(Void aVoid) {
-      this.originalPassphrase = (EditText) PassphraseChangeActivity.this.findViewById(R.id.old_passphrase);
-
-      // If exception not thrown and master secret not null -> setMasterSecret
-      if (exception == null) {
-        if (masterSecret != null) {
-          setMasterSecret(masterSecret);
-        }
+    protected void onPostExecute(MasterSecret masterSecret) {
+      if (masterSecret != null) {
+        setMasterSecret(masterSecret);
       }
 
-      // If exception is thrown -> Toast incorrect old passphrase and set EditText to empty
       else {
         Toast.makeText(context, R.string.PassphraseChangeActivity_incorrect_old_passphrase_exclamation,
                        Toast.LENGTH_LONG).show();
-        this.originalPassphrase.setText("");
+        originalPassphrase.setText("");
       }
     }
   }

--- a/src/org/thoughtcrime/securesms/PassphraseChangeActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphraseChangeActivity.java
@@ -102,7 +102,7 @@ public class PassphraseChangeActivity extends PassphraseActivity {
                      R.string.PassphraseChangeActivity_enter_new_passphrase_exclamation,
                      Toast.LENGTH_SHORT).show();
     } else {
-      new ChangePassphraseTask(this, original, passphrase).execute();
+      new ChangePassphraseTask(this).execute(original, passphrase);
     }
   }
 
@@ -118,15 +118,11 @@ public class PassphraseChangeActivity extends PassphraseActivity {
     }
   }
 
-  private class ChangePassphraseTask extends AsyncTask<Void, Void, MasterSecret> {
+  private class ChangePassphraseTask extends AsyncTask<String, Void, MasterSecret> {
     private final Context context;
-    private String original;
-    private String passphrase;
 
-    public ChangePassphraseTask(Context context, String original, String passphrase) {
-      this.context    = context;
-      this.original   = original;
-      this.passphrase = passphrase;
+    public ChangePassphraseTask(Context context) {
+      this.context = context;
     }
 
     @Override
@@ -135,9 +131,9 @@ public class PassphraseChangeActivity extends PassphraseActivity {
     }
 
     @Override
-    protected MasterSecret doInBackground(Void... params) {
+    protected MasterSecret doInBackground(String... params) {
       try {
-        MasterSecret masterSecret = MasterSecretUtil.changeMasterSecretPassphrase(context, original, passphrase);
+        MasterSecret masterSecret = MasterSecretUtil.changeMasterSecretPassphrase(context, params[0], params[1]);
         TextSecurePreferences.setPasswordDisabled(context, false);
 
         return masterSecret;

--- a/src/org/thoughtcrime/securesms/PassphraseChangeActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphraseChangeActivity.java
@@ -130,6 +130,11 @@ public class PassphraseChangeActivity extends PassphraseActivity {
     }
 
     @Override
+    protected void onPreExecute() {
+      okButton.setEnabled(false);
+    }
+
+    @Override
     protected MasterSecret doInBackground(Void... params) {
       try {
         MasterSecret masterSecret = MasterSecretUtil.changeMasterSecretPassphrase(context, original, passphrase);
@@ -145,6 +150,8 @@ public class PassphraseChangeActivity extends PassphraseActivity {
 
     @Override
     protected void onPostExecute(MasterSecret masterSecret) {
+      okButton.setEnabled(true);
+
       if (masterSecret != null) {
         setMasterSecret(masterSecret);
       } else {


### PR DESCRIPTION
Created new ChangeMasterSecretPassphrase AsyncTask class to handle the changeMasterSecretPassphrase method outside the UI thread. 

Also moved the try-catch block for changeMasterSecretPassphrase from verifyAndSavePassphrases method to AsyncTask class so we don't have the other stuff that don't throw any exceptions in the try block.

Fixes #2768