### PR TITLE
moved more view manipulation into UI thread

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -638,13 +638,18 @@ public class ConversationItem extends LinearLayout {
           return;
         }
       }
-      mediaThumbnail.hide();
+      this.onFailure(new IllegalStateException("thumbnailFuture is null"));
     }
 
     @Override
     public void onFailure(Throwable error) {
       Log.w(TAG, error);
-      mediaThumbnail.hide();
+      handler.post(new Runnable() {
+        @Override
+        public void run() {
+          mediaThumbnail.hide();
+        }
+      });
     }
   }
 }


### PR DESCRIPTION
issue #2740 contains a strange java.lang.IllegalStateException, this exception resulted in a crash because SlideDeckListener was attempting to change the visibility of a view while outside the UI thread.

// FREEBIE

see debug log [here](https://gist.github.com/anonymous/dacb1a8a3ef662a2921f)
references crash at [this line](https://github.com/WhisperSystems/TextSecure/blob/e0737451db1cb52209c5ae6a00521551be5b728d/src/org/thoughtcrime/securesms/ConversationItem.java#L637)