### PR TITLE
fix proguardDebugTest build target

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -167,6 +167,7 @@ android {
                           'proguard-square-okio.pro',
                           'proguard-spongycastle.pro',
                           'proguard-rounded-image-view.pro',
+                          'proguard-testing.pro',
                           'proguard.cfg'
         }
         release {

--- a/proguard-testing.pro
+++ b/proguard-testing.pro
@@ -1,0 +1,10 @@
+-dontobfuscate
+-dontskipnonpubliclibraryclassmembers
+
+-dontwarn android.test.**
+-dontwarn com.android.support.test.**
+-dontwarn sun.reflect.**
+-dontwarn org.assertj.**
+-dontwarn org.hamcrest.**
+-dontwarn org.mockito.**
+-dontwarn com.squareup.**


### PR DESCRIPTION
added a new set of proguard rules to fix the 'proguardDebugTest' target.

Fixes #2871
// FREEBIE