### PR TITLE
Remove read_call_log permission

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -29,7 +29,6 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.READ_CALL_LOG" />
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
 


### PR DESCRIPTION
According to https://github.com/WhisperSystems/TextSecure/issues/574#issuecomment-33328040 it was used for showing recent contacts, which we don't do for quite a while now. 