### PR TITLE
fix emoji sort order to be last in first out

### DIFF
--- a/src/org/thoughtcrime/securesms/util/Emoji.java
+++ b/src/org/thoughtcrime/securesms/util/Emoji.java
@@ -330,9 +330,7 @@ public class Emoji {
         prefs = PreferenceManager.getDefaultSharedPreferences(context);
       }
 
-      if (recentlyUsed.contains(asset)) {
-        recentlyUsed.remove(asset);
-      }
+      recentlyUsed.remove(asset);
       recentlyUsed.add(asset);
 
       if (recentlyUsed.size() > EMOJI_LRU_SIZE) {

--- a/src/org/thoughtcrime/securesms/util/Emoji.java
+++ b/src/org/thoughtcrime/securesms/util/Emoji.java
@@ -263,7 +263,8 @@ public class Emoji {
   }
 
   public Pair<Integer, Drawable> getRecentlyUsed(int position, double size, PageLoadedListener pageLoadedListener) {
-    String code = EmojiLRU.getRecentlyUsed(context)[position];
+    String[] recentlyUsed = EmojiLRU.getRecentlyUsed(context);
+    String   code         = recentlyUsed[recentlyUsed.length - 1 - position];
     return new Pair<Integer, Drawable>(Integer.parseInt(code, 16), getEmojiDrawable(code, size, pageLoadedListener));
   }
 
@@ -329,6 +330,9 @@ public class Emoji {
         prefs = PreferenceManager.getDefaultSharedPreferences(context);
       }
 
+      if (recentlyUsed.contains(asset)) {
+        recentlyUsed.remove(asset);
+      }
       recentlyUsed.add(asset);
 
       if (recentlyUsed.size() > EMOJI_LRU_SIZE) {


### PR DESCRIPTION
EDIT: the recent emoji tab was sorting emoji as last in last out instead of last in first out. also, if an emoji was already in the recent emoji cache its order would not be updated on reinsert-- for example, [A, B, C, B] resulted in the ordered set [A, B, C] instead of [A, C, B].

1) reverse array index used in recent emoji getter.
2) remove duplicate entries to the recent emoji cache before inserting.

Fixes #2967
// FREEBIE