### PR TITLE
no more Release.java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,6 +156,8 @@ android {
         exclude 'LICENSE'
         exclude 'NOTICE'
         exclude 'asm-license.txt'
+        exclude 'META-INF/LICENSE'
+        exclude 'META-INF/NOTICE'
     }
 
     signingConfigs {
@@ -206,11 +208,6 @@ android {
             aidl.srcDirs = ['androidTest/java']
             renderscript.srcDirs = ['androidTest/java']
         }
-    }
-
-    packagingOptions {
-        exclude 'META-INF/LICENSE'
-        exclude 'META-INF/NOTICE'
     }
 
      lintOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -143,6 +143,7 @@ android {
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         buildConfigField "long", "BUILD_TIMESTAMP", System.currentTimeMillis() + "L"
+        buildConfigField "String", "PUSH_URL", "\"https://textsecure-service.whispersystems.org\""
     }
 
     compileOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -181,19 +181,7 @@ android {
         }
         release {
             minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'),
-                          'proguard-google-play-services.pro',
-                          'proguard-dagger.pro',
-                          'proguard-jackson.pro',
-                          'proguard-sqlite.pro',
-                          'proguard-appcompat-v7.pro',
-                          'proguard-square-okhttp.pro',
-                          'proguard-square-okio.pro',
-                          'proguard-spongycastle.pro',
-                          'proguard-rounded-image-view.pro',
-                          'proguard-glide.pro',
-                          'proguard-shortcutbadger.pro',
-                          'proguard.cfg'
+            proguardFiles = buildTypes.debug.proguardFiles
             signingConfig signingConfigs.release
         }
         testing.initWith(buildTypes.debug)

--- a/src/org/thoughtcrime/securesms/Release.java
+++ b/src/org/thoughtcrime/securesms/Release.java
@@ -1,7 +1,0 @@
-package org.thoughtcrime.securesms;
-
-public class Release {
-
-  public static final String PUSH_URL = "https://textsecure-service.whispersystems.org";
-//  public static final String PUSH_URL = "http://192.168.1.135:8080";
-}

--- a/src/org/thoughtcrime/securesms/dependencies/TextSecureCommunicationModule.java
+++ b/src/org/thoughtcrime/securesms/dependencies/TextSecureCommunicationModule.java
@@ -2,7 +2,7 @@ package org.thoughtcrime.securesms.dependencies;
 
 import android.content.Context;
 
-import org.thoughtcrime.securesms.Release;
+import org.thoughtcrime.securesms.BuildConfig;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.crypto.storage.TextSecureAxolotlStore;
 import org.thoughtcrime.securesms.jobs.AttachmentDownloadJob;
@@ -47,7 +47,7 @@ public class TextSecureCommunicationModule {
   }
 
   @Provides TextSecureAccountManager provideTextSecureAccountManager() {
-    return new TextSecureAccountManager(Release.PUSH_URL,
+    return new TextSecureAccountManager(BuildConfig.PUSH_URL,
                                         new TextSecurePushTrustStore(context),
                                         TextSecurePreferences.getLocalNumber(context),
                                         TextSecurePreferences.getPushServerPassword(context));
@@ -57,7 +57,7 @@ public class TextSecureCommunicationModule {
     return new TextSecureMessageSenderFactory() {
       @Override
       public TextSecureMessageSender create(MasterSecret masterSecret) {
-        return new TextSecureMessageSender(Release.PUSH_URL,
+        return new TextSecureMessageSender(BuildConfig.PUSH_URL,
                                            new TextSecurePushTrustStore(context),
                                            TextSecurePreferences.getLocalNumber(context),
                                            TextSecurePreferences.getPushServerPassword(context),
@@ -69,7 +69,7 @@ public class TextSecureCommunicationModule {
   }
 
   @Provides TextSecureMessageReceiver provideTextSecureMessageReceiver() {
-    return new TextSecureMessageReceiver(Release.PUSH_URL,
+    return new TextSecureMessageReceiver(BuildConfig.PUSH_URL,
                                          new TextSecurePushTrustStore(context),
                                          new DynamicCredentialsProvider(context));
   }

--- a/src/org/thoughtcrime/securesms/jobs/AvatarDownloadJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/AvatarDownloadJob.java
@@ -5,7 +5,7 @@ import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.util.Log;
 
-import org.thoughtcrime.securesms.Release;
+import org.thoughtcrime.securesms.BuildConfig;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.GroupDatabase;
@@ -95,7 +95,7 @@ public class AvatarDownloadJob extends MasterSecretJob {
   }
 
   private File downloadAttachment(String relay, long contentLocation) throws IOException {
-    PushServiceSocket socket = new PushServiceSocket(Release.PUSH_URL,
+    PushServiceSocket socket = new PushServiceSocket(BuildConfig.PUSH_URL,
                                                      new TextSecurePushTrustStore(context),
                                                      new StaticCredentialsProvider(TextSecurePreferences.getLocalNumber(context),
                                                                                    TextSecurePreferences.getPushServerPassword(context),

--- a/src/org/thoughtcrime/securesms/push/TextSecureCommunicationFactory.java
+++ b/src/org/thoughtcrime/securesms/push/TextSecureCommunicationFactory.java
@@ -2,7 +2,7 @@ package org.thoughtcrime.securesms.push;
 
 import android.content.Context;
 
-import org.thoughtcrime.securesms.Release;
+import org.thoughtcrime.securesms.BuildConfig;
 import org.thoughtcrime.securesms.crypto.SecurityEvent;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.crypto.storage.TextSecureAxolotlStore;
@@ -20,14 +20,14 @@ import static org.whispersystems.textsecure.api.TextSecureMessageSender.EventLis
 public class TextSecureCommunicationFactory {
 
   public static TextSecureAccountManager createManager(Context context) {
-    return new TextSecureAccountManager(Release.PUSH_URL,
+    return new TextSecureAccountManager(BuildConfig.PUSH_URL,
                                         new TextSecurePushTrustStore(context),
                                         TextSecurePreferences.getLocalNumber(context),
                                         TextSecurePreferences.getPushServerPassword(context));
   }
 
   public static TextSecureAccountManager createManager(Context context, String number, String password) {
-    return new TextSecureAccountManager(Release.PUSH_URL, new TextSecurePushTrustStore(context),
+    return new TextSecureAccountManager(BuildConfig.PUSH_URL, new TextSecurePushTrustStore(context),
                                         number, password);
   }
 


### PR DESCRIPTION
1) move PUSH_URL from Release.java into BuildConfig.java
2) avoid redeclaration of proguard files, prevents future #3127
3) move all packagingOptions exclusions into a single closure

the first is necessary for my upcoming espresso test PR, the second and third make our build file more readable which makes espresso test related changes easier to create and understand.