### PR TITLE
Changed bubble message font size to match the input text message.

### DIFF
--- a/res/layout/conversation_bubble_incoming.xml
+++ b/res/layout/conversation_bubble_incoming.xml
@@ -50,7 +50,7 @@
                   android:paddingRight="10dp"
                   android:textAppearance="?android:attr/textAppearanceSmall"
                   android:textColor="?conversation_received_text_primary_color"
-                  android:textSize="16sp"
+                  android:textSize="18sp"
                   android:autoLink="all"
                   android:linksClickable="true" />
 

--- a/res/layout/conversation_bubble_outgoing.xml
+++ b/res/layout/conversation_bubble_outgoing.xml
@@ -53,7 +53,7 @@
                   android:textAppearance="?android:attr/textAppearanceSmall"
                   android:textColor="?conversation_sent_text_primary_color"
                   android:textColorLink="?conversation_sent_text_primary_color"
-                  android:textSize="16sp"
+                  android:textSize="18sp"
                   tools:text="Mango pickle lorem ipsum" />
 
         <LinearLayout android:id="@+id/mms_download_controls"


### PR DESCRIPTION
This should fix the issue #2769, where the input text message size was different to the actual message (sent and received). Tested on several different devices.