### PR TITLE
Fix for recipients with unusual characters in their phone number.

### DIFF
--- a/src/org/thoughtcrime/securesms/jobs/SmsSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/SmsSendJob.java
@@ -4,6 +4,7 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.telephony.PhoneNumberUtils;
 import android.telephony.SmsManager;
 import android.util.Log;
 
@@ -90,6 +91,10 @@ public class SmsSendJob extends SendJob {
     ArrayList<PendingIntent> sentIntents      = constructSentIntents(message.getId(), message.getType(), messages, false);
     ArrayList<PendingIntent> deliveredIntents = constructDeliveredIntents(message.getId(), message.getType(), messages);
     String recipient                          = message.getIndividualRecipient().getNumber();
+
+    // Remove all the separators from the phone number, since some (e.g. no-break space) can
+    // cause NPEs in SmsManager's sendTextMessage() function.
+    recipient = PhoneNumberUtils.stripSeparators(recipient);
 
     // NOTE 11/04/14 -- There's apparently a bug where for some unknown recipients
     // and messages, this will throw an NPE.  We have no idea why, so we're just


### PR DESCRIPTION
I did some debugging and found that the reason for my NullPointerException in #3096 was because there was a no-break space (Unicode code point 0xA0) in between the area code and the phone number.  After quite a bit of trial and error, I was able to reproduce this with other contacts by adding/removing non-breaking spaces.  So I just used `PhoneNumberUtils.stripSeparators()` to remove those characters so that `SmsManager` wouldn't throw any exceptions, and that solves the issue.

This might be the reason for the issue described in the note in the code.

If I had to guess where the non-breaking space came from in my contact, I would say that it had to do with the web interface of Google Contacts (but that's just speculation).