### PR TITLE
Correct the notification repeat interval

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -419,7 +419,7 @@ public class MessageNotifier {
     alarmIntent.putExtra("reminder_count", count);
 
     PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, alarmIntent, PendingIntent.FLAG_CANCEL_CURRENT);
-    long          timeout       = TimeUnit.SECONDS.toMillis(10);
+    long          timeout       = TimeUnit.MINUTES.toMillis(2);
 
     alarmManager.set(AlarmManager.RTC_WAKEUP, System.currentTimeMillis() + timeout, pendingIntent);
   }


### PR DESCRIPTION
Discussion on the mailing list recommended 2 minutes as the interval to
use (not 10 seconds).