### PR TITLE
fix the connectedCheck build target

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -167,6 +167,7 @@ android {
                           'proguard-square-okio.pro',
                           'proguard-spongycastle.pro',
                           'proguard-rounded-image-view.pro',
+                          'proguard-testing.pro',
                           'proguard.cfg'
         }
         release {

--- a/proguard-appcompat-v7.pro
+++ b/proguard-appcompat-v7.pro
@@ -1,7 +1,8 @@
+# only obfuscate this one pagacke because LGE ROM bug
+-keepnames class !android.support.v7.internal.view.menu.**, ** { *; }
+
 -keep public class android.support.v7.widget.** { *; }
 -keep public class android.support.v7.internal.widget.** { *; }
-# below line disabled due to LGE ROM bug.
-# -keep public class android.support.v7.internal.view.menu.** { *; }
 
 -keep public class * extends android.support.v4.view.ActionProvider {
     public <init>(android.content.Context);

--- a/proguard-testing.pro
+++ b/proguard-testing.pro
@@ -1,0 +1,10 @@
+-keepattributes Exceptions
+-dontskipnonpubliclibraryclassmembers
+
+-dontwarn android.test.**
+-dontwarn com.android.support.test.**
+-dontwarn sun.reflect.**
+-dontwarn org.assertj.**
+-dontwarn org.hamcrest.**
+-dontwarn org.mockito.**
+-dontwarn com.squareup.**


### PR DESCRIPTION
1) only obfuscate the package android.support.v7.internal.view.menu to prevent LGE ROM bug.
2) '-keepattributes Exceptions' to allow for throwing from mocks
3) -dontskipnonpubliclibraryclassmembers and -dontwarn for everything else

Fixes #2871
// FREEBIE