### PR TITLE
Fix for occasional generated avatar mis-sizing in conversation.

### DIFF
--- a/src/org/thoughtcrime/securesms/contacts/ContactPhotoFactory.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactPhotoFactory.java
@@ -54,18 +54,24 @@ public class ContactPhotoFactory {
   }
 
   public static Drawable getDefaultContactPhoto(Context context, @Nullable String name) {
+    int targetSize = context.getResources().getDimensionPixelSize(R.dimen.contact_photo_target_size);
+
     if (name != null && !name.isEmpty()) {
-      int targetSize = context.getResources().getDimensionPixelSize(R.dimen.contact_photo_target_size);
       return TextDrawable.builder().beginConfig()
                          .width(targetSize)
                          .height(targetSize)
-                         .endConfig().buildRound(String.valueOf(name.charAt(0)),
+                         .endConfig()
+                         .buildRound(String.valueOf(name.charAt(0)),
                                                  COLOR_GENERATOR.getColor(name));
     }
 
     synchronized (defaultPhotoLock) {
       if (defaultContactPhoto == null)
-        defaultContactPhoto = TextDrawable.builder().buildRound("#", UNKNOWN_COLOR);
+        defaultContactPhoto = TextDrawable.builder().beginConfig()
+                                          .width(targetSize)
+                                          .height(targetSize)
+                                          .endConfig()
+                                          .buildRound("#", UNKNOWN_COLOR);
 
       return defaultContactPhoto;
     }

--- a/src/org/thoughtcrime/securesms/contacts/ContactPhotoFactory.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactPhotoFactory.java
@@ -1,17 +1,8 @@
 package org.thoughtcrime.securesms.contacts;
 
 import android.content.Context;
-import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.graphics.Canvas;
-import android.graphics.Color;
-import android.graphics.ColorFilter;
-import android.graphics.Matrix;
-import android.graphics.Paint;
-import android.graphics.PixelFormat;
-import android.graphics.drawable.BitmapDrawable;
-import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
 import android.net.Uri;
@@ -20,7 +11,6 @@ import android.os.Build.VERSION_CODES;
 import android.provider.ContactsContract;
 import android.support.annotation.Nullable;
 import android.util.Log;
-import android.view.Gravity;
 import android.widget.ImageView;
 
 import com.amulyakhare.textdrawable.TextDrawable;
@@ -63,10 +53,14 @@ public class ContactPhotoFactory {
     }
   }
 
-  public static Drawable getDefaultContactPhoto(@Nullable String name) {
+  public static Drawable getDefaultContactPhoto(Context context, @Nullable String name) {
     if (name != null && !name.isEmpty()) {
-      return TextDrawable.builder().buildRound(String.valueOf(name.charAt(0)),
-                                               COLOR_GENERATOR.getColor(name));
+      int targetSize = context.getResources().getDimensionPixelSize(R.dimen.contact_photo_target_size);
+      return TextDrawable.builder().beginConfig()
+                         .width(targetSize)
+                         .height(targetSize)
+                         .endConfig().buildRound(String.valueOf(name.charAt(0)),
+                                                 COLOR_GENERATOR.getColor(name));
     }
 
     synchronized (defaultPhotoLock) {
@@ -118,7 +112,7 @@ public class ContactPhotoFactory {
       }
     }
 
-    return getDefaultContactPhoto(name);
+    return getDefaultContactPhoto(context, name);
   }
 
   public static Drawable getGroupContactPhoto(Context context, @Nullable byte[] avatar) {

--- a/src/org/thoughtcrime/securesms/recipients/Recipient.java
+++ b/src/org/thoughtcrime/securesms/recipients/Recipient.java
@@ -147,7 +147,7 @@ public class Recipient {
 
   public static Recipient getUnknownRecipient(Context context) {
     return new Recipient("Unknown", "Unknown", -1, null,
-                         ContactPhotoFactory.getDefaultContactPhoto(null));
+                         ContactPhotoFactory.getDefaultContactPhoto(context, null));
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/recipients/RecipientProvider.java
+++ b/src/org/thoughtcrime/securesms/recipients/RecipientProvider.java
@@ -75,7 +75,7 @@ public class RecipientProvider {
     } else {
       final Drawable defaultPhoto        = isGroupRecipient
                                            ? ContactPhotoFactory.getDefaultGroupPhoto(context)
-                                           : ContactPhotoFactory.getDefaultContactPhoto(null);
+                                           : ContactPhotoFactory.getDefaultContactPhoto(context, null);
 
       recipient = new Recipient(null, number, recipientId, null, defaultPhoto);
     }
@@ -143,7 +143,7 @@ public class RecipientProvider {
         cursor.close();
     }
 
-    return new RecipientDetails(null, number, null, ContactPhotoFactory.getDefaultContactPhoto(null));
+    return new RecipientDetails(null, number, null, ContactPhotoFactory.getDefaultContactPhoto(context, null));
   }
 
   private RecipientDetails getGroupRecipientDetails(Context context, String groupId) {

--- a/src/org/thoughtcrime/securesms/recipients/RecipientProvider.java
+++ b/src/org/thoughtcrime/securesms/recipients/RecipientProvider.java
@@ -133,9 +133,10 @@ public class RecipientProvider {
     try {
       if (cursor != null && cursor.moveToFirst()) {
         Uri      contactUri   = Contacts.getLookupUri(cursor.getLong(2), cursor.getString(1));
+        String   name         = cursor.getString(3).equals(cursor.getString(0)) ? null : cursor.getString(0);
         Drawable contactPhoto = ContactPhotoFactory.getContactPhoto(context,
-                                                                    Uri.withAppendedPath(Contacts.CONTENT_URI, cursor.getLong(2)+""),
-                                                                    cursor.getString(0));
+                                                                    Uri.withAppendedPath(Contacts.CONTENT_URI, cursor.getLong(2) + ""),
+                                                                    name);
         return new RecipientDetails(cursor.getString(0), cursor.getString(3), contactUri, contactPhoto);
       }
     } finally {


### PR DESCRIPTION
Drawables are (strangely) mutable objects.  We reuse a single
drawable for each recipient, but some avatar views (the
conversation list -- 40dp) are larger than others (the
conversation -- 30dp).

This results in a situation where TextDrawable doesn't render
itself appropriately, because the bounds are modified by a larger
view.

Giving the Drawable an intrinsic width and height resolves this
conflict.

// FREEBIE