### PR TITLE
don't change cursor if adapter is null

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -283,12 +283,16 @@ public class ConversationFragment extends ListFragment
 
   @Override
   public void onLoadFinished(Loader<Cursor> arg0, Cursor cursor) {
-    ((CursorAdapter)getListAdapter()).changeCursor(cursor);
+    if (getListAdapter() != null) {
+      ((CursorAdapter) getListAdapter()).changeCursor(cursor);
+    }
   }
 
   @Override
   public void onLoaderReset(Loader<Cursor> arg0) {
-    ((CursorAdapter)getListAdapter()).changeCursor(null);
+    if (getListAdapter() != null) {
+      ((CursorAdapter) getListAdapter()).changeCursor(null);
+    }
   }
 
   public interface ConversationFragmentListener {


### PR DESCRIPTION
Addresses #2970

I wasn't able to find a way to reproduce this. This fix is just a nullcheck, but there's still the problem of this loader being called when the list adapter wasn't initialized. @rhodey do you know why `ConversationFragment`'s `onNewIntent` doesn't check for recipients being null, while it does in `initializeListAdapter`?