### PR TITLE
 add SwitchCompat to preferences

### DIFF
--- a/res/layout/switch_compat_preference.xml
+++ b/res/layout/switch_compat_preference.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v7.widget.SwitchCompat xmlns:android="http://schemas.android.com/apk/res/android"
+                                        android:id="@android:id/checkbox"
+                                        android:layout_width="wrap_content"
+                                        android:layout_height="wrap_content"
+                                        android:background="@null"
+                                        android:clickable="false"
+                                        android:focusable="false"
+                                        android:focusableInTouchMode="false" />

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <CheckBoxPreference android:defaultValue="false"
+    <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+                        android:defaultValue="false"
                         android:key="pref_toggle_push_messaging"
                         android:title="@string/preferences__textsecure_messages"
                         android:summary="@string/preferences__use_the_data_channel_for_communication_with_other_textsecure_users"/>
 
-    <CheckBoxPreference android:defaultValue="false"
+    <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+                        android:defaultValue="false"
                         android:key="pref_enter_sends"
                         android:summary="@string/preferences__pressing_the_enter_key_will_send_text_messages"
                         android:title="@string/preferences__pref_enter_sends_title"/>

--- a/res/xml/preferences_app_protection.xml
+++ b/res/xml/preferences_app_protection.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <CheckBoxPreference android:key="pref_enable_passphrase_temporary"
+    <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+                        android:key="pref_enable_passphrase_temporary"
                         android:defaultValue="true"
                         android:title="@string/preferences__enable_passphrase"
                         android:summary="@string/preferences__enable_local_encryption_of_messages_and_keys"/>
@@ -21,7 +22,8 @@
                 android:key="pref_timeout_interval"
                 android:dependency="pref_timeout_passphrase"/>
 
-    <CheckBoxPreference android:defaultValue="true"
+    <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+                        android:defaultValue="true"
                         android:key="pref_screen_security"
                         android:title="@string/preferences__screen_security"
                         android:summary="@string/preferences__disable_screen_security_to_allow_screen_shots" />

--- a/res/xml/preferences_notifications.xml
+++ b/res/xml/preferences_notifications.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <CheckBoxPreference android:key="pref_key_enable_notifications"
+    <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+                        android:key="pref_key_enable_notifications"
                         android:title="@string/preferences__notifications"
                         android:summary="@string/preferences__display_message_notifications_in_status_bar"
                         android:defaultValue="true" />

--- a/res/xml/preferences_sms_mms.xml
+++ b/res/xml/preferences_sms_mms.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <CheckBoxPreference android:defaultValue="true"
+    <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+                        android:defaultValue="true"
                         android:key="pref_all_sms"
                         android:summary="@string/preferences__use_textsecure_for_viewing_and_storing_all_incoming_text_messages"
                         android:title="@string/preferences__pref_all_sms_title" />
 
-    <CheckBoxPreference android:defaultValue="true"
+    <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+                        android:defaultValue="true"
                         android:key="pref_all_mms"
                         android:summary="@string/preferences__use_textsecure_for_viewing_and_storing_all_incoming_multimedia_messages"
                         android:title="@string/preferences__pref_all_mms_title" />
@@ -15,12 +17,14 @@
                 android:title="@string/ApplicationPreferencesActivity_sms_disabled"
                 android:summary="@string/ApplicationPreferencesActivity_touch_to_make_textsecure_your_default_sms_app" />
 
-    <CheckBoxPreference android:defaultValue="false"
+    <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+                        android:defaultValue="false"
                         android:key="pref_delivery_report_sms"
                         android:summary="@string/preferences__request_a_delivery_report_for_each_sms_message_you_send"
                         android:title="@string/preferences__sms_delivery_reports" />
 
-    <CheckBoxPreference android:defaultValue="false"
+    <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+                        android:defaultValue="false"
                         android:key="pref_wifi_sms"
                         android:title="@string/preferences__support_wifi_calling"
                         android:summary="@string/preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi"/>

--- a/res/xml/preferences_storage.xml
+++ b/res/xml/preferences_storage.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <CheckBoxPreference android:defaultValue="false"
+    <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+                        android:defaultValue="false"
                         android:key="pref_trim_threads"
                         android:summary="@string/preferences__automatically_delete_older_messages_once_a_conversation_thread_exceeds_a_specified_length"
                         android:title="@string/preferences__delete_old_messages" />

--- a/src/org/thoughtcrime/securesms/components/SwitchPreferenceCompat.java
+++ b/src/org/thoughtcrime/securesms/components/SwitchPreferenceCompat.java
@@ -1,0 +1,37 @@
+package org.thoughtcrime.securesms.components;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.preference.CheckBoxPreference;
+import android.util.AttributeSet;
+
+import org.thoughtcrime.securesms.R;
+
+public class SwitchPreferenceCompat extends CheckBoxPreference {
+
+    public SwitchPreferenceCompat(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        setLayoutRes();
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public SwitchPreferenceCompat(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        setLayoutRes();
+    }
+
+    public SwitchPreferenceCompat(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        setLayoutRes();
+    }
+
+    public SwitchPreferenceCompat(Context context) {
+        super(context);
+        setLayoutRes();
+    }
+
+    private void setLayoutRes() {
+        setWidgetLayoutResource(R.layout.switch_compat_preference);
+    }
+}


### PR DESCRIPTION
Since https://code.google.com/p/android/issues/detail?id=78262 is fixed and we use AppCompat v22 now, it should be possible to use SwitchComapt for some preferences:

![screenshot_2015-05-08-19-21-48](https://cloud.githubusercontent.com/assets/5296073/7541722/b0cc7376-f5b7-11e4-9955-d9b02b9f9c86.png)
![screenshot_2015-05-08-19-21-55](https://cloud.githubusercontent.com/assets/5296073/7541723/b24137e6-f5b7-11e4-855b-231c98c4dd2b.png)
![screenshot_2015-05-08-19-22-05](https://cloud.githubusercontent.com/assets/5296073/7541724/b3e07332-f5b7-11e4-9351-fdc8765ddee5.png)
