### PR TITLE
Updated some exception object identifiers

### DIFF
--- a/src/org/thoughtcrime/securesms/dom/smil/SmilRegionElementImpl.java
+++ b/src/org/thoughtcrime/securesms/dom/smil/SmilRegionElementImpl.java
@@ -76,7 +76,7 @@ public class SmilRegionElementImpl extends SmilElementImpl implements
     public int getLeft() {
         try {
             return parseRegionLength(getAttribute(LEFT_ATTRIBUTE_NAME), true);
-        } catch (NumberFormatException _) {
+        } catch (NumberFormatException e) {
             if (LOCAL_LOGV) {
                 Log.v(TAG, "Left attribute is not set or incorrect.");
             }
@@ -86,7 +86,7 @@ public class SmilRegionElementImpl extends SmilElementImpl implements
             int right = parseRegionLength(getAttribute(RIGHT_ATTRIBUTE_NAME), true);
             int width = parseRegionLength(getAttribute(WIDTH_ATTRIBUTE_NAME), true);
             return bbw - right - width;
-        } catch (NumberFormatException _) {
+        } catch (NumberFormatException e) {
             if (LOCAL_LOGV) {
                 Log.v(TAG, "Right or width attribute is not set or incorrect.");
             }
@@ -97,7 +97,7 @@ public class SmilRegionElementImpl extends SmilElementImpl implements
     public int getTop() {
         try {
             return parseRegionLength(getAttribute(TOP_ATTRIBUTE_NAME), false);
-        } catch (NumberFormatException _) {
+        } catch (NumberFormatException e) {
             if (LOCAL_LOGV) {
                 Log.v(TAG, "Top attribute is not set or incorrect.");
             }
@@ -107,7 +107,7 @@ public class SmilRegionElementImpl extends SmilElementImpl implements
             int bottom = parseRegionLength(getAttribute(BOTTOM_ATTRIBUTE_NAME), false);
             int height = parseRegionLength(getAttribute(HEIGHT_ATTRIBUTE_NAME), false);
             return bbh - bottom - height;
-        } catch (NumberFormatException _) {
+        } catch (NumberFormatException e) {
             if (LOCAL_LOGV) {
                 Log.v(TAG, "Bottom or height attribute is not set or incorrect.");
             }
@@ -118,7 +118,7 @@ public class SmilRegionElementImpl extends SmilElementImpl implements
     public int getZIndex() {
         try {
             return Integer.parseInt(this.getAttribute(Z_INDEX_ATTRIBUTE_NAME));
-        } catch (NumberFormatException _) {
+        } catch (NumberFormatException e) {
             return 0;
         }
     }
@@ -160,7 +160,7 @@ public class SmilRegionElementImpl extends SmilElementImpl implements
             return height == 0 ?
                     ((SMILDocument) getOwnerDocument()).getLayout().getRootLayout().getHeight() :
                         height;
-        } catch (NumberFormatException _) {
+        } catch (NumberFormatException e) {
             if (LOCAL_LOGV) {
                 Log.v(TAG, "Height attribute is not set or incorrect.");
             }
@@ -168,14 +168,14 @@ public class SmilRegionElementImpl extends SmilElementImpl implements
         int bbh = ((SMILDocument) getOwnerDocument()).getLayout().getRootLayout().getHeight();
         try {
             bbh -= parseRegionLength(getAttribute(TOP_ATTRIBUTE_NAME), false);
-        } catch (NumberFormatException _) {
+        } catch (NumberFormatException e) {
             if (LOCAL_LOGV) {
                 Log.v(TAG, "Top attribute is not set or incorrect.");
             }
         }
         try {
             bbh -= parseRegionLength(getAttribute(BOTTOM_ATTRIBUTE_NAME), false);
-        } catch (NumberFormatException _) {
+        } catch (NumberFormatException e) {
             if (LOCAL_LOGV) {
                 Log.v(TAG, "Bottom attribute is not set or incorrect.");
             }
@@ -193,7 +193,7 @@ public class SmilRegionElementImpl extends SmilElementImpl implements
             return width == 0 ?
                     ((SMILDocument) getOwnerDocument()).getLayout().getRootLayout().getWidth() :
                         width;
-        } catch (NumberFormatException _) {
+        } catch (NumberFormatException e) {
             if (LOCAL_LOGV) {
                 Log.v(TAG, "Width attribute is not set or incorrect.");
             }
@@ -201,14 +201,14 @@ public class SmilRegionElementImpl extends SmilElementImpl implements
         int bbw = ((SMILDocument) getOwnerDocument()).getLayout().getRootLayout().getWidth();
         try {
             bbw -= parseRegionLength(getAttribute(LEFT_ATTRIBUTE_NAME), true);
-        } catch (NumberFormatException _) {
+        } catch (NumberFormatException e) {
             if (LOCAL_LOGV) {
                 Log.v(TAG, "Left attribute is not set or incorrect.");
             }
         }
         try {
             bbw -= parseRegionLength(getAttribute(RIGHT_ATTRIBUTE_NAME), true);
-        } catch (NumberFormatException _) {
+        } catch (NumberFormatException e) {
             if (LOCAL_LOGV) {
                 Log.v(TAG, "Right attribute is not set or incorrect.");
             }

--- a/src/org/thoughtcrime/securesms/dom/smil/TimeImpl.java
+++ b/src/org/thoughtcrime/securesms/dom/smil/TimeImpl.java
@@ -147,7 +147,7 @@ public class TimeImpl implements Time {
                 // Handle Timecount-val without metric
                 try {
                     return parseFloat(clockValue, 0, true) * 1000;
-                } catch (NumberFormatException _) {
+                } catch (NumberFormatException e) {
                     // Ignore
                 }
 

--- a/src/ws/com/google/android/mms/pdu/EncodedStringValue.java
+++ b/src/ws/com/google/android/mms/pdu/EncodedStringValue.java
@@ -146,7 +146,7 @@ public class EncodedStringValue implements Cloneable {
             	}
             	try {
                     return new String(mData, CharacterSets.MIMENAME_ISO_8859_1);
-                } catch (UnsupportedEncodingException _) {
+                } catch (UnsupportedEncodingException e1) {
                     return new String(mData); // system default encoding.
                 }
             }
@@ -217,7 +217,7 @@ public class EncodedStringValue implements Cloneable {
             try {
                 ret[i] = new EncodedStringValue(mCharacterSet,
                         temp[i].getBytes());
-            } catch (NullPointerException _) {
+            } catch (NullPointerException e) {
                 // Can't arrive here
                 return null;
             }


### PR DESCRIPTION
Updated "_" (underscore) exception object identifiers to something more conventional (‘e’) as the underscore identifier might not be supported in releases after Java 8.

This will also fix some of the warnings given when building TextSecure. ([terminal screenshot](https://cloud.githubusercontent.com/assets/6370064/6993521/a396369c-daff-11e4-8ad1-ca33690454bb.png))