### PR TITLE
bump new drafts to top of conversation list

### DIFF
--- a/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -132,6 +132,9 @@ public class ThreadDatabase extends Database {
 
   public void updateSnippet(long threadId, String snippet, long type) {
     ContentValues contentValues = new ContentValues(3);
+    long          date          = System.currentTimeMillis();
+
+    contentValues.put(DATE, date - date % 1000);
     contentValues.put(SNIPPET, snippet);
     contentValues.put(SNIPPET_TYPE, type);
     SQLiteDatabase db = databaseHelper.getWritableDatabase();


### PR DESCRIPTION
calls to ThreadDatabase.updateSnippet() now update the thread timestamp, thus causing draft messages to be bumped up in the conversation list sort order.

Fixes #1055
// FREEBIE