### PR TITLE
make ListPartitionTest run during connectedCheck

### DIFF
--- a/androidTest/java/org/thoughtcrime/securesms/util/ListPartitionTest.java
+++ b/androidTest/java/org/thoughtcrime/securesms/util/ListPartitionTest.java
@@ -1,11 +1,13 @@
 package org.thoughtcrime.securesms.util;
 
+import org.thoughtcrime.securesms.TextSecureTestCase;
+
 import java.util.LinkedList;
 import java.util.List;
 
 import static junit.framework.Assert.assertEquals;
 
-public class ListPartitionTest {
+public class ListPartitionTest extends TextSecureTestCase {
 
   public void testPartitionEven() {
     List<Integer> list = new LinkedList<>();


### PR DESCRIPTION
make ListPartitionTest run during connectedCheck

Fixes #3007
// FREEBIE

@moxie0 I'm curious what build target you used to run these tests in the first place? they pass, for the record :P