### PR TITLE
fixed DynamicLanguage to handle silly orientation-related Locale changes

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -18,6 +18,7 @@ package org.thoughtcrime.securesms;
 
 import android.app.Application;
 import android.content.Context;
+import android.content.res.Configuration;
 
 import org.thoughtcrime.securesms.crypto.PRNGFixes;
 import org.thoughtcrime.securesms.dependencies.AxolotlStorageModule;
@@ -27,14 +28,13 @@ import org.thoughtcrime.securesms.jobs.GcmRefreshJob;
 import org.thoughtcrime.securesms.jobs.persistence.EncryptingJobSerializer;
 import org.thoughtcrime.securesms.jobs.requirements.MasterSecretRequirementProvider;
 import org.thoughtcrime.securesms.jobs.requirements.ServiceRequirementProvider;
+import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.whispersystems.jobqueue.JobManager;
 import org.whispersystems.jobqueue.dependencies.DependencyInjector;
 import org.whispersystems.jobqueue.requirements.NetworkRequirementProvider;
 import org.whispersystems.libaxolotl.logging.AxolotlLoggerProvider;
 import org.whispersystems.libaxolotl.util.AndroidAxolotlLogger;
-
-import java.security.Security;
 
 import dagger.ObjectGraph;
 
@@ -106,6 +106,11 @@ public class ApplicationContext extends Application implements DependencyInjecto
     {
       this.jobManager.add(new GcmRefreshJob(this));
     }
+  }
+
+  @Override
+  public void onConfigurationChanged(Configuration newConfig) {
+    DynamicLanguage.onConfigurationChanged(getApplicationContext(), newConfig);
   }
 
 }

--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -110,7 +110,7 @@ public class ApplicationContext extends Application implements DependencyInjecto
 
   @Override
   public void onConfigurationChanged(Configuration newConfig) {
-    DynamicLanguage.onConfigurationChanged(getApplicationContext(), newConfig);
+    DynamicLanguage.onConfigurationChanged(this, newConfig);
   }
 
 }


### PR DESCRIPTION
fixed `DynamicLanguage` to handle silly `Locale` changes caused by screen orientation and other `android:configChanges` events.

Fixes #2815, #2898
// FREEBIE

tested on my N5 (Lollipop) and N1 (GB). with these changes `DynamicLanguage` now contains no instance variables and holds no state, so could in theory be made static.