### PR TITLE
fix handling of sms:, smsto:, mms:, mmsto: URIs

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -223,7 +223,9 @@
     <activity android:name=".SmsSendtoActivity">
         <intent-filter>
             <action android:name="android.intent.action.SENDTO" />
+            <action android:name="android.intent.action.VIEW" />
             <category android:name="android.intent.category.DEFAULT" />
+            <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="sms" />
             <data android:scheme="smsto" />
             <data android:scheme="mms" />

--- a/androidTest/java/org/thoughtcrime/securesms/util/Rfc5724UriTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/util/Rfc5724UriTest.java
@@ -84,7 +84,6 @@ public class Rfc5724UriTest extends TextSecureTestCase {
   public void testGetQueryParams() throws Exception {
     final String[][] uriTestPairs = {
         {"sms:+15555555555",         "a", null},
-        {"smsto:+15555555555?a",     "a", null},
         {"mms:+15555555555?b=",      "a", null},
         {"mmsto:+15555555555?a=",    "a", ""},
         {"sms:+15555555555?a=b",     "a", "b"},

--- a/androidTest/java/org/thoughtcrime/securesms/util/Rfc5724UriTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/util/Rfc5724UriTest.java
@@ -27,28 +27,12 @@ public class Rfc5724UriTest extends TextSecureTestCase {
 
   private static final String TAG = Rfc5724UriTest.class.getSimpleName();
 
-  public void testInvalidSchemas() throws Exception {
-    final String[] invalidUris = {
-        "",
-        "+15555555555",
-        "sms+15555555555",
-        ":sms+15555555555",
-        "sms+15555555555:",
-        "+15555555555sms:"
-    };
-
-    for (String uri : invalidUris) {
-      try {
-        new Rfc5724Uri(uri);
-        Log.e(TAG, "uri " + uri + " should have failed schema check");
-        assertTrue(false);
-      } catch (URISyntaxException e) { }
-    }
-  }
-
-  public void testInvalidRecipients() throws Exception {
+  public void testInvalidPath() throws Exception {
     final String[] invalidSchemaUris = {
+        "",
+        ":",
         "sms:",
+        ":sms",
         "sms:?goto=fail",
         "sms:?goto=fail&fail=goto"
     };
@@ -56,7 +40,7 @@ public class Rfc5724UriTest extends TextSecureTestCase {
     for (String uri : invalidSchemaUris) {
       try {
         new Rfc5724Uri(uri);
-        Log.e(TAG, "uri " + uri + " should have failed recipients check");
+        Log.e(TAG, "uri " + uri + " should have failed path check");
         assertTrue(false);
       } catch (URISyntaxException e) { }
     }
@@ -78,7 +62,7 @@ public class Rfc5724UriTest extends TextSecureTestCase {
     }
   }
 
-  public void testGetRecipients() throws Exception {
+  public void testGetPath() throws Exception {
     final String[][] uriTestPairs = {
         {"sms:+15555555555",                      "+15555555555"},
         {"smsto:+15555555555?",                   "+15555555555"},
@@ -92,8 +76,8 @@ public class Rfc5724UriTest extends TextSecureTestCase {
 
     for (String[] uriTestPair : uriTestPairs) {
       final Rfc5724Uri testUri = new Rfc5724Uri(uriTestPair[0]);
-      Log.d(TAG, testUri.getRecipients() + " ?= " + uriTestPair[1]);
-      assertTrue(testUri.getRecipients().equals(uriTestPair[1]));
+      Log.d(TAG, testUri.getPath() + " ?= " + uriTestPair[1]);
+      assertTrue(testUri.getPath().equals(uriTestPair[1]));
     }
   }
 
@@ -112,7 +96,7 @@ public class Rfc5724UriTest extends TextSecureTestCase {
 
     for (String[] uriTestPair : uriTestPairs) {
       final Rfc5724Uri testUri     = new Rfc5724Uri(uriTestPair[0]);
-      final String     paramResult = testUri.getQueryParam(uriTestPair[1]);
+      final String     paramResult = testUri.getQueryParams().get(uriTestPair[1]);
 
       Log.d(TAG, paramResult + " ?= " + uriTestPair[2]);
       if (paramResult == null) assertTrue(uriTestPair[2] == null);

--- a/androidTest/java/org/thoughtcrime/securesms/util/Rfc5724UriTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/util/Rfc5724UriTest.java
@@ -46,23 +46,6 @@ public class Rfc5724UriTest extends TextSecureTestCase {
     }
   }
 
-  public void testRestrictedTokens() throws Exception {
-    final String[] invalidUris = {
-        "sms::+15555555555",
-        "sms:+15555555555??",
-        "sms:+15555555555&",
-        "sms:+15555555555&?"
-    };
-
-    for (String uri : invalidUris) {
-      try {
-        new Rfc5724Uri(uri);
-        Log.e(TAG, "uri " + uri + " should have failed restricted tokens check");
-        assertTrue(false);
-      } catch (URISyntaxException e) { }
-    }
-  }
-
   public void testInvalidRecipients() throws Exception {
     final String[] invalidSchemaUris = {
         "sms:",
@@ -90,6 +73,7 @@ public class Rfc5724UriTest extends TextSecureTestCase {
 
     for (String[] uriTestPair : uriTestPairs) {
       final Rfc5724Uri testUri = new Rfc5724Uri(uriTestPair[0]);
+      Log.d(TAG, testUri.getSchema() + " ?= " + uriTestPair[1]);
       assertTrue(testUri.getSchema().equals(uriTestPair[1]));
     }
   }
@@ -108,6 +92,7 @@ public class Rfc5724UriTest extends TextSecureTestCase {
 
     for (String[] uriTestPair : uriTestPairs) {
       final Rfc5724Uri testUri = new Rfc5724Uri(uriTestPair[0]);
+      Log.d(TAG, testUri.getRecipients() + " ?= " + uriTestPair[1]);
       assertTrue(testUri.getRecipients().equals(uriTestPair[1]));
     }
   }
@@ -129,6 +114,7 @@ public class Rfc5724UriTest extends TextSecureTestCase {
       final Rfc5724Uri testUri     = new Rfc5724Uri(uriTestPair[0]);
       final String     paramResult = testUri.getQueryParam(uriTestPair[1]);
 
+      Log.d(TAG, paramResult + " ?= " + uriTestPair[2]);
       if (paramResult == null) assertTrue(uriTestPair[2] == null);
       else                     assertTrue(paramResult.equals(uriTestPair[2]));
     }

--- a/androidTest/java/org/thoughtcrime/securesms/util/Rfc5724UriTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/util/Rfc5724UriTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.thoughtcrime.securesms.util;
+
+import android.util.Log;
+
+import org.thoughtcrime.securesms.TextSecureTestCase;
+
+import java.net.URISyntaxException;
+
+public class Rfc5724UriTest extends TextSecureTestCase {
+
+  private static final String TAG = Rfc5724UriTest.class.getSimpleName();
+
+  public void testInvalidSchemas() throws Exception {
+    final String[] invalidUris = {
+        "",
+        "+15555555555",
+        "sms+15555555555",
+        ":sms+15555555555",
+        "sms+15555555555:",
+        "+15555555555sms:"
+    };
+
+    for (String uri : invalidUris) {
+      try {
+        new Rfc5724Uri(uri);
+        Log.e(TAG, "uri " + uri + " should have failed schema check");
+        assertTrue(false);
+      } catch (URISyntaxException e) { }
+    }
+  }
+
+  public void testRestrictedTokens() throws Exception {
+    final String[] invalidUris = {
+        "sms::+15555555555",
+        "sms:+15555555555??",
+        "sms:+15555555555&",
+        "sms:+15555555555&?"
+    };
+
+    for (String uri : invalidUris) {
+      try {
+        new Rfc5724Uri(uri);
+        Log.e(TAG, "uri " + uri + " should have failed restricted tokens check");
+        assertTrue(false);
+      } catch (URISyntaxException e) { }
+    }
+  }
+
+  public void testInvalidRecipients() throws Exception {
+    final String[] invalidSchemaUris = {
+        "sms:",
+        "sms:?goto=fail",
+        "sms:?goto=fail&fail=goto"
+    };
+
+    for (String uri : invalidSchemaUris) {
+      try {
+        new Rfc5724Uri(uri);
+        Log.e(TAG, "uri " + uri + " should have failed recipients check");
+        assertTrue(false);
+      } catch (URISyntaxException e) { }
+    }
+  }
+
+  public void testGetSchema() throws Exception {
+    final String[][] uriTestPairs = {
+        {"sms:+15555555555",           "sms"},
+        {"sMs:+15555555555",           "sMs"},
+        {"smsto:+15555555555?",        "smsto"},
+        {"mms:+15555555555?a=b",       "mms"},
+        {"mmsto:+15555555555?a=b&c=d", "mmsto"}
+    };
+
+    for (String[] uriTestPair : uriTestPairs) {
+      final Rfc5724Uri testUri = new Rfc5724Uri(uriTestPair[0]);
+      assertTrue(testUri.getSchema().equals(uriTestPair[1]));
+    }
+  }
+
+  public void testGetRecipients() throws Exception {
+    final String[][] uriTestPairs = {
+        {"sms:+15555555555",                      "+15555555555"},
+        {"smsto:+15555555555?",                   "+15555555555"},
+        {"mms:+15555555555?a=b",                  "+15555555555"},
+        {"mmsto:+15555555555?a=b&c=d",            "+15555555555"},
+        {"sms:+15555555555,+14444444444",         "+15555555555,+14444444444"},
+        {"sms:+15555555555,+14444444444?",        "+15555555555,+14444444444"},
+        {"sms:+15555555555,+14444444444?a=b",     "+15555555555,+14444444444"},
+        {"sms:+15555555555,+14444444444?a=b&c=d", "+15555555555,+14444444444"}
+    };
+
+    for (String[] uriTestPair : uriTestPairs) {
+      final Rfc5724Uri testUri = new Rfc5724Uri(uriTestPair[0]);
+      assertTrue(testUri.getRecipients().equals(uriTestPair[1]));
+    }
+  }
+
+  public void testGetQueryParams() throws Exception {
+    final String[][] uriTestPairs = {
+        {"sms:+15555555555",         "a", null},
+        {"smsto:+15555555555?a",     "a", null},
+        {"mms:+15555555555?b=",      "a", null},
+        {"mmsto:+15555555555?a=",    "a", ""},
+        {"sms:+15555555555?a=b",     "a", "b"},
+        {"sms:+15555555555?a=b&c=d", "a", "b"},
+        {"sms:+15555555555?a=b&c=d", "b", null},
+        {"sms:+15555555555?a=b&c=d", "c", "d"},
+        {"sms:+15555555555?a=b&c=d", "d", null}
+    };
+
+    for (String[] uriTestPair : uriTestPairs) {
+      final Rfc5724Uri testUri     = new Rfc5724Uri(uriTestPair[0]);
+      final String     paramResult = testUri.getQueryParam(uriTestPair[1]);
+
+      if (paramResult == null) assertTrue(uriTestPair[2] == null);
+      else                     assertTrue(paramResult.equals(uriTestPair[2]));
+    }
+  }
+
+}

--- a/src/org/thoughtcrime/securesms/SmsSendtoActivity.java
+++ b/src/org/thoughtcrime/securesms/SmsSendtoActivity.java
@@ -34,8 +34,8 @@ public class SmsSendtoActivity extends Activity {
     } else {
       try {
         Rfc5724Uri smsUri = new Rfc5724Uri(original.getData().toString());
-        body = smsUri.getQueryParam("body");
-        data = smsUri.getRecipients();
+        body = smsUri.getQueryParams().get("body");
+        data = smsUri.getPath();
       } catch (URISyntaxException e) {
         Log.w(TAG, "unable to parse RFC5724 URI from intent", e);
       }

--- a/src/org/thoughtcrime/securesms/SmsSendtoActivity.java
+++ b/src/org/thoughtcrime/securesms/SmsSendtoActivity.java
@@ -3,13 +3,20 @@ package org.thoughtcrime.securesms;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.widget.Toast;
 
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.recipients.RecipientFactory;
 import org.thoughtcrime.securesms.recipients.Recipients;
+import org.thoughtcrime.securesms.util.Rfc5724Uri;
+
+import java.net.URISyntaxException;
 
 public class SmsSendtoActivity extends Activity {
+
+  private static final String TAG = SmsSendtoActivity.class.getSimpleName();
+
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     startActivity(getNextIntent(getIntent()));
@@ -18,8 +25,22 @@ public class SmsSendtoActivity extends Activity {
   }
 
   private Intent getNextIntent(Intent original) {
-    String     body       = original.getStringExtra("sms_body");
-    String     data       = original.getData().getSchemeSpecificPart();
+    String body = "";
+    String data = "";
+
+    if (original.getAction().equals(Intent.ACTION_SENDTO)) {
+      body = original.getStringExtra("sms_body");
+      data = original.getData().getSchemeSpecificPart();
+    } else {
+      try {
+        Rfc5724Uri smsUri = new Rfc5724Uri(original.getData().toString());
+        body = smsUri.getQueryParam("body");
+        data = smsUri.getRecipients();
+      } catch (URISyntaxException e) {
+        Log.w(TAG, "unable to parse RFC5724 URI from intent", e);
+      }
+    }
+
     Recipients recipients = RecipientFactory.getRecipientsFromString(this, data, false);
     long       threadId   = DatabaseFactory.getThreadDatabase(this).getThreadIdIfExistsFor(recipients);
 

--- a/src/org/thoughtcrime/securesms/util/Rfc5724Uri.java
+++ b/src/org/thoughtcrime/securesms/util/Rfc5724Uri.java
@@ -59,7 +59,7 @@ public class Rfc5724Uri {
     for (String keyValue : uri.split("\\?")[1].split("&")) {
       String[] parts = keyValue.split("=");
 
-      if(parts.length == 1) queryParams.put(parts[0], "");
+      if (parts.length == 1) queryParams.put(parts[0], "");
       else                  queryParams.put(parts[0], URLDecoder.decode(parts[1]));
     }
 

--- a/src/org/thoughtcrime/securesms/util/Rfc5724Uri.java
+++ b/src/org/thoughtcrime/securesms/util/Rfc5724Uri.java
@@ -39,20 +39,20 @@ public class Rfc5724Uri {
   private String parseSchema() throws URISyntaxException {
     String[] parts = uri.split(":");
 
-    if (parts.length < 1 || parts[0].length() < 1) throw new URISyntaxException(uri, "invalid schema");
-    else                                           return parts[0];
+    if (parts.length < 1 || parts[0].isEmpty()) throw new URISyntaxException(uri, "invalid schema");
+    else                                        return parts[0];
   }
 
   private String parsePath() throws URISyntaxException {
     String[] parts = uri.split("\\?")[0].split(":", 2);
 
-    if (parts.length < 2 || parts[1].length() < 1) throw new URISyntaxException(uri, "invalid path");
-    else                                           return parts[1];
+    if (parts.length < 2 || parts[1].isEmpty()) throw new URISyntaxException(uri, "invalid path");
+    else                                        return parts[1];
   }
 
   private Map<String, String> parseQueryParams() throws URISyntaxException {
     Map<String, String> queryParams = new HashMap<>();
-    if (!uri.contains("?") || uri.split("\\?").length < 2) {
+    if (uri.split("\\?").length < 2) {
       return queryParams;
     }
 

--- a/src/org/thoughtcrime/securesms/util/Rfc5724Uri.java
+++ b/src/org/thoughtcrime/securesms/util/Rfc5724Uri.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.thoughtcrime.securesms.util;
+
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+
+public class Rfc5724Uri {
+
+  private static final String SCHEMA_SMS   = "sms:";
+  private static final String SCHEMA_SMSTO = "smsto:";
+  private static final String SCHEMA_MMS   = "mms:";
+  private static final String SCHEMA_MMSTO = "mmsto:";
+
+  private final String uri;
+
+  public Rfc5724Uri(String uri) throws URISyntaxException {
+    this.uri = uri;
+    handleValidateUri();
+  }
+
+  private void handleValidateUri() throws URISyntaxException {
+    String uriLower = uri.toLowerCase();
+
+    if (!uriLower.startsWith(SCHEMA_SMS) && !uriLower.startsWith(SCHEMA_SMSTO) &&
+        !uriLower.startsWith(SCHEMA_MMS) && !uriLower.startsWith(SCHEMA_MMSTO))
+    {
+      throw new URISyntaxException(uri, "supplied URI does not contain a valid schema");
+    }
+
+    String[] restrictedTokens = {":", "?"};
+    for (String token : restrictedTokens) {
+      int tokenIndex = uriLower.indexOf(token);
+      if (tokenIndex >= 0 && uriLower.length() > tokenIndex + 1) {
+        if (uriLower.indexOf(token, tokenIndex + 1) >= 0) {
+          throw new URISyntaxException(uri, "supplied URI contains more than one " + token);
+        }
+      }
+    }
+
+    if (uriLower.contains("&") &&
+       (!uriLower.contains("?") || uriLower.indexOf("?") > uriLower.indexOf("&")))
+    {
+      throw new URISyntaxException(uri, "token & only allowed in query string");
+    }
+
+    if (uriLower.indexOf(":") + 1 == getUriWithoutQuery().length()) {
+      throw new URISyntaxException(uri, "supplied URI contains no recipients");
+    }
+  }
+
+  private String getUriWithoutQuery() {
+    int queryIndex = uri.indexOf("?");
+
+    if (queryIndex > 0) return uri.substring(0, queryIndex);
+    else                return uri;
+  }
+
+  public String getSchema() {
+    return uri.split(":")[0];
+  }
+
+  public String getRecipients() {
+    return getUriWithoutQuery().split(":")[1];
+  }
+
+  public String getQueryParam(String key) {
+    int startIndex  = uri.indexOf(key + "=");
+    int startOffset = key.length() + 1;
+
+    if      (startIndex < 0)                             return null;
+    else if (uri.length() <= (startIndex + startOffset)) return "";
+
+    int endIndex = uri.indexOf("&", startIndex);
+
+    if (endIndex > startIndex) return URLDecoder.decode(uri.substring(startIndex + startOffset, endIndex));
+    else                       return URLDecoder.decode(uri.substring(startIndex + startOffset));
+  }
+
+}

--- a/src/org/thoughtcrime/securesms/util/Rfc5724Uri.java
+++ b/src/org/thoughtcrime/securesms/util/Rfc5724Uri.java
@@ -59,9 +59,8 @@ public class Rfc5724Uri {
     for (String keyValue : uri.split("\\?")[1].split("&")) {
       String[] parts = keyValue.split("=");
 
-      if     (!keyValue.contains("=")) throw new URISyntaxException(uri, "");
-      else if(parts.length == 1)       queryParams.put(parts[0], "");
-      else                             queryParams.put(parts[0], URLDecoder.decode(parts[1]));
+      if(parts.length == 1) queryParams.put(parts[0], "");
+      else                  queryParams.put(parts[0], URLDecoder.decode(parts[1]));
     }
 
     return queryParams;

--- a/src/org/thoughtcrime/securesms/util/Rfc5724Uri.java
+++ b/src/org/thoughtcrime/securesms/util/Rfc5724Uri.java
@@ -57,11 +57,11 @@ public class Rfc5724Uri {
     }
 
     for (String keyValue : uri.split("\\?")[1].split("&")) {
-      if (keyValue.contains("=")) {
-        String[] parts = keyValue.split("=");
-        String   value = (parts.length == 1) ? "" : parts[1];
-        queryParams.put(parts[0], URLDecoder.decode(value));
-      }
+      String[] parts = keyValue.split("=");
+
+      if     (!keyValue.contains("=")) throw new URISyntaxException(uri, "");
+      else if(parts.length == 1)       queryParams.put(parts[0], "");
+      else                             queryParams.put(parts[0], URLDecoder.decode(parts[1]));
     }
 
     return queryParams;


### PR DESCRIPTION
1) added VIEW action and BROWSABLE category to the intent filter of SmsSendtoActivity
2) created two helper methods to make up for bugs in the processing of RFC5724 SMS URIs by android.net.Uri

Fixes #2578
// FREEBIE

tested on my Nexus 5 (A 5.1) & LG Optimus 2X (A 2.3.4).