### PR TITLE
smarter MMS logic, more chance of success

### DIFF
--- a/src/org/thoughtcrime/securesms/jobs/MmsDownloadJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/MmsDownloadJob.java
@@ -12,6 +12,7 @@ import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.MmsDatabase;
 import org.thoughtcrime.securesms.jobs.requirements.MasterSecretRequirement;
 import org.thoughtcrime.securesms.mms.ApnUnavailableException;
+import org.thoughtcrime.securesms.mms.CompatMmsConnection;
 import org.thoughtcrime.securesms.mms.IncomingLollipopMmsConnection;
 import org.thoughtcrime.securesms.mms.IncomingMediaMessage;
 import org.thoughtcrime.securesms.mms.IncomingLegacyMmsConnection;
@@ -89,7 +90,7 @@ public class MmsDownloadJob extends MasterSecretJob {
 
       Log.w(TAG, "Downloading mms at " + Uri.parse(contentLocation).getHost());
 
-      RetrieveConf retrieveConf = getMmsConnection(context).retrieve(contentLocation, transactionId);
+      RetrieveConf retrieveConf = new CompatMmsConnection(context).retrieve(contentLocation, transactionId);
       if (retrieveConf == null) {
         throw new MmsException("RetrieveConf was null");
       }
@@ -120,16 +121,6 @@ public class MmsDownloadJob extends MasterSecretJob {
     } catch (InvalidMessageException e) {
       Log.w(TAG, e);
       database.markAsDecryptFailed(messageId, threadId);
-    }
-  }
-
-  private IncomingMmsConnection getMmsConnection(Context context)
-      throws ApnUnavailableException
-  {
-    if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
-      return new IncomingLollipopMmsConnection(context);
-    } else {
-      return new IncomingLegacyMmsConnection(context);
     }
   }
 

--- a/src/org/thoughtcrime/securesms/mms/CompatMmsConnection.java
+++ b/src/org/thoughtcrime/securesms/mms/CompatMmsConnection.java
@@ -1,0 +1,66 @@
+package org.thoughtcrime.securesms.mms;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import org.thoughtcrime.securesms.transport.UndeliverableMessageException;
+
+import java.io.IOException;
+import java.net.Inet6Address;
+import java.net.InterfaceAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Enumeration;
+
+import ws.com.google.android.mms.MmsException;
+import ws.com.google.android.mms.pdu.RetrieveConf;
+import ws.com.google.android.mms.pdu.SendConf;
+
+public class CompatMmsConnection implements OutgoingMmsConnection, IncomingMmsConnection {
+  private static final String TAG = CompatMmsConnection.class.getSimpleName();
+
+  private Context context;
+
+  public CompatMmsConnection(Context context) {
+    this.context = context;
+  }
+
+  @Nullable @Override public SendConf send(@NonNull byte[] pduBytes)
+      throws UndeliverableMessageException
+  {
+    try {
+      Log.w(TAG, "Sending via legacy connection");
+      return new OutgoingLegacyMmsConnection(context).send(pduBytes);
+    } catch (UndeliverableMessageException | ApnUnavailableException e) {
+      if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
+        Log.w(TAG, "Falling back to try sending via Lollipop API");
+        return new OutgoingLollipopMmsConnection(context).send(pduBytes);
+      } else {
+        throw new UndeliverableMessageException(e);
+      }
+    }
+  }
+
+  @Nullable @Override public RetrieveConf retrieve(@NonNull String contentLocation,
+                                                   byte[] transactionId)
+      throws MmsException, MmsRadioException, ApnUnavailableException, IOException
+  {
+    try {
+      Log.w(TAG, "Receiving via legacy connection");
+      return new IncomingLegacyMmsConnection(context).retrieve(contentLocation, transactionId);
+    } catch (MmsRadioException | IOException | ApnUnavailableException e) {
+      if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
+        Log.w(TAG, "Falling back to try receiving via Lollipop API");
+        return new IncomingLollipopMmsConnection(context).retrieve(contentLocation, transactionId);
+      } else {
+        throw e;
+      }
+    }
+  }
+}

--- a/src/org/thoughtcrime/securesms/mms/IncomingLegacyMmsConnection.java
+++ b/src/org/thoughtcrime/securesms/mms/IncomingLegacyMmsConnection.java
@@ -104,13 +104,9 @@ public class IncomingLegacyMmsConnection extends LegacyMmsConnection implements 
     final String  targetHost = useProxy
                              ? contentApn.getProxy()
                              : Uri.parse(contentApn.getMmsc()).getHost();
-    try {
-      if (checkRouteToHost(context, targetHost, usingMmsRadio)) {
-        Log.w(TAG, "got successful route to host " + targetHost);
-        pdu = execute(constructRequest(contentApn, useProxy));
-      }
-    } catch (IOException ioe) {
-      Log.w(TAG, ioe);
+    if (checkRouteToHost(context, targetHost, usingMmsRadio)) {
+      Log.w(TAG, "got successful route to host " + targetHost);
+      pdu = execute(constructRequest(contentApn, useProxy));
     }
 
     if (pdu == null) {

--- a/src/org/thoughtcrime/securesms/mms/LollipopMmsConnection.java
+++ b/src/org/thoughtcrime/securesms/mms/LollipopMmsConnection.java
@@ -67,7 +67,7 @@ public abstract class LollipopMmsConnection extends BroadcastReceiver {
   }
 
   protected void waitForResult() throws TimeoutException {
-    long timeoutExpiration = System.currentTimeMillis() + 30000;
+    long timeoutExpiration = System.currentTimeMillis() + 60000;
     while (!resultAvailable) {
       Util.wait(this, Math.max(1, timeoutExpiration - System.currentTimeMillis()));
       if (System.currentTimeMillis() >= timeoutExpiration) {


### PR DESCRIPTION
Instead of using only the Lollipoop API on Android > v21 (typo, but I will not change it given our success rate with that API), we'll use the legacy API with a couple changes after looking 

1. Utilize the hidden API `requestRouteToHostAddress` that takes an `InetAddress` (IPv6-capable) instead of a forced IPv4 integer-encoded address. Will fallback to the IPv4 one if reflection fails for whatever reason.
2. If on Lollipop and our manual MMS code doesn't work, will try to use the Lollipop API and give it 60 seconds instead of 30, since I did run into the timeout not being long enough in certain conditions and I'm thinking maybe it just wasn't long enough for some carriers.