### PR TITLE
Fix sendComplete UI updates on destroyed views

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -974,7 +974,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     boolean refreshFragment = (threadId != this.threadId);
     this.threadId = threadId;
 
-    if (fragment == null) {
+    if (fragment == null || !fragment.isVisible() || isFinishing()) {
       return;
     }
 


### PR DESCRIPTION
While I couldn't reproduce, should fix #2915 for people with phones that for whatever reason have longer IO times.

On a larger note, it might be worth considering a model where we use EventBus or Otto and AsyncTask simply broadcasts an event on finish. Activities and Fragments can choose to only listen for events when their UI is ready to react to them. By now it's become obvious that any AsyncTasks that end in unchecked UI operations are a bad idea.