### PR TITLE
fix for issue #3004

### DIFF
--- a/androidTest/java/org/thoughtcrime/securesms/contacts/ContactsCursorLoaderTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/contacts/ContactsCursorLoaderTest.java
@@ -1,0 +1,52 @@
+package org.thoughtcrime.securesms.contacts;
+
+import android.database.Cursor;
+import android.os.Looper;
+
+import org.thoughtcrime.securesms.TextSecureTestCase;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class ContactsCursorLoaderTest extends TextSecureTestCase {
+
+  public void setUp() throws Exception {
+    super.setUp();
+    Looper.prepare();
+  }
+
+  /*
+   loadInBackground() may have multiple threads running through it concurrently
+   depending on the android device version. Make sure concurrency does not cause
+   the code to throw exceptions.
+   */
+  public void testConcurrentDatabaseAccess() throws InterruptedException {
+    final ContactsCursorLoader loader = new ContactsCursorLoader(this.getContext(),
+            "", true);
+
+    ExecutorService exec = Executors.newFixedThreadPool(6);
+    for (int n = 0; n < 6; ++n) {
+
+      Runnable task = new Runnable() {
+        @Override
+        public void run() {
+          try {
+            Cursor csr = loader.loadInBackground();
+            assertTrue("thread execution ok", true);
+          } catch (Exception e) {
+            fail(e.getMessage());
+          }
+        }
+      };
+      exec.execute(task);
+    }
+
+    exec.shutdown();
+    boolean terminatedOk = exec.awaitTermination(4, TimeUnit.SECONDS);
+    if (!terminatedOk) {
+      fail("expected termination in less than 4 seconds, slow device?");
+    }
+  }
+}

--- a/src/org/thoughtcrime/securesms/PushContactSelectionListFragment.java
+++ b/src/org/thoughtcrime/securesms/PushContactSelectionListFragment.java
@@ -87,12 +87,6 @@ public class PushContactSelectionListFragment extends    Fragment
   }
 
   @Override
-  public void onDestroyView() {
-    super.onDestroyView();
-    ContactsDatabase.destroyInstance();
-  }
-
-  @Override
   public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     return inflater.inflate(R.layout.push_contact_selection_list_activity, container, false);
   }

--- a/src/org/thoughtcrime/securesms/contacts/ContactsCursorLoader.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactsCursorLoader.java
@@ -26,6 +26,7 @@ import android.support.v4.content.CursorLoader;
  * @author Jake McGinty
  */
 public class ContactsCursorLoader extends CursorLoader {
+  private final static Object lock = new Object();
 
   private final Context          context;
   private final String           filter;
@@ -41,13 +42,12 @@ public class ContactsCursorLoader extends CursorLoader {
 
   @Override
   public Cursor loadInBackground() {
-    ContactsDatabase.destroyInstance();
-    db = ContactsDatabase.getInstance(context);
-    return db.query(filter, pushOnly);
+    synchronized (lock) {
+      db = ContactsDatabase.getInstance(context);
+      Cursor csr = db.query(filter, pushOnly);
+      ContactsDatabase.destroyInstance();
+      return csr;
+    }
   }
 
-  @Override
-  public void onReset() {
-    super.onReset();
-  }
 }

--- a/src/org/thoughtcrime/securesms/contacts/ContactsDatabase.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactsDatabase.java
@@ -77,12 +77,12 @@ public class ContactsDatabase {
 
   private static ContactsDatabase instance = null;
 
-  public synchronized static ContactsDatabase getInstance(Context context) {
+  public static ContactsDatabase getInstance(Context context) {
     if (instance == null) instance = new ContactsDatabase(context);
     return instance;
   }
 
-  public synchronized static void destroyInstance() {
+  public static void destroyInstance() {
     if (instance != null) instance.close();
     instance = null;
   }


### PR DESCRIPTION
This exception happens when one thread is accessing the database helper through a reference after it has been closed by another thread. I have tried to do a minimal fix that will prevent this error. As a note both the original and modified versions invoke destroyInstance() which effectively destroys the in memory database with each call of loadInBackground (can be verified by adding a log statement / break point in DatabaseOpenHelper::ContactsDatabase.onCreate() ) that methodology seems like it could made more performant but since it has been performant enough so far, I am not going to be intrusive and do more. Also included is a test for this issue.  -- Best, Marc