### PR TITLE
Fix identity verification screen design issues

### DIFF
--- a/res/layout/verify_identity_activity.xml
+++ b/res/layout/verify_identity_activity.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
             android:layout_width="fill_parent"
-            android:layout_height="fill_parent">
+            android:layout_height="fill_parent"
+            android:fillViewport="true">
 
     <LinearLayout android:layout_width="fill_parent"
                   android:layout_height="wrap_content"
-                  android:layout_marginLeft="16dip"
-                  android:layout_marginRight="16dip"
-                  android:layout_gravity="center"
+                  android:padding="20dp"
+                  android:gravity="center"
                   android:orientation="vertical">
 
         <TextView
@@ -15,23 +15,26 @@
                 android:layout_height="wrap_content"
                 android:textAppearance="?android:attr/textAppearanceLarge"
                 android:text="@string/verify_identity_activity__their_identity_they_read"
-                android:padding="7dip" />
+                android:layout_marginBottom="8dp" />
 
         <TextView
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
                 android:textAppearance="?android:attr/textAppearanceLarge"
                 android:typeface="monospace"
+                android:fontFamily="monospace"
                 android:id="@+id/friend_reads"
                 android:text=""
-                android:padding="7dip" />
+                android:layout_marginBottom="8dp" />
+
 
         <TextView
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/verify_identity_activity__your_identity_you_read"
                 android:textAppearance="?android:attr/textAppearanceLarge"
-                android:padding="7dip" />
+                android:layout_marginBottom="8dp" />
+
 
         <TextView
                 android:layout_width="fill_parent"
@@ -39,7 +42,8 @@
                 android:id="@+id/you_read"
                 android:textAppearance="?android:attr/textAppearanceLarge"
                 android:typeface="monospace"
-                android:text=""
-                android:padding="7dip" />
+                android:fontFamily="monospace"
+                android:text="" />
+
     </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
- Corrected improper usage of ScrollView that would cut off contents when taller than the layout.

- Adjusted margins and paddings to match Material specs (20dp from sides).

- Fixed monospaced font being overridden on Lollipop.

Fixes #2904. FREEBIE.