### PR TITLE
prevent NPE from GooglePlayServicesUtil

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -672,7 +672,7 @@
     <string name="message_details_header__with">With:</string>
 
     <!-- PlayServicesProblemFragment -->
-    <string name="PlayServicesProblemFragment__google_play_services_is_not_authentic">The version of the Google Play services installed on this device is not authentic.</string>
+    <string name="PlayServicesProblemFragment__please_install_an_authentic_version_of_google_play">Please install an authentic version of Google Play Services and try again.</string>
 
     <!-- AndroidManifest.xml -->
     <string name="AndroidManifest__create_passphrase">Create passphrase</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -671,6 +671,9 @@
     <string name="message_details_header__from">From:</string>
     <string name="message_details_header__with">With:</string>
 
+    <!-- PlayServicesProblemFragment -->
+    <string name="PlayServicesProblemFragment__google_play_services_is_not_authentic">The version of the Google Play services installed on this device is not authentic.</string>
+
     <!-- AndroidManifest.xml -->
     <string name="AndroidManifest__create_passphrase">Create passphrase</string>
     <string name="AndroidManifest__enter_passphrase">Enter passphrase</string>

--- a/src/org/thoughtcrime/securesms/PlayServicesProblemFragment.java
+++ b/src/org/thoughtcrime/securesms/PlayServicesProblemFragment.java
@@ -18,13 +18,13 @@
 package org.thoughtcrime.securesms;
 
 import android.app.Dialog;
+import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 import android.util.Log;
 
 import com.afollestad.materialdialogs.MaterialDialog;
-import com.afollestad.materialdialogs.MaterialDialog.ButtonCallback;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
 
@@ -33,15 +33,7 @@ public class PlayServicesProblemFragment extends DialogFragment {
   private Dialog getPlayServicesInvalidDialog() {
     return new MaterialDialog.Builder(getActivity())
                .content(R.string.PlayServicesProblemFragment__please_install_an_authentic_version_of_google_play)
-               .cancelable(false)
-               .positiveText(android.R.string.ok)
-               .callback(new ButtonCallback() {
-                 @Override
-                 public void onPositive(MaterialDialog dialog) {
-                   super.onPositive(dialog);
-                   getActivity().finish();
-                 }
-               })
+               .negativeText(android.R.string.ok)
                .build();
   }
 
@@ -60,6 +52,18 @@ public class PlayServicesProblemFragment extends DialogFragment {
         Log.w(getClass().getName(), "received error code " + code);
         return getPlayServicesInvalidDialog();
     }
+  }
+
+  @Override
+  public void onCancel(DialogInterface dialog) {
+    super.onCancel(dialog);
+    getActivity().finish();
+  }
+
+  @Override
+  public void onDismiss(DialogInterface dialog) {
+    super.onDismiss(dialog);
+    getActivity().finish();
   }
 
 }

--- a/src/org/thoughtcrime/securesms/PlayServicesProblemFragment.java
+++ b/src/org/thoughtcrime/securesms/PlayServicesProblemFragment.java
@@ -32,7 +32,7 @@ public class PlayServicesProblemFragment extends DialogFragment {
 
   private Dialog getPlayServicesInvalidDialog() {
     return new MaterialDialog.Builder(getActivity())
-               .content(R.string.PlayServicesProblemFragment__google_play_services_is_not_authentic)
+               .content(R.string.PlayServicesProblemFragment__please_install_an_authentic_version_of_google_play)
                .cancelable(false)
                .positiveText(android.R.string.ok)
                .callback(new ButtonCallback() {

--- a/src/org/thoughtcrime/securesms/PlayServicesProblemFragment.java
+++ b/src/org/thoughtcrime/securesms/PlayServicesProblemFragment.java
@@ -21,15 +21,45 @@ import android.app.Dialog;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
+import android.util.Log;
 
+import com.afollestad.materialdialogs.MaterialDialog;
+import com.afollestad.materialdialogs.MaterialDialog.ButtonCallback;
+import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
 
 public class PlayServicesProblemFragment extends DialogFragment {
 
+  private Dialog getPlayServicesInvalidDialog() {
+    return new MaterialDialog.Builder(getActivity())
+               .content(R.string.PlayServicesProblemFragment__google_play_services_is_not_authentic)
+               .cancelable(false)
+               .positiveText(android.R.string.ok)
+               .callback(new ButtonCallback() {
+                 @Override
+                 public void onPositive(MaterialDialog dialog) {
+                   super.onPositive(dialog);
+                   getActivity().finish();
+                 }
+               })
+               .build();
+  }
+
   @Override
-  public Dialog onCreateDialog(@NonNull Bundle bundle) {
+  @NonNull
+  public Dialog onCreateDialog(Bundle bundle) {
     int code = GooglePlayServicesUtil.isGooglePlayServicesAvailable(getActivity());
-    return GooglePlayServicesUtil.getErrorDialog(code, getActivity(), 9111);
+
+    switch (code) {
+      case ConnectionResult.SERVICE_MISSING:
+      case ConnectionResult.SERVICE_VERSION_UPDATE_REQUIRED:
+      case ConnectionResult.SERVICE_DISABLED:
+        return GooglePlayServicesUtil.getErrorDialog(code, getActivity(), 9111);
+
+      default:
+        Log.w(getClass().getName(), "received error code " + code);
+        return getPlayServicesInvalidDialog();
+    }
   }
 
 }


### PR DESCRIPTION
GooglePlayServicesUtil.getErrorDialog() returns null when passed the error code ConnectionResult.SERVICE_INVALID so we have to provide our own error dialog for this. Error message taken directly from android documentation on this code.

1) correct placement of @NonNull annotation
2) create new string resource for service invalid error message
3) return custom dialog for ConnectionResult.SERVICE_INVALID

Fixes #2505
// FREEBIE