### PR TITLE
fix the connectedCheck build target

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,7 @@ dependencyVerification {
 android {
     compileSdkVersion 22
     buildToolsVersion '22.0.1'
+    testBuildType "testing"
 
     dexOptions {
         javaMaxHeapSize "4g"
@@ -183,6 +184,10 @@ android {
                           'proguard-rounded-image-view.pro',
                           'proguard.cfg'
             signingConfig signingConfigs.release
+        }
+        testing.initWith(buildTypes.debug)
+        testing {
+            proguardFile 'proguard-testing.pro'
         }
     }
 

--- a/proguard-appcompat-v7.pro
+++ b/proguard-appcompat-v7.pro
@@ -1,7 +1,8 @@
+# only obfuscate this one pagacke because LGE ROM bug
+-keepnames class !android.support.v7.internal.view.menu.**, ** { *; }
+
 -keep public class android.support.v7.widget.** { *; }
 -keep public class android.support.v7.internal.widget.** { *; }
-# below line disabled due to LGE ROM bug.
-# -keep public class android.support.v7.internal.view.menu.** { *; }
 
 -keep public class * extends android.support.v4.view.ActionProvider {
     public <init>(android.content.Context);

--- a/proguard-appcompat-v7.pro
+++ b/proguard-appcompat-v7.pro
@@ -1,4 +1,4 @@
-# only obfuscate this one pagacke because LGE ROM bug
+# https://code.google.com/p/android/issues/detail?id=78377
 -keepnames class !android.support.v7.internal.view.menu.**, ** { *; }
 
 -keep public class android.support.v7.widget.** { *; }

--- a/proguard-testing.pro
+++ b/proguard-testing.pro
@@ -1,0 +1,10 @@
+-keepattributes Exceptions
+-dontskipnonpubliclibraryclassmembers
+
+-dontwarn android.test.**
+-dontwarn com.android.support.test.**
+-dontwarn sun.reflect.**
+-dontwarn org.assertj.**
+-dontwarn org.hamcrest.**
+-dontwarn org.mockito.**
+-dontwarn com.squareup.**


### PR DESCRIPTION
1) create a new build type used exclusively for testing, 'testing'
2) only obfuscate the package android.support.v7.internal.view.menu to
prevent LGE ROM bug
3) '-keepattributes Exceptions' to allow for throwing from mocks
4) -dontskipnonpubliclibraryclassmembers and -dontwarn for everything else

Fixes #2871
// FREEBIE