### PR TITLE
Added Wearable-Actions to Notifications

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -249,8 +249,11 @@ public class MessageNotifier {
     builder.setDeleteIntent(PendingIntent.getBroadcast(context, 0, new Intent(DeleteReceiver.DELETE_REMINDER_ACTION), 0));
 
     if (masterSecret != null) {
-      builder.addAction(R.drawable.check, context.getString(R.string.MessageNotifier_mark_all_as_read),
-                        notificationState.getMarkAsReadIntent(context, masterSecret));
+       NotificationCompat.Action markAllAsReadAction =
+         new NotificationCompat.Action(R.drawable.check, context.getString(R.string.MessageNotifier_mark_all_as_read),
+                                       notificationState.getMarkAsReadIntent(context, masterSecret));
+       builder.addAction(markAllAsReadAction);
+       builder.extend(new NotificationCompat.WearableExtender().addAction(markAllAsReadAction));
     }
 
     InboxStyle style = new InboxStyle();

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -196,8 +196,11 @@ public class MessageNotifier {
     if (recipient.getContactUri() != null) builder.addPerson(recipient.getContactUri().toString());
 
     if (masterSecret != null) {
-      builder.addAction(R.drawable.check, context.getString(R.string.MessageNotifier_mark_as_read),
-                        notificationState.getMarkAsReadIntent(context, masterSecret));
+      NotificationCompat.Action markAsReadAction =
+        new NotificationCompat.Action(R.drawable.check, context.getString(R.string.MessageNotifier_mark_as_read),
+                                      notificationState.getMarkAsReadIntent(context, masterSecret));
+      builder.addAction(markAsReadAction);
+      builder.extend(new NotificationCompat.WearableExtender().addAction(markAsReadAction));
     }
 
     SpannableStringBuilder content = new SpannableStringBuilder();


### PR DESCRIPTION
To better support wearable devices, I also added the notification actions via the "WearableExtender()" to the NotificationCompat.Builder.

This should give all the Android Wear-compatible device owner the possibility to mark incoming messages as read without the need to pull out their phone, aka. enable maximum laziness (but why else would you own a smart watch, right?).

Tested it with my own Pebble and worked great.