### PR TITLE
maintain one ContactsDatabase instance per Loader

### DIFF
--- a/src/org/thoughtcrime/securesms/PushContactSelectionListFragment.java
+++ b/src/org/thoughtcrime/securesms/PushContactSelectionListFragment.java
@@ -87,12 +87,6 @@ public class PushContactSelectionListFragment extends    Fragment
   }
 
   @Override
-  public void onDestroyView() {
-    super.onDestroyView();
-    ContactsDatabase.destroyInstance();
-  }
-
-  @Override
   public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     return inflater.inflate(R.layout.push_contact_selection_list_activity, container, false);
   }

--- a/src/org/thoughtcrime/securesms/contacts/ContactsCursorLoader.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactsCursorLoader.java
@@ -19,6 +19,11 @@ package org.thoughtcrime.securesms.contacts;
 import android.content.Context;
 import android.database.Cursor;
 import android.support.v4.content.CursorLoader;
+import android.util.Log;
+
+import junit.framework.Assert;
+
+import java.util.concurrent.Semaphore;
 
 /**
  * CursorLoader that initializes a ContactsDatabase instance
@@ -26,11 +31,13 @@ import android.support.v4.content.CursorLoader;
  * @author Jake McGinty
  */
 public class ContactsCursorLoader extends CursorLoader {
+  private static final String TAG        = ContactsCursorLoader.class.getSimpleName();
+  private static final int    DB_PERMITS = 100;
 
   private final Context          context;
   private final String           filter;
   private final boolean          pushOnly;
-  private final Object           dbLock = new Object();
+  private final Semaphore        dbSemaphore = new Semaphore(DB_PERMITS);
   private       ContactsDatabase db;
 
   public ContactsCursorLoader(Context context, String filter, boolean pushOnly) {
@@ -43,16 +50,27 @@ public class ContactsCursorLoader extends CursorLoader {
 
   @Override
   public Cursor loadInBackground() {
-    synchronized (dbLock) {
+    try {
+      dbSemaphore.acquire();
       return db.query(filter, pushOnly);
+    } catch (InterruptedException ie) {
+      throw new AssertionError(ie);
+    } finally {
+      dbSemaphore.release();
     }
   }
 
   @Override
   public void onReset() {
-    synchronized (dbLock) {
+    Log.w(TAG, "onReset()");
+    try {
+      dbSemaphore.acquire(DB_PERMITS);
       db.close();
       db = new ContactsDatabase(context);
+    } catch (InterruptedException ie) {
+      throw new AssertionError(ie);
+    } finally {
+      dbSemaphore.release(DB_PERMITS);
     }
     super.onReset();
   }

--- a/src/org/thoughtcrime/securesms/contacts/ContactsDatabase.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactsDatabase.java
@@ -75,19 +75,7 @@ public class ContactsDatabase {
   public static final int PUSH_TYPE   = 1;
   public static final int GROUP_TYPE  = 2;
 
-  private static ContactsDatabase instance = null;
-
-  public synchronized static ContactsDatabase getInstance(Context context) {
-    if (instance == null) instance = new ContactsDatabase(context);
-    return instance;
-  }
-
-  public synchronized static void destroyInstance() {
-    if (instance != null) instance.close();
-    instance = null;
-  }
-
-  private ContactsDatabase(Context context) {
+  public ContactsDatabase(Context context) {
     this.dbHelper = new DatabaseOpenHelper(context);
     this.context  = context;
   }


### PR DESCRIPTION
A proposed alternative fix for #3004 as suggested in #3034 that removes the unnecessary singleton logic and enforces thread safety when doing database operations on the contacts db.