### PR TITLE
Espresso tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ tests
 lint.xml
 local.properties
 ant.properties
+gradle.properties
 .DS_Store
 build.log
 build-log.xml
@@ -19,3 +20,4 @@ build
 signing.properties
 library/lib/
 library/obj/
+espressoTest/res/values/arrays.xml

--- a/androidTest/java/org/thoughtcrime/securesms/util/SmsUtil.java
+++ b/androidTest/java/org/thoughtcrime/securesms/util/SmsUtil.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms.util;
+
+import android.annotation.SuppressLint;
+import android.content.Intent;
+import android.os.Bundle;
+import android.provider.Telephony;
+import android.telephony.PhoneNumberUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Method;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SmsUtil {
+
+  private static byte reverseByte(byte b) {
+    return (byte) ((b & 0xF0) >> 4 | (b & 0x0F) << 4);
+  }
+
+  /*
+  credit :D
+  http://stackoverflow.com/a/12338541
+   */
+  public static byte[] buildSmsPdu(String senderPstnNumber, String body) throws Exception{
+    byte[]   scBytes     = PhoneNumberUtils.networkPortionToCalledPartyBCD("0000000000");
+    byte[]   senderBytes = PhoneNumberUtils.networkPortionToCalledPartyBCD(senderPstnNumber);
+    int      lsmcs       = scBytes.length;
+    byte[]   dateBytes   = new byte[7];
+    Calendar calendar    = new GregorianCalendar();
+
+    dateBytes[0] = reverseByte((byte) (calendar.get(Calendar.YEAR)));
+    dateBytes[1] = reverseByte((byte) (calendar.get(Calendar.MONTH) + 1));
+    dateBytes[2] = reverseByte((byte) (calendar.get(Calendar.DAY_OF_MONTH)));
+    dateBytes[3] = reverseByte((byte) (calendar.get(Calendar.HOUR_OF_DAY)));
+    dateBytes[4] = reverseByte((byte) (calendar.get(Calendar.MINUTE)));
+    dateBytes[5] = reverseByte((byte) (calendar.get(Calendar.SECOND)));
+    dateBytes[6] = reverseByte((byte) ((calendar.get(Calendar.ZONE_OFFSET) + calendar.get(Calendar.DST_OFFSET)) / (60 * 1000 * 15)));
+
+    ByteArrayOutputStream bo = new ByteArrayOutputStream();
+    bo.write(lsmcs);
+    bo.write(scBytes);
+    bo.write(0x04);
+    bo.write((byte) senderPstnNumber.length());
+    bo.write(senderBytes);
+    bo.write(0x00);
+    bo.write(0x00);
+    bo.write(dateBytes);
+
+    String sReflectedClassName   = "com.android.internal.telephony.GsmAlphabet";
+    Class  cReflectedNFCExtras   = Class.forName(sReflectedClassName);
+    Method stringToGsm7BitPacked = cReflectedNFCExtras.getMethod("stringToGsm7BitPacked", new Class[] { String.class });
+
+    stringToGsm7BitPacked.setAccessible(true);
+    byte[] bodybytes = (byte[]) stringToGsm7BitPacked.invoke(null, body);
+    bo.write(bodybytes);
+
+    return bo.toByteArray();
+  }
+
+  @SuppressLint("NewApi")
+  public static Intent buildSmsReceivedIntent(String senderPstnNumber, String smsBody) throws Exception {
+    final Intent smsIntent = mock(Intent.class);
+    final Bundle smsExtras = new Bundle();
+    final byte[] smsPdu    = SmsUtil.buildSmsPdu(senderPstnNumber, smsBody);
+
+    smsExtras.putSerializable("pdus", new Object[]{smsPdu});
+
+    when(smsIntent.getAction()).thenReturn(Telephony.Sms.Intents.SMS_RECEIVED_ACTION);
+    when(smsIntent.getExtras()).thenReturn(smsExtras);
+
+    return smsIntent;
+  }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -78,10 +78,9 @@ dependencies {
     androidTestCompile ('com.squareup.assertj:assertj-android:1.0.0') {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
-    androidTestCompile ('com.android.support.test.espresso:espresso-core:2.0') {
+    androidTestCompile ('com.android.support.test.espresso:espresso-core:2.1') {
         exclude group: 'javax.inject'
     }
-    androidTestCompile 'com.android.support.test:testing-support-lib:0.1'
 }
 
 dependencyVerification {
@@ -189,6 +188,7 @@ android {
         testing.initWith(buildTypes.debug)
         testing {
             proguardFile 'proguard-testing.pro'
+            buildConfigField "String", "PUSH_URL", "\"https://textsecure-service-staging.whispersystems.org\""
         }
     }
 
@@ -204,9 +204,6 @@ android {
         }
         androidTest {
             java.srcDirs = ['androidTest/java']
-            resources.srcDirs = ['androidTest/java']
-            aidl.srcDirs = ['androidTest/java']
-            renderscript.srcDirs = ['androidTest/java']
         }
     }
 
@@ -244,4 +241,11 @@ if (propFile.canRead()){
 }else {
     println 'signing.properties not found'
     android.buildTypes.release.signingConfig = null
+}
+
+if (project.hasProperty('espresso')) {
+    android.sourceSets.androidTest {
+        java.srcDirs = ['androidTest/java', 'espressoTest/java']
+        res.srcDirs  = ['espressoTest/res']
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -156,6 +156,8 @@ android {
         exclude 'LICENSE'
         exclude 'NOTICE'
         exclude 'asm-license.txt'
+        exclude 'META-INF/LICENSE'
+        exclude 'META-INF/NOTICE'
     }
 
     signingConfigs {
@@ -206,11 +208,6 @@ android {
             aidl.srcDirs = ['androidTest/java']
             renderscript.srcDirs = ['androidTest/java']
         }
-    }
-
-    packagingOptions {
-        exclude 'META-INF/LICENSE'
-        exclude 'META-INF/NOTICE'
     }
 
      lintOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -143,6 +143,7 @@ android {
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         buildConfigField "long", "BUILD_TIMESTAMP", System.currentTimeMillis() + "L"
+        buildConfigField "String", "PUSH_URL", "\"https://textsecure-service.whispersystems.org\""
     }
 
     compileOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -181,19 +181,7 @@ android {
         }
         release {
             minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'),
-                          'proguard-google-play-services.pro',
-                          'proguard-dagger.pro',
-                          'proguard-jackson.pro',
-                          'proguard-sqlite.pro',
-                          'proguard-appcompat-v7.pro',
-                          'proguard-square-okhttp.pro',
-                          'proguard-square-okio.pro',
-                          'proguard-spongycastle.pro',
-                          'proguard-rounded-image-view.pro',
-                          'proguard-glide.pro',
-                          'proguard-shortcutbadger.pro',
-                          'proguard.cfg'
+            proguardFiles = buildTypes.debug.proguardFiles
             signingConfig signingConfigs.release
         }
         testing.initWith(buildTypes.debug)

--- a/espressoTest/java/org/thoughtcrime/securesms/ApplicationPreferencesActivityActions.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/ApplicationPreferencesActivityActions.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import org.hamcrest.Matchers;
+
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.matcher.PreferenceMatchers.withKey;
+
+public class ApplicationPreferencesActivityActions {
+
+  public static void clickSmsAndMmsSetting() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("preference_category_sms_mms"))).perform(click());
+  }
+
+  public static void clickNotificationsSetting() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("preference_category_notifications"))).perform(click());
+  }
+
+  public static void clickAppProtectionSetting() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("preference_category_app_protection"))).perform(click());
+  }
+
+  public static void clickAppearanceSetting() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("preference_category_appearance"))).perform(click());
+  }
+
+  public static void clickDeleteOldMessagesSetting() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("preference_category_storage"))).perform(click());
+  }
+
+  public static void clickAdvancedSetting() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("preference_category_advanced"))).perform(click());
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/ApplicationPreferencesActivityTest.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/ApplicationPreferencesActivityTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import android.test.suitebuilder.annotation.LargeTest;
+
+import org.hamcrest.Matchers;
+
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.PreferenceMatchers.withKey;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static org.thoughtcrime.securesms.EspressoUtil.waitOn;
+
+@LargeTest
+public class ApplicationPreferencesActivityTest extends TextSecureEspressoTestCase<ConversationListActivity> {
+
+  public ApplicationPreferencesActivityTest() {
+    super(ConversationListActivity.class);
+  }
+
+  private void checkAllPreferencesDisplayed() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("preference_category_sms_mms")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("preference_category_notifications")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("preference_category_app_protection")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("preference_category_appearance")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("preference_category_storage")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("preference_category_advanced")))
+          .check(matches(isDisplayed()));
+  }
+
+  public void testClickSettings() throws Exception {
+    loadActivity(ConversationListActivity.class, STATE_REGISTRATION_SKIPPED);
+    ConversationListActivityActions.clickSettings(getContext());
+    waitOn(ApplicationPreferencesActivity.class);
+    checkAllPreferencesDisplayed();
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/ConversationActivityActions.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/ConversationActivityActions.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import android.content.Context;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.thoughtcrime.securesms.EspressoUtil.typeTextAndCloseKeyboard;
+
+public class ConversationActivityActions {
+
+  public static void clickAddAttachment(Context context) throws Exception {
+    openActionBarOverflowOrOptionsMenu(context);
+    onView(withText(R.string.conversation__menu_add_attachment)).perform(click());
+  }
+
+  public static void clickAllImages(Context context) throws Exception {
+    openActionBarOverflowOrOptionsMenu(context);
+    onView(withText(R.string.conversation__menu_view_media)).perform(click());
+  }
+
+  public static void clickDeleteThread(Context context) throws Exception {
+    openActionBarOverflowOrOptionsMenu(context);
+    onView(withText(R.string.conversation__menu_delete_thread)).perform(click());
+  }
+
+  public static void toggleEmojiKeyboard() throws Exception {
+    onView(withId(R.id.emoji_toggle)).perform(click());
+  }
+
+  public static void typeMessage(String message) throws Exception {
+    typeTextAndCloseKeyboard(onView(withId(R.id.embedded_text_editor)), message);
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/ConversationListActivityActions.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/ConversationListActivityActions.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import android.content.Context;
+
+import org.thoughtcrime.securesms.R;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+public class ConversationListActivityActions {
+
+  public static void dismissReminder() throws Exception {
+    onView(withId(R.id.cancel)).perform(click());
+  }
+
+  public static void clickNewConversation() throws Exception {
+    onView(withId(R.id.fab)).perform(click());
+  }
+
+  public static void clickNewGroup(Context context) throws Exception {
+    openActionBarOverflowOrOptionsMenu(context);
+    onView(withText(R.string.text_secure_normal__menu_new_group)).perform(click());
+  }
+
+  public static void clickLock(Context context) throws Exception {
+    openActionBarOverflowOrOptionsMenu(context);
+    onView(withText(R.string.text_secure_normal__menu_clear_passphrase)).perform(click());
+  }
+
+  public static void clickMarkAllRead(Context context) throws Exception {
+    openActionBarOverflowOrOptionsMenu(context);
+    onView(withText(R.string.text_secure_normal__mark_all_as_read)).perform(click());
+  }
+
+  public static void clickImportExport(Context context) throws Exception {
+    openActionBarOverflowOrOptionsMenu(context);
+    onView(withText(R.string.arrays__import_export)).perform(click());
+  }
+
+  public static void clickMyIdentity(Context context) throws Exception {
+    openActionBarOverflowOrOptionsMenu(context);
+    onView(withText(R.string.arrays__my_identity_key)).perform(click());
+  }
+
+  public static void clickSettings(Context context) throws Exception {
+    openActionBarOverflowOrOptionsMenu(context);
+    onView(withText(R.string.text_secure_normal__menu_settings)).perform(click());
+  }
+
+  public static void deleteSelected() throws Exception {
+    onView(withId(R.id.menu_delete_selected)).perform(click());
+    onView(withText(R.string.delete)).perform(click());
+  }
+
+  public static void cancelDeleteSelected() throws Exception {
+    onView(withId(R.id.menu_delete_selected)).perform(click());
+    onView(withText(android.R.string.cancel)).perform(click());
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/ConversationListActivityTest.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/ConversationListActivityTest.java
@@ -1,0 +1,279 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import android.test.suitebuilder.annotation.LargeTest;
+import android.util.Log;
+import android.widget.TextView;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.thoughtcrime.securesms.components.DefaultSmsReminder;
+import org.thoughtcrime.securesms.components.ExpiredBuildReminder;
+import org.thoughtcrime.securesms.components.PushRegistrationReminder;
+import org.thoughtcrime.securesms.components.SystemSmsImportReminder;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static android.support.test.espresso.Espresso.pressBack;
+import static android.support.test.espresso.action.ViewActions.longClick;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.allOf;
+import static org.thoughtcrime.securesms.EspressoUtil.addContact;
+import static org.thoughtcrime.securesms.EspressoUtil.waitOn;
+import static org.thoughtcrime.securesms.ViewMatchers.withRecyclerItem;
+import static org.thoughtcrime.securesms.ViewMatchers.withRecyclerItemCount;
+
+@LargeTest
+public class ConversationListActivityTest extends TextSecureEspressoTestCase<ConversationListActivity> {
+  private final static String TAG = ConversationListActivityTest.class.getSimpleName();
+
+  public ConversationListActivityTest() {
+    super(ConversationListActivity.class);
+  }
+
+  private void checkOptionsMenuItemsDisplayed() throws Exception {
+    onView(withContentDescription(getContext().getString(R.string.conversation_list__menu_search)))
+          .check(matches(isDisplayed()));
+
+    openActionBarOverflowOrOptionsMenu(getContext());
+    onView(withText(R.string.text_secure_normal__menu_new_group)).check(matches(isDisplayed()));
+    onView(withText(R.string.text_secure_normal__mark_all_as_read)).check(matches(isDisplayed()));
+    onView(withText(R.string.arrays__import_export)).check(matches(isDisplayed()));
+    onView(withText(R.string.arrays__my_identity_key)).check(matches(isDisplayed()));
+    onView(withText(R.string.text_secure_normal__menu_settings)).check(matches(isDisplayed()));
+
+    if (!TextSecurePreferences.isPasswordDisabled(getContext())) {
+      onView(withText(R.string.text_secure_normal__menu_clear_passphrase))
+            .check(matches(isDisplayed()));
+    }
+
+    pressBack();
+  }
+
+  private boolean checkReminderIsDisplayed() throws Exception {
+    boolean reminderVisible    = true;
+    Integer reminderTitleResId = null;
+    Integer reminderTextResId  = null;
+
+    if (ExpiredBuildReminder.isEligible(getContext())) {
+      reminderTitleResId = R.string.reminder_header_expired_build;
+      reminderTextResId  = R.string.reminder_header_expired_build_details;
+    } else if (DefaultSmsReminder.isEligible(getContext())) {
+      reminderTitleResId = R.string.reminder_header_sms_default_title;
+      reminderTextResId  = R.string.reminder_header_sms_default_text;
+    } else if (SystemSmsImportReminder.isEligible(getContext())) {
+      reminderTitleResId = R.string.reminder_header_sms_import_title;
+      reminderTextResId  = R.string.reminder_header_sms_import_text;
+    } else if (PushRegistrationReminder.isEligible(getContext())) {
+      reminderTitleResId = R.string.reminder_header_push_title;
+      reminderTextResId  = R.string.reminder_header_push_text;
+    } else {
+      reminderVisible = false;
+    }
+
+    if (reminderVisible) {
+      onView(withId(R.id.reminder_title)).check(matches(isDisplayed()));
+      onView(withId(R.id.reminder_title)).check(matches(withText(reminderTitleResId)));
+      onView(withId(R.id.reminder_text)).check(matches(isDisplayed()));
+      onView(withId(R.id.reminder_text)).check(matches(withText(reminderTextResId)));
+    }
+
+    return reminderVisible;
+  }
+
+  private void loadAndCheckState() throws Exception {
+    loadActivity(ConversationListActivity.class, STATE_REGISTRATION_SKIPPED);
+    checkOptionsMenuItemsDisplayed();
+    checkReminderIsDisplayed();
+  }
+
+  public void testDismissAllReminders() throws Exception {
+    loadAndCheckState();
+
+    int expectedReminders = 0;
+    if (ExpiredBuildReminder.isEligible(getContext()))    expectedReminders++;
+    if (DefaultSmsReminder.isEligible(getContext()))      expectedReminders++;
+    if (SystemSmsImportReminder.isEligible(getContext())) expectedReminders++;
+
+    Log.d(TAG, "expecting to see " + expectedReminders + " reminders");
+    while (expectedReminders > 0) {
+      if (!checkReminderIsDisplayed()) {
+        throw new IllegalStateException("expected to see " + expectedReminders + " more reminders");
+      }
+
+      Log.d(TAG, "found reminder, dismissing now");
+      ConversationListActivityActions.dismissReminder();
+      expectedReminders--;
+
+      ConversationListActivityActions.clickSettings(getContext());
+      waitOn(ApplicationPreferencesActivity.class);
+      pressBack();
+      waitOn(ConversationListActivity.class);
+    }
+
+    if (checkReminderIsDisplayed() && !PushRegistrationReminder.isEligible(getContext())) {
+      throw new IllegalStateException("only expected to see " + expectedReminders + " reminders");
+    }
+  }
+
+  public void testClickNewConversation() throws Exception {
+    loadAndCheckState();
+    ConversationListActivityActions.clickNewConversation();
+    waitOn(NewConversationActivity.class);
+  }
+
+  public void testClickNewGroup() throws Exception {
+    loadAndCheckState();
+    ConversationListActivityActions.clickNewGroup(getContext());
+    waitOn(GroupCreateActivity.class);
+  }
+
+  public void testClickImportExport() throws Exception {
+    loadAndCheckState();
+    ConversationListActivityActions.clickImportExport(getContext());
+    waitOn(ImportExportActivity.class);
+  }
+
+  public void testClickMyIdentity() throws Exception {
+    loadAndCheckState();
+    ConversationListActivityActions.clickMyIdentity(getContext());
+    waitOn(ViewLocalIdentityActivity.class);
+  }
+
+  public void testClickSettings() throws Exception {
+    loadAndCheckState();
+    ConversationListActivityActions.clickSettings(getContext());
+    waitOn(ApplicationPreferencesActivity.class);
+  }
+
+  public static Matcher<Object> isThreadFrom(final String contactName) {
+    return new TypeSafeMatcher<Object>() {
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("is thread from: " + contactName);
+      }
+
+      @Override
+      public boolean matchesSafely(Object object) {
+        if (!(object instanceof ConversationListItem)) {
+          return false;
+        }
+
+        ConversationListItem itemView = (ConversationListItem) object;
+        TextView             fromView = (TextView) itemView.findViewById(R.id.from);
+        return fromView.getText().toString().equals(contactName);
+      }
+    };
+  }
+
+  public static Matcher<Object> withThreadSnippet(final String snippet) {
+    return new TypeSafeMatcher<Object>() {
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("is thread with snippet: " + snippet);
+      }
+
+      @Override
+      public boolean matchesSafely(Object object) {
+        if (!(object instanceof ConversationListItem)) {
+          return false;
+        }
+
+        ConversationListItem itemView    = (ConversationListItem) object;
+        TextView             snippetView = (TextView) itemView.findViewById(R.id.subject);
+        return snippetView.getText().toString().equals(snippet);
+      }
+    };
+  }
+
+  @SuppressWarnings("unchecked")
+  public void testSaveTextDraft() throws Exception {
+    final String CONTACT_NAME   = "Clement Duval";
+    final String CONTACT_NUMBER = "55555555555";
+    final String DRAFT_MESSAGE  = "I struck him in the name of liberty";
+    final String DRAFT_SNIPPET  = getContext().getString(R.string.ThreadRecord_draft) + " " + DRAFT_MESSAGE;
+
+    addContact(getContext(), CONTACT_NAME, CONTACT_NUMBER);
+    loadAndCheckState();
+
+    ConversationListActivityActions.clickNewConversation();
+    waitOn(NewConversationActivity.class);
+    NewConversationActivityActions.clickContactWithName(CONTACT_NAME);
+    waitOn(ConversationActivity.class);
+    ConversationActivityActions.typeMessage(DRAFT_MESSAGE);
+    pressBack();
+    waitOn(ConversationListActivity.class);
+
+    onView(withId(R.id.list)).check(matches(
+        withRecyclerItemCount(1L)
+    ));
+    onView(withId(R.id.list)).check(matches(
+        withRecyclerItem(allOf(
+            isDisplayed(),
+            isThreadFrom(CONTACT_NAME),
+            withThreadSnippet(DRAFT_SNIPPET)))
+    ));
+  }
+
+  /*
+  this is known to fail on some older devices due to some espresso
+  related app-compat bug
+   */
+  @SuppressWarnings("unchecked")
+  public void testSaveDeleteTextDraft() throws Exception {
+    final String CONTACT_NAME   = "Clement Duval";
+    final String CONTACT_NUMBER = "55555555555";
+    final String DRAFT_MESSAGE  = "I struck him in the name of liberty";
+    final String DRAFT_SNIPPET  = getContext().getString(R.string.ThreadRecord_draft) + " " + DRAFT_MESSAGE;
+
+    addContact(getContext(), CONTACT_NAME, CONTACT_NUMBER);
+    loadAndCheckState();
+
+    ConversationListActivityActions.clickNewConversation();
+    waitOn(NewConversationActivity.class);
+    NewConversationActivityActions.clickContactWithName(CONTACT_NAME);
+    waitOn(ConversationActivity.class);
+    ConversationActivityActions.typeMessage(DRAFT_MESSAGE);
+    pressBack();
+    waitOn(ConversationListActivity.class);
+
+    onView(withId(R.id.list)).check(matches(
+        withRecyclerItemCount(1L)
+    ));
+    onView(withId(R.id.list)).check(matches(
+        withRecyclerItem(allOf(
+            isDisplayed(),
+            isThreadFrom(CONTACT_NAME),
+            withThreadSnippet(DRAFT_SNIPPET)))
+    ));
+
+    onView(withText(CONTACT_NAME)).perform(longClick());
+    ConversationListActivityActions.deleteSelected();
+
+    onView(withId(R.id.list)).check(matches(
+        withRecyclerItemCount(0L)
+    ));
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/EspressoUtil.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/EspressoUtil.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import android.app.Activity;
+import android.app.Instrumentation.ActivityMonitor;
+import android.content.ContentProviderOperation;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.ContactsContract;
+import android.support.test.espresso.NoActivityResumedException;
+import android.support.test.espresso.ViewInteraction;
+import android.util.Log;
+
+import java.util.ArrayList;
+
+import static android.support.test.espresso.action.ViewActions.replaceText;
+import static android.support.test.espresso.action.ViewActions.typeText;
+import static android.support.test.espresso.Espresso.closeSoftKeyboard;
+import static android.support.test.espresso.Espresso.pressBack;
+
+public class EspressoUtil {
+  private final static String TAG = EspressoUtil.class.getSimpleName();
+
+  public static void waitOn(Class<? extends Activity> clazz) {
+    Log.w(TAG, "waiting for " + clazz.getName());
+    new ActivityMonitor(clazz.getName(), null, true).waitForActivityWithTimeout(10000);
+  }
+
+  public static void actuallyCloseSoftKeyboard() throws Exception {
+    closeSoftKeyboard();
+    Thread.sleep(800);
+  }
+
+  public static void typeTextAndCloseKeyboard(ViewInteraction view, String text) throws Exception {
+    view.perform(typeText(text));
+    actuallyCloseSoftKeyboard();
+  }
+
+  public static void replaceTextAndCloseKeyboard(ViewInteraction view, String text) throws Exception {
+    view.perform(replaceText(text));
+    actuallyCloseSoftKeyboard();
+  }
+
+  public static void closeAllActivities() throws Exception {
+    for (int i = 0; i < 10; i++) {
+      try {
+
+        pressBack();
+
+      } catch (NoActivityResumedException e) {
+        Log.d(TAG, "you made me do this, android");
+        return;
+      }
+    }
+
+    throw new IllegalStateException("what are you doing with 10 open activities?!");
+  }
+
+  public static long addContact(Context context, String name, String number) throws Exception {
+    ArrayList<ContentProviderOperation> operations = new ArrayList<>();
+
+    operations.add(ContentProviderOperation
+        .newInsert(ContactsContract.RawContacts.CONTENT_URI)
+        .withValue(ContactsContract.RawContacts.ACCOUNT_TYPE, null)
+        .withValue(ContactsContract.RawContacts.ACCOUNT_NAME, null)
+        .build());
+
+    operations.add(ContentProviderOperation
+        .newInsert(ContactsContract.Data.CONTENT_URI)
+        .withValueBackReference(ContactsContract.Data.RAW_CONTACT_ID, 0)
+        .withValue(ContactsContract.Data.MIMETYPE, ContactsContract.CommonDataKinds.StructuredName.CONTENT_ITEM_TYPE)
+        .withValue(ContactsContract.CommonDataKinds.StructuredName.DISPLAY_NAME, name)
+        .build());
+
+      operations.add(ContentProviderOperation.
+          newInsert(ContactsContract.Data.CONTENT_URI)
+          .withValueBackReference(ContactsContract.Data.RAW_CONTACT_ID, 0)
+          .withValue(ContactsContract.Data.MIMETYPE, ContactsContract.CommonDataKinds.Phone.CONTENT_ITEM_TYPE)
+          .withValue(ContactsContract.CommonDataKinds.Phone.NUMBER, number)
+          .withValue(ContactsContract.CommonDataKinds.Phone.TYPE, ContactsContract.CommonDataKinds.Phone.TYPE_MOBILE)
+          .build());
+
+    return context.getContentResolver().applyBatch(ContactsContract.AUTHORITY, operations).length;
+  }
+
+  public static void removeAllContacts(Context context) throws Exception {
+    ContentResolver contentResolver = context.getContentResolver();
+    Cursor          cursor          = contentResolver.query(ContactsContract.Contacts.CONTENT_URI, null, null, null, null);
+
+    try {
+
+      while (cursor.moveToNext()) {
+        String contactKey = cursor.getString(cursor.getColumnIndex(ContactsContract.Contacts.LOOKUP_KEY));
+        Uri    contactUri = Uri.withAppendedPath(ContactsContract.Contacts.CONTENT_LOOKUP_URI, contactKey);
+        contentResolver.delete(contactUri, null, null);
+      }
+
+    } finally {
+      cursor.close();
+    }
+  }
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/GroupCreateActivityTest.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/GroupCreateActivityTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import android.support.test.espresso.matcher.ViewMatchers;
+import android.test.suitebuilder.annotation.LargeTest;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static org.hamcrest.Matchers.not;
+
+@LargeTest
+public class GroupCreateActivityTest extends TextSecureEspressoTestCase<ConversationListActivity> {
+
+  public GroupCreateActivityTest() {
+    super(ConversationListActivity.class);
+  }
+
+  private void clickNewGroup() throws Exception {
+    ConversationListActivityActions.clickNewGroup(getContext());
+    EspressoUtil.waitOn(GroupCreateActivity.class);
+  }
+
+  public void testLayoutWithPush() throws Exception {
+    loadActivity(ConversationListActivity.class, STATE_REGISTERED);
+    clickNewGroup();
+
+    onView(ViewMatchers.withId(R.id.push_disabled)).check(matches(not(isDisplayed())));
+    onView(withId(R.id.push_disabled_reason)).check(matches(not(isDisplayed())));
+  }
+
+  public void testLayoutWithoutPush() throws Exception {
+    loadActivity(ConversationListActivity.class, STATE_REGISTRATION_SKIPPED);
+    clickNewGroup();
+
+    onView(ViewMatchers.withId(R.id.push_disabled)).check(matches(isDisplayed()));
+    onView(withId(R.id.push_disabled_reason)).check(matches(isDisplayed()));
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/ImportExportActivityTest.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/ImportExportActivityTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import android.support.test.espresso.matcher.ViewMatchers;
+import android.test.suitebuilder.annotation.LargeTest;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.swipeLeft;
+import static android.support.test.espresso.action.ViewActions.swipeRight;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+
+@LargeTest
+public class ImportExportActivityTest extends TextSecureEspressoTestCase<ConversationListActivity> {
+
+  public ImportExportActivityTest() {
+    super(ConversationListActivity.class);
+  }
+
+  private void checkImportLayout() throws Exception {
+    onView(ViewMatchers.withId(R.id.import_sms)).check(matches(isDisplayed()));
+    onView(withId(R.id.import_encrypted_backup)).check(matches(isDisplayed()));
+    onView(withId(R.id.import_plaintext_backup)).check(matches(isDisplayed()));
+  }
+
+  private void checkExportLayout() throws Exception {
+    onView(withId(R.id.export_plaintext_backup)).check(matches(isDisplayed()));
+  }
+
+  private void clickImportExport() throws Exception {
+    loadActivity(ConversationListActivity.class, STATE_REGISTRATION_SKIPPED);
+    ConversationListActivityActions.clickImportExport(getContext());
+    EspressoUtil.waitOn(ImportExportActivity.class);
+  }
+
+  public void testLayout() throws Exception {
+    clickImportExport();
+    checkImportLayout();
+    onView(withId(R.id.import_sms)).perform(swipeLeft());
+    checkExportLayout();
+    onView(withId(R.id.export_plaintext_backup)).perform(swipeRight());
+    checkImportLayout();
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/NewConversationActivityActions.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/NewConversationActivityActions.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+
+public class NewConversationActivityActions {
+
+  public static void filterNameOrNumber(String nameOrNumber) throws Exception {
+    EspressoUtil.replaceTextAndCloseKeyboard(onView(withId(R.id.filter)), nameOrNumber);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static void clickContactWithName(String name) throws Exception {
+    onView(allOf(withId(R.id.name), withText(name))).perform(click());
+  }
+
+  @SuppressWarnings("unchecked")
+  public static void clickContactWithNumber(String number) throws Exception {
+    onView(allOf(withId(R.id.number), withText(containsString(number)))).perform(click());
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/NewConversationActivityTest.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/NewConversationActivityTest.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import android.test.suitebuilder.annotation.LargeTest;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+import static org.hamcrest.Matchers.allOf;
+
+@LargeTest
+public class NewConversationActivityTest extends TextSecureEspressoTestCase<ConversationListActivity> {
+
+  final String[][] TEST_CONTACTS = {
+      {"Nadezhda Tolokonnikova", "11111111111", "Nad", "ezh", "ova"},
+      {"Jules Bonnot",           "22222222222", "Jul", "nno", "not"},
+      {"Masha Kolenkia",         "33333333333", "Mas", "len", "kia"},
+      {"Chairman Meow",          "44444444444", "Cha", "rma", "eow"},
+      {"Clement Duval",          "55555555555", "Cle", "eme", "val"},
+      {"Nestor Makhno",          "66666666666", "Nes", "sto", "hno"},
+      {"Wilhelm Reich",          "77777777777", "Wil", "hel", "ich"}
+  };
+
+  public NewConversationActivityTest() {
+    super(ConversationListActivity.class);
+  }
+
+  private void populateContacts() throws Exception {
+    for(String[] TEST_CONTACT : TEST_CONTACTS) {
+      EspressoUtil.addContact(getContext(), TEST_CONTACT[0], TEST_CONTACT[1]);
+    }
+  }
+
+  private void clickNewConversation() throws Exception{
+    ConversationListActivityActions.clickNewConversation();
+    EspressoUtil.waitOn(NewConversationActivity.class);
+    EspressoUtil.actuallyCloseSoftKeyboard();
+  }
+
+  @SuppressWarnings("unchecked")
+  public void testContactFilterPrefix() throws Exception {
+    populateContacts();
+    loadActivity(ConversationListActivity.class, STATE_REGISTERED);
+    clickNewConversation();
+
+    for (String[] TEST_CONTACT : TEST_CONTACTS) {
+      NewConversationActivityActions.filterNameOrNumber(TEST_CONTACT[2]);
+      onView(allOf(withId(R.id.name), withText(TEST_CONTACT[0]))).check(matches(isDisplayed()));
+    }
+  }
+
+  // this is known to fail on some devices, see #2378
+  @SuppressWarnings("unchecked")
+  public void testContactFilterMiddle() throws Exception {
+    populateContacts();
+    loadActivity(ConversationListActivity.class, STATE_REGISTERED);
+    clickNewConversation();
+
+    for (String[] TEST_CONTACT : TEST_CONTACTS) {
+      NewConversationActivityActions.filterNameOrNumber(TEST_CONTACT[3]);
+      onView(allOf(withId(R.id.name), withText(TEST_CONTACT[0]))).check(matches(isDisplayed()));
+    }
+  }
+
+  // this is known to fail on some devices, see #2378
+  @SuppressWarnings("unchecked")
+  public void testContactFilterPostfix() throws Exception {
+    populateContacts();
+    loadActivity(ConversationListActivity.class, STATE_REGISTERED);
+    clickNewConversation();
+
+    for (String[] TEST_CONTACT : TEST_CONTACTS) {
+      NewConversationActivityActions.filterNameOrNumber(TEST_CONTACT[4]);
+      onView(allOf(withId(R.id.name), withText(TEST_CONTACT[0]))).check(matches(isDisplayed()));
+    }
+  }
+
+  public void testNewConversationWithNonPushContact() throws Exception {
+    populateContacts();
+    loadActivity(ConversationListActivity.class, STATE_REGISTERED);
+    clickNewConversation();
+
+    NewConversationActivityActions.clickContactWithName("Chairman Meow");
+    EspressoUtil.waitOn(ConversationActivity.class);
+  }
+
+  @SuppressWarnings("unchecked")
+  public void testNewConversationWithUnknownWhenRegistered() throws Exception {
+    loadActivity(ConversationListActivity.class, STATE_REGISTERED);
+    clickNewConversation();
+
+    NewConversationActivityActions.filterNameOrNumber("8888888888");
+    NewConversationActivityActions.clickContactWithNumber("8888888888");
+    EspressoUtil.waitOn(ConversationActivity.class);
+  }
+
+  @SuppressWarnings("unchecked")
+  public void testNewConversationWithUnknownWhenUnregistered() throws Exception {
+    loadActivity(ConversationListActivity.class, STATE_REGISTRATION_SKIPPED);
+    clickNewConversation();
+
+    NewConversationActivityActions.filterNameOrNumber("8888888888");
+    NewConversationActivityActions.clickContactWithNumber("8888888888");
+    EspressoUtil.waitOn(ConversationActivity.class);
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/PassphraseChangeActivityActions.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/PassphraseChangeActivityActions.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+
+public class PassphraseChangeActivityActions {
+
+  public static void clickOk() throws Exception {
+    onView(withId(R.id.ok_button)).perform(click());
+  }
+
+  public static void clickCancel() throws Exception {
+    onView(withId(R.id.cancel_button)).perform(click());
+  }
+
+  public static void typeNewPassphrase(String passphrase, String repeat) throws Exception {
+    EspressoUtil.typeTextAndCloseKeyboard(onView(withId(R.id.new_passphrase)), passphrase);
+    EspressoUtil.typeTextAndCloseKeyboard(onView(withId(R.id.repeat_passphrase)), repeat);
+  }
+
+  public static void typeNewPassphrase(String passphrase) throws Exception {
+    typeNewPassphrase(passphrase, passphrase);
+  }
+
+  public static void typeChangePassphrase(String oldPassphrase, String newPassphrase) throws Exception {
+    EspressoUtil.typeTextAndCloseKeyboard(onView(withId(R.id.old_passphrase)), oldPassphrase);
+    EspressoUtil.typeTextAndCloseKeyboard(onView(withId(R.id.new_passphrase)), newPassphrase);
+    EspressoUtil.typeTextAndCloseKeyboard(onView(withId(R.id.repeat_passphrase)), newPassphrase);
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/PassphraseChangeActivityTest.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/PassphraseChangeActivityTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import android.test.suitebuilder.annotation.LargeTest;
+
+import org.thoughtcrime.securesms.preferences.AppProtectionPreferenceFragmentActions;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static org.hamcrest.Matchers.not;
+
+@LargeTest
+public class PassphraseChangeActivityTest extends TextSecureEspressoTestCase<ConversationListActivity> {
+
+  private static final String ORIGINAL_PASSPHRASE = "badpass";
+  private static final String CHANGE_PASSPHRASE   = "worse";
+
+  public PassphraseChangeActivityTest() {
+    super(ConversationListActivity.class);
+  }
+
+  private void checkState() throws Exception {
+    EspressoUtil.actuallyCloseSoftKeyboard();
+
+    if (TextSecurePreferences.isPasswordDisabled(getContext())) {
+      onView(withId(R.id.old_passphrase)).check(matches(not(isDisplayed())));
+      onView(withId(R.id.old_passphrase_label)).check(matches(not(isDisplayed())));
+    } else {
+      onView(withId(R.id.old_passphrase)).check(matches(isDisplayed()));
+      onView(withId(R.id.old_passphrase_label)).check(matches(isDisplayed()));
+    }
+
+    onView(withId(R.id.new_passphrase)).check(matches(isDisplayed()));
+    onView(withId(R.id.repeat_passphrase)).check(matches(isDisplayed()));
+  }
+
+  private void clickEnablePassphraseAndCheckState() throws Exception {
+    loadActivity(ConversationListActivity.class, STATE_REGISTRATION_SKIPPED);
+    ConversationListActivityActions.clickSettings(getContext());
+    EspressoUtil.waitOn(ApplicationPreferencesActivity.class);
+    ApplicationPreferencesActivityActions.clickAppProtectionSetting();
+    AppProtectionPreferenceFragmentActions.clickEnablePassphrase();
+    EspressoUtil.waitOn(PassphraseChangeActivity.class);
+    checkState();
+  }
+
+  public void testEnablePassphrase() throws Exception {
+    clickEnablePassphraseAndCheckState();
+    PassphraseChangeActivityActions.typeNewPassphrase(ORIGINAL_PASSPHRASE);
+    PassphraseChangeActivityActions.clickOk();
+
+    EspressoUtil.waitOn(ApplicationPreferencesActivity.class);
+    assertTrue(!TextSecurePreferences.isPasswordDisabled(getContext()));
+  }
+
+  public void testEnablePassphraseCancel() throws Exception {
+    clickEnablePassphraseAndCheckState();
+    EspressoUtil.actuallyCloseSoftKeyboard();
+    PassphraseChangeActivityActions.clickCancel();
+
+    EspressoUtil.waitOn(ApplicationPreferencesActivity.class);
+    assertTrue(TextSecurePreferences.isPasswordDisabled(getContext()));
+  }
+
+  public void testEnablePassphraseDoesNotMatch() throws Exception {
+    clickEnablePassphraseAndCheckState();
+    PassphraseChangeActivityActions.typeNewPassphrase(ORIGINAL_PASSPHRASE, "nope");
+    PassphraseChangeActivityActions.clickOk();
+    PassphraseChangeActivityActions.clickCancel();
+
+    EspressoUtil.waitOn(ApplicationPreferencesActivity.class);
+    assertTrue(TextSecurePreferences.isPasswordDisabled(getContext()));
+  }
+
+  private void clickChangePassphraseAndCheckState() throws Exception {
+    testEnablePassphrase();
+    AppProtectionPreferenceFragmentActions.clickChangePassphrase();
+    EspressoUtil.waitOn(PassphraseChangeActivity.class);
+    checkState();
+  }
+
+  public void testChangePassphrase() throws Exception {
+    clickChangePassphraseAndCheckState();
+    PassphraseChangeActivityActions.typeChangePassphrase(ORIGINAL_PASSPHRASE, CHANGE_PASSPHRASE);
+    PassphraseChangeActivityActions.clickOk();
+
+    EspressoUtil.waitOn(ApplicationPreferencesActivity.class);
+    assertTrue(!TextSecurePreferences.isPasswordDisabled(getContext()));
+  }
+
+  public void testChangePassphraseCancel() throws Exception {
+    clickChangePassphraseAndCheckState();
+
+    EspressoUtil.actuallyCloseSoftKeyboard();
+    PassphraseChangeActivityActions.clickCancel();
+
+    EspressoUtil.waitOn(ApplicationPreferencesActivity.class);
+    assertTrue(!TextSecurePreferences.isPasswordDisabled(getContext()));
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/RegistrationActivityActions.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/RegistrationActivityActions.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+public class RegistrationActivityActions {
+
+  public static void typeCountryCode(String countryCode) throws Exception {
+    EspressoUtil.replaceTextAndCloseKeyboard(onView(withId(R.id.country_code)), countryCode);
+  }
+
+  public static void typeLocalNumber(String localNumber) throws Exception {
+    EspressoUtil.replaceTextAndCloseKeyboard(onView(withId(R.id.number)), localNumber);
+  }
+
+  public static void clickRegister() throws Exception {
+    onView(withId(R.id.registerButton)).perform(click());
+  }
+
+  public static void clickCancel() throws Exception {
+    onView(withId(R.id.skipButton)).perform(click());
+  }
+
+  public static void clickContinue() throws Exception {
+    onView(withText(R.string.RegistrationActivity_continue)).perform(click());
+  }
+
+  public static void clickEdit() throws Exception {
+    onView(withText(R.string.RegistrationActivity_edit)).perform(click());
+  }
+
+  public static void enterPstnNumber(String pstnCountry, String pstnNumber) throws Exception {
+    typeCountryCode(pstnCountry);
+    typeLocalNumber(pstnNumber);
+  }
+
+  public static void sleepTillRegistrationConnected() {
+    long timeout = 0L;
+    while (timeout < 10000L) {
+      try {
+
+        Thread.sleep(1000);
+        timeout += 1000;
+        onView(withId(R.id.verification_progress)).check(matches(isDisplayed()));
+        return;
+
+      } catch (InterruptedException e) { }
+        catch (AssertionError e)       { }
+    }
+    throw new AssertionError("failed to connect to registration servers within 10 seconds");
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/RegistrationActivityTest.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/RegistrationActivityTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import android.support.test.espresso.matcher.ViewMatchers;
+import android.test.suitebuilder.annotation.LargeTest;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static org.hamcrest.Matchers.not;
+
+@LargeTest
+public class RegistrationActivityTest extends TextSecureEspressoTestCase<ConversationListActivity> {
+
+  public RegistrationActivityTest() {
+    super(ConversationListActivity.class);
+  }
+
+  private void loadStateAndCheck() throws Exception {
+    loadActivity(RegistrationActivity.class, STATE_BASE);
+    onView(ViewMatchers.withId(R.id.skipButton)).check(matches(not(isDisplayed())));
+    onView(withId(R.id.registerButton)).check(matches(isDisplayed()));
+  }
+
+  public void testRegister() throws Exception {
+    loadStateAndCheck();
+    RegistrationActivityActions.enterPstnNumber(pstnCountry, pstnNumber);
+    sleepThroughRegistrationLimit();
+    RegistrationActivityActions.clickRegister();
+    RegistrationActivityActions.clickContinue();
+    EspressoUtil.waitOn(RegistrationProgressActivity.class);
+    RegistrationActivityActions.sleepTillRegistrationConnected();
+    RegistrationBypassUtil.receiveVerificationSms(getContext(), pstnCountry, pstnNumber, verificationCode);
+    EspressoUtil.waitOn(ConversationListActivity.class);
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/RegistrationBypassUtil.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/RegistrationBypassUtil.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Build.VERSION;
+import android.util.Log;
+
+import org.thoughtcrime.securesms.service.SmsListener;
+import org.thoughtcrime.securesms.util.SmsUtil;
+import org.thoughtcrime.securesms.test.R;
+
+public class RegistrationBypassUtil {
+
+  private static final String TAG = RegistrationBypassUtil.class.getSimpleName();
+
+  private static String getKeyForDevice() {
+    Log.d(TAG, "release: " + VERSION.RELEASE + ", model: " + Build.MODEL);
+    return VERSION.RELEASE + " - " + Build.MODEL;
+  }
+
+  public static String getPstnStringForDevice(Context context) {
+    final String   DEVICE_KEY   = getKeyForDevice();
+    final String[] TEST_DEVICES = context.getResources().getStringArray(R.array.test_devices);
+    final String[] PSTN_STRINGS = context.getResources().getStringArray(R.array.test_pstn_numbers);
+          int      deviceIndex  = -1;
+
+    if (TEST_DEVICES.length == 0 || PSTN_STRINGS.length != TEST_DEVICES.length) {
+      throw new AssertionError("one test device per pstn number required");
+    }
+
+    for (int i = 0; i < TEST_DEVICES.length; i++) {
+      if (TEST_DEVICES[i].equals(DEVICE_KEY)) {
+        deviceIndex = i;
+        break;
+      }
+    }
+
+    if (deviceIndex < 0) return PSTN_STRINGS[PSTN_STRINGS.length - 1];
+    else                 return PSTN_STRINGS[deviceIndex];
+  }
+
+  public static String getVerificationCodeForPstnString(Context context, String pstnString) {
+    final String[] PSTN_STRINGS = context.getResources().getStringArray(R.array.test_pstn_numbers);
+    final String[] VERIFY_CODES = context.getResources().getStringArray(R.array.test_verification_codes);
+          int      pstnIndex    = -1;
+
+    if (PSTN_STRINGS.length == 0 || PSTN_STRINGS.length != VERIFY_CODES.length) {
+      throw new AssertionError("one verification code per pstn number required");
+    }
+
+    for (int i = 0; i < PSTN_STRINGS.length; i++) {
+      if (PSTN_STRINGS[i].equals(pstnString)) {
+        pstnIndex = i;
+        break;
+      }
+    }
+
+    if (pstnIndex < 0) throw new AssertionError("no verification code for " + pstnString);
+    else               return VERIFY_CODES[pstnIndex];
+  }
+
+  public static void receiveVerificationSms(Context context,
+                                            String  pstnCountry,
+                                            String  pstnNumber,
+                                            String  verificationCode)
+      throws Exception
+  {
+    final String smsVerifyMessage = "Your TextSecure verification code: " + verificationCode;
+    final Intent smsVerifyIntent  = SmsUtil.buildSmsReceivedIntent(pstnCountry + pstnNumber, smsVerifyMessage);
+
+    try {
+      new SmsListener().onReceive(context, smsVerifyIntent);
+    } catch (IllegalStateException e) {
+      Log.w(TAG, "some api levels are picky with abortBroadcast()", e);
+    }
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/TextSecureEspressoTestCase.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/TextSecureEspressoTestCase.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import android.app.Activity;
+import android.content.Context;
+import android.preference.PreferenceManager;
+import android.test.ActivityInstrumentationTestCase2;
+import android.util.Log;
+
+import org.thoughtcrime.securesms.crypto.MasterSecretUtil;
+import org.thoughtcrime.securesms.database.DatabaseFactory;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
+
+public class TextSecureEspressoTestCase<T extends Activity> extends ActivityInstrumentationTestCase2<T> {
+
+  private static final String TAG = TextSecureEspressoTestCase.class.getSimpleName();
+
+  public static final int STATE_BASE                 = 0x00000000;
+  public static final int STATE_REGISTRATION_SKIPPED = 0x00000001;
+  public static final int STATE_REGISTERED           = 0x00000002;
+
+  private static final long REGISTRATION_RATE_LIMIT_MS = 60000 + 10000;
+  private static       long TIME_LAST_REGISTERED       = 0L;
+
+  protected String pstnCountry;
+  protected String pstnNumber;
+  protected String verificationCode;
+
+  public TextSecureEspressoTestCase(Class<T> clazz) {
+    super(clazz);
+  }
+
+  protected static void sleepThroughRegistrationLimit() {
+    long msPassedSinceReg = System.currentTimeMillis() - TIME_LAST_REGISTERED;
+    long msSleepRemaining = REGISTRATION_RATE_LIMIT_MS - msPassedSinceReg;
+
+    Log.d(TAG, "sleeping for " + msSleepRemaining + "ms to avoid registration rate limit");
+    while (msSleepRemaining > 0) {
+      try {
+
+        Thread.sleep(1000);
+        msSleepRemaining -= 1000;
+
+      } catch (InterruptedException e) { }
+    }
+    TIME_LAST_REGISTERED = System.currentTimeMillis();
+  }
+
+  protected Context getContext() {
+    return getInstrumentation().getTargetContext();
+  }
+
+  private void initBaseState() throws Exception {
+    EspressoUtil.removeAllContacts(getContext());
+    DatabaseFactory.getDraftDatabase(getContext()).clearAllDrafts();
+    DatabaseFactory.getThreadDatabase(getContext()).deleteAllConversations();
+    PreferenceManager.getDefaultSharedPreferences(getContext()).edit().clear().commit();
+    getContext().getSharedPreferences(MasterSecretUtil.PREFERENCES_NAME, 0).edit().clear().commit();
+    getContext().getSharedPreferences("SecureSMS", 0).edit().clear().commit();
+  }
+
+  protected void loadActivity(Class<? extends Activity> clazz, int state) throws Exception {
+    switch (state) {
+      case STATE_REGISTRATION_SKIPPED:
+        TextSecurePreferences.setPromptedPushRegistration(getContext(), true);
+        getActivity();
+        break;
+
+      case STATE_REGISTERED:
+        getActivity();
+        EspressoUtil.waitOn(RegistrationActivity.class);
+        RegistrationActivityActions.enterPstnNumber(pstnCountry, pstnNumber);
+        sleepThroughRegistrationLimit();
+        RegistrationActivityActions.clickRegister();
+        RegistrationActivityActions.clickContinue();
+        EspressoUtil.waitOn(RegistrationProgressActivity.class);
+        RegistrationActivityActions.sleepTillRegistrationConnected();
+        RegistrationBypassUtil.receiveVerificationSms(getContext(), pstnCountry, pstnNumber, verificationCode);
+        break;
+
+      default:
+        getActivity();
+    }
+
+    EspressoUtil.waitOn(clazz);
+  }
+
+  private void initMockPstnState() throws Exception {
+    final Context context    = getInstrumentation().getContext();
+    final String  pstnString = RegistrationBypassUtil.getPstnStringForDevice(context);
+
+    pstnCountry      = pstnString.split(":")[0].replace("+", "");
+    pstnNumber       = pstnString.split(":")[1];
+    verificationCode = RegistrationBypassUtil.getVerificationCodeForPstnString(context, pstnString);
+
+    Log.d(TAG, "using pstn id of " + pstnString + " with verification code " + verificationCode);
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    System.setProperty("dexmaker.dexcache", getContext().getCacheDir().getPath());
+    super.setUp();
+
+    if (pstnCountry == null || pstnNumber == null || verificationCode == null) {
+      initMockPstnState();
+    }
+    initBaseState();
+  }
+
+  @Override
+  public void tearDown() throws Exception {
+    EspressoUtil.actuallyCloseSoftKeyboard();
+    EspressoUtil.closeAllActivities();
+    super.tearDown();
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/ViewLocalIdentityActivityTest.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/ViewLocalIdentityActivityTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import android.support.test.espresso.matcher.ViewMatchers;
+import android.test.suitebuilder.annotation.LargeTest;
+
+import org.thoughtcrime.securesms.crypto.IdentityKeyUtil;
+import org.whispersystems.libaxolotl.IdentityKey;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+@LargeTest
+public class ViewLocalIdentityActivityTest extends TextSecureEspressoTestCase<ConversationListActivity> {
+
+  public ViewLocalIdentityActivityTest() {
+    super(ConversationListActivity.class);
+  }
+
+  private void clickMyIdentity() throws Exception {
+    loadActivity(ConversationListActivity.class, STATE_REGISTRATION_SKIPPED);
+    ConversationListActivityActions.clickMyIdentity(getContext());
+    EspressoUtil.waitOn(ViewLocalIdentityActivity.class);
+  }
+
+  public void testLayout() throws Exception {
+    clickMyIdentity();
+    final IdentityKey idKey = IdentityKeyUtil.getIdentityKey(getContext());
+    onView(ViewMatchers.withId(R.id.identity_fingerprint)).check(matches(withText(idKey.getFingerprint())));
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/ViewMatchers.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/ViewMatchers.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+public class ViewMatchers {
+
+  public static Matcher<View> withRecyclerItem(final Matcher<Object> itemMatcher) {
+    return new TypeSafeMatcher<View>() {
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("with recycler item: ");
+        itemMatcher.describeTo(description);
+      }
+
+      @Override
+      public boolean matchesSafely(View view) {
+        if (!(view instanceof RecyclerView)) {
+          return false;
+        }
+
+        RecyclerView recyclerView = ((RecyclerView) view);
+        for (int i = 0; i < recyclerView.getChildCount(); i++) {
+          if (itemMatcher.matches(recyclerView.getChildAt(i))) {
+            return true;
+          }
+        }
+        return false;
+      }
+    };
+  }
+
+  public static Matcher<View> withRecyclerItemCount(final long itemCount) {
+    return new TypeSafeMatcher<View>() {
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("with recycler item count: " + itemCount);
+      }
+
+      @Override
+      public boolean matchesSafely(View view) {
+        if (!(view instanceof RecyclerView)) {
+          return false;
+        }
+
+        RecyclerView recyclerView = ((RecyclerView) view);
+        return recyclerView.getChildCount() == itemCount;
+      }
+    };
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragmentActions.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragmentActions.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms.preferences;
+
+import org.hamcrest.Matchers;
+
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.matcher.PreferenceMatchers.withKey;
+
+public class AdvancedPreferenceFragmentActions {
+
+  public static void clickTextSecureMessages() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_toggle_push_messaging"))).perform(click());
+  }
+
+  public static void clickEnterKeySends() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_enter_sends"))).perform(click());
+  }
+
+  public static void clickChooseIdentity() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_choose_identity"))).perform(click());
+  }
+
+  public static void clickSubmitDebugLog() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_submit_debug_logs"))).perform(click());
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragmentTest.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragmentTest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms.preferences;
+
+import android.test.suitebuilder.annotation.LargeTest;
+
+import org.hamcrest.Matchers;
+import org.thoughtcrime.securesms.ApplicationPreferencesActivity;
+import org.thoughtcrime.securesms.ConversationListActivity;
+import org.thoughtcrime.securesms.LogSubmitActivity;
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.RegistrationActivity;
+import org.thoughtcrime.securesms.contacts.ContactIdentityManager;
+import org.thoughtcrime.securesms.ApplicationPreferencesActivityActions;
+import org.thoughtcrime.securesms.ConversationListActivityActions;
+import org.thoughtcrime.securesms.TextSecureEspressoTestCase;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
+
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.PreferenceMatchers.withKey;
+import static android.support.test.espresso.matcher.ViewMatchers.isChecked;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isNotChecked;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.thoughtcrime.securesms.EspressoUtil.waitOn;
+
+@LargeTest
+public class AdvancedPreferenceFragmentTest extends TextSecureEspressoTestCase<ConversationListActivity> {
+
+  public AdvancedPreferenceFragmentTest() {
+    super(ConversationListActivity.class);
+  }
+
+  private void checkAllPreferencesDisplayed() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_toggle_push_messaging")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("pref_enter_sends")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("pref_submit_debug_logs")))
+          .check(matches(isDisplayed()));
+
+    ContactIdentityManager identity = ContactIdentityManager.getInstance(getContext());
+    if (!identity.isSelfIdentityAutoDetected()) {
+      onData(Matchers.<Object>allOf(withKey("pref_choose_identity")))
+            .check(matches(isDisplayed()));
+    }
+  }
+
+  private void checkViewsMatchPreferences() throws Exception {
+    if (TextSecurePreferences.isPushRegistered(getContext())) {
+      isChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_toggle_push_messaging"))));
+    } else {
+      isNotChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_toggle_push_messaging"))));
+    }
+
+    if (TextSecurePreferences.isEnterSendsEnabled(getContext())) {
+      isChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_enter_sends"))));
+    } else {
+      isNotChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_enter_sends"))));
+    }
+  }
+
+  private void clickAdvancedSettingAndCheckState() throws Exception {
+    ConversationListActivityActions.clickSettings(getContext());
+    waitOn(ApplicationPreferencesActivity.class);
+    ApplicationPreferencesActivityActions.clickAdvancedSetting();
+
+    checkAllPreferencesDisplayed();
+    checkViewsMatchPreferences();
+  }
+
+  public void testEnableTextSecureMessages() throws Exception {
+    loadActivity(ConversationListActivity.class, STATE_REGISTRATION_SKIPPED);
+    clickAdvancedSettingAndCheckState();
+    AdvancedPreferenceFragmentActions.clickTextSecureMessages();
+    waitOn(RegistrationActivity.class);
+  }
+
+  public void testDisableTextSecureMessages() throws Exception {
+    loadActivity(ConversationListActivity.class, STATE_REGISTERED);
+    clickAdvancedSettingAndCheckState();
+    AdvancedPreferenceFragmentActions.clickTextSecureMessages();
+    onView(withText(R.string.ApplicationPreferencesActivity_disable_push_messages))
+          .check(matches(isDisplayed()));
+    onView(withText(android.R.string.cancel)).perform(click());
+  }
+
+  public void testSubmitDebugLog() throws Exception {
+    loadActivity(ConversationListActivity.class, STATE_REGISTRATION_SKIPPED);
+    clickAdvancedSettingAndCheckState();
+    AdvancedPreferenceFragmentActions.clickSubmitDebugLog();
+    waitOn(LogSubmitActivity.class);
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragmentActions.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragmentActions.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms.preferences;
+
+import org.hamcrest.Matchers;
+import org.thoughtcrime.securesms.R;
+
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.matcher.PreferenceMatchers.withKey;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+public class AppProtectionPreferenceFragmentActions {
+
+  public static void clickEnablePassphrase() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_enable_passphrase_temporary"))).perform(click());
+  }
+
+  public static void disablePassphrase() throws Exception {
+    clickEnablePassphrase();
+    onView(withText(R.string.ApplicationPreferencesActivity_disable)).perform(click());
+  }
+
+  public static void clickChangePassphrase() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_change_passphrase"))).perform(click());
+  }
+
+  public static void clickTimeoutPassphrase() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_timeout_passphrase"))).perform(click());
+  }
+
+  public static void clickScreenSecurity() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_screen_security"))).perform(click());
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragmentTest.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragmentTest.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms.preferences;
+
+import android.os.Build;
+import android.test.suitebuilder.annotation.LargeTest;
+
+import org.hamcrest.Matchers;
+import org.thoughtcrime.securesms.ApplicationPreferencesActivity;
+import org.thoughtcrime.securesms.ConversationListActivity;
+import org.thoughtcrime.securesms.PassphraseChangeActivity;
+import org.thoughtcrime.securesms.ApplicationPreferencesActivityActions;
+import org.thoughtcrime.securesms.ConversationListActivityActions;
+import org.thoughtcrime.securesms.PassphraseChangeActivityActions;
+import org.thoughtcrime.securesms.TextSecureEspressoTestCase;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
+
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.PreferenceMatchers.withKey;
+import static android.support.test.espresso.matcher.ViewMatchers.isChecked;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isNotChecked;
+import static org.thoughtcrime.securesms.EspressoUtil.waitOn;
+
+@LargeTest
+public class AppProtectionPreferenceFragmentTest extends TextSecureEspressoTestCase<ConversationListActivity> {
+
+  private static final String ORIGINAL_PASSPHRASE = "badpass";
+
+  public AppProtectionPreferenceFragmentTest() {
+    super(ConversationListActivity.class);
+  }
+
+  private void checkAllPreferencesDisplayed() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_enable_passphrase_temporary"))).check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("pref_change_passphrase"))).check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("pref_timeout_passphrase"))).check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("pref_timeout_interval"))).check(matches(isDisplayed()));
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+      onData(Matchers.<Object>allOf(withKey("pref_screen_security")))
+            .check(matches(isDisplayed()));
+    }
+  }
+
+  private void checkViewsMatchPreferences() throws Exception {
+    if (!TextSecurePreferences.isPasswordDisabled(getContext())) {
+      isChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_enable_passphrase_temporary"))));
+    } else {
+      isNotChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_enable_passphrase_temporary"))));
+    }
+
+    if (TextSecurePreferences.isPassphraseTimeoutEnabled(getContext())) {
+      isChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_timeout_passphrase"))));
+    } else {
+      isNotChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_timeout_passphrase"))));
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+      if (TextSecurePreferences.isScreenSecurityEnabled(getContext())) {
+        isChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_screen_security"))));
+      } else {
+        isNotChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_screen_security"))));
+      }
+    }
+  }
+
+  private void checkState() throws Exception {
+    checkAllPreferencesDisplayed();
+    checkViewsMatchPreferences();
+  }
+
+  private void clickAppProtectionSettingAndCheckState() throws Exception {
+    loadActivity(ConversationListActivity.class, STATE_REGISTRATION_SKIPPED);
+    ConversationListActivityActions.clickSettings(getContext());
+    waitOn(ApplicationPreferencesActivity.class);
+    ApplicationPreferencesActivityActions.clickAppProtectionSetting();
+    checkState();
+  }
+
+  public void testEnablePassphrase() throws Exception {
+    clickAppProtectionSettingAndCheckState();
+
+    AppProtectionPreferenceFragmentActions.clickEnablePassphrase();
+    waitOn(PassphraseChangeActivity.class);
+    PassphraseChangeActivityActions.typeNewPassphrase(ORIGINAL_PASSPHRASE);
+    PassphraseChangeActivityActions.clickOk();
+    waitOn(ApplicationPreferencesActivity.class);
+
+    isChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_enable_passphrase_temporary"))));
+    checkState();
+  }
+
+  public void testDisablePassphrase() throws Exception {
+    testEnablePassphrase();
+    AppProtectionPreferenceFragmentActions.disablePassphrase();
+
+    isNotChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_enable_passphrase_temporary"))));
+    checkState();
+  }
+
+  public void testEnablePassphraseTimeout() throws Exception {
+    testEnablePassphrase();
+    AppProtectionPreferenceFragmentActions.clickTimeoutPassphrase();
+
+    isChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_timeout_passphrase"))));
+    checkState();
+  }
+
+  public void testDisableScreenSecurity() throws Exception {
+    clickAppProtectionSettingAndCheckState();
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+      return;
+    }
+
+    AppProtectionPreferenceFragmentActions.clickScreenSecurity();
+    isNotChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_screen_security"))));
+    checkState();
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/preferences/AppearancePreferenceFragmentActions.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/preferences/AppearancePreferenceFragmentActions.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms.preferences;
+
+import org.hamcrest.Matchers;
+
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.matcher.PreferenceMatchers.withKey;
+
+public class AppearancePreferenceFragmentActions {
+
+  public static void clickTheme() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_theme"))).perform(click());
+  }
+
+  public static void clickLanguage() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_language"))).perform(click());
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/preferences/AppearancePreferenceFragmentTest.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/preferences/AppearancePreferenceFragmentTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms.preferences;
+
+import android.test.suitebuilder.annotation.LargeTest;
+
+import org.hamcrest.Matchers;
+import org.thoughtcrime.securesms.ConversationListActivity;
+import org.thoughtcrime.securesms.TextSecureEspressoTestCase;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
+
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.PreferenceMatchers.withKey;
+import static android.support.test.espresso.matcher.PreferenceMatchers.withSummaryText;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+
+@LargeTest
+public class AppearancePreferenceFragmentTest extends TextSecureEspressoTestCase<ConversationListActivity> {
+
+  public AppearancePreferenceFragmentTest() {
+    super(ConversationListActivity.class);
+  }
+
+  private void checkAllPreferencesDisplayed() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_theme")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("pref_language")))
+          .check(matches(isDisplayed()));
+  }
+
+  private void checkViewsMatchPreferences() throws Exception {
+    // todo :|
+    final String theme = TextSecurePreferences.getTheme(getContext());
+    onData(Matchers.<Object>allOf(withKey("pref_theme"), withSummaryText(theme)))
+          .check(matches(isDisplayed()));
+
+    final String language = TextSecurePreferences.getTheme(getContext());
+    onData(Matchers.<Object>allOf(withKey("pref_language"), withSummaryText(language)))
+        .check(matches(isDisplayed()));
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragmentActions.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragmentActions.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms.preferences;
+
+import org.hamcrest.Matchers;
+
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.matcher.PreferenceMatchers.withKey;
+
+public class NotificationsPreferenceFragmentActions {
+
+  public static void clickEnableNotifications() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_key_enable_notifications"))).perform(click());
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragmentTest.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragmentTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms.preferences;
+
+import android.test.suitebuilder.annotation.LargeTest;
+
+import org.hamcrest.Matchers;
+import org.thoughtcrime.securesms.ApplicationPreferencesActivity;
+import org.thoughtcrime.securesms.ConversationListActivity;
+import org.thoughtcrime.securesms.ApplicationPreferencesActivityActions;
+import org.thoughtcrime.securesms.ConversationListActivityActions;
+import org.thoughtcrime.securesms.TextSecureEspressoTestCase;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
+
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.PreferenceMatchers.withKey;
+import static android.support.test.espresso.matcher.ViewMatchers.isChecked;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isNotChecked;
+import static org.thoughtcrime.securesms.EspressoUtil.waitOn;
+
+@LargeTest
+public class NotificationsPreferenceFragmentTest extends TextSecureEspressoTestCase<ConversationListActivity> {
+
+  public NotificationsPreferenceFragmentTest() {
+    super(ConversationListActivity.class);
+  }
+
+  private void checkAllPreferencesDisplayed() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_key_enable_notifications")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("pref_key_ringtone")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("pref_key_vibrate")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("pref_led_color")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("pref_led_blink")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("pref_key_inthread_notifications")))
+          .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("pref_repeat_alerts")))
+          .check(matches(isDisplayed()));
+  }
+
+  private void checkViewsMatchPreferences() throws Exception {
+    if (TextSecurePreferences.isNotificationsEnabled(getContext())) {
+      isChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_key_enable_notifications"))));
+    } else {
+      isNotChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_key_enable_notifications"))));
+    }
+
+    if (TextSecurePreferences.isNotificationVibrateEnabled(getContext())) {
+      isChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_key_vibrate"))));
+    } else {
+      isNotChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_key_vibrate"))));
+    }
+
+    if (TextSecurePreferences.isInThreadNotifications(getContext())) {
+      isChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_key_inthread_notifications"))));
+    } else {
+      isNotChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_key_inthread_notifications"))));
+    }
+  }
+
+  private void clickNotificationsSettingAndCheckState() throws Exception {
+    loadActivity(ConversationListActivity.class, STATE_REGISTRATION_SKIPPED);
+    ConversationListActivityActions.clickSettings(getContext());
+    waitOn(ApplicationPreferencesActivity.class);
+    ApplicationPreferencesActivityActions.clickNotificationsSetting();
+
+    checkAllPreferencesDisplayed();
+    checkViewsMatchPreferences();
+  }
+
+  public void testEnableNotifications() throws Exception {
+    clickNotificationsSettingAndCheckState();
+    NotificationsPreferenceFragmentActions.clickEnableNotifications();
+    isChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_key_enable_notifications"))));
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/preferences/SmsMmsPreferenceFragmentActions.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/preferences/SmsMmsPreferenceFragmentActions.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms.preferences;
+
+import org.hamcrest.Matchers;
+
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.matcher.PreferenceMatchers.withKey;
+
+public class SmsMmsPreferenceFragmentActions {
+
+  public static void clickReceiveAllSms() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_all_sms"))).perform(click());
+  }
+
+  public static void clickReceiveAllMms() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_all_mms"))).perform(click());
+  }
+
+  public static void clickSmsDeliveryReports() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_delivery_report_sms"))).perform(click());
+  }
+
+  public static void clickWifiCallingCompat() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_wifi_sms"))).perform(click());
+  }
+
+}

--- a/espressoTest/java/org/thoughtcrime/securesms/preferences/StoragePreferenceFragmentActions.java
+++ b/espressoTest/java/org/thoughtcrime/securesms/preferences/StoragePreferenceFragmentActions.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms.preferences;
+
+import org.hamcrest.Matchers;
+
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.matcher.PreferenceMatchers.withKey;
+
+public class StoragePreferenceFragmentActions {
+
+  public static void clickDeleteOldMessages() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_trim_threads"))).perform(click());
+  }
+
+  public static void clickConversationLengthLimit() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_trim_length"))).perform(click());
+  }
+
+  public static void clickTrimAllNow() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_trim_now"))).perform(click());
+  }
+
+}

--- a/proguard-testing.pro
+++ b/proguard-testing.pro
@@ -4,6 +4,7 @@
 -dontwarn android.test.**
 -dontwarn com.android.support.test.**
 -dontwarn sun.reflect.**
+-dontwarn sun.misc.**
 -dontwarn org.assertj.**
 -dontwarn org.hamcrest.**
 -dontwarn org.mockito.**

--- a/src/org/thoughtcrime/securesms/Release.java
+++ b/src/org/thoughtcrime/securesms/Release.java
@@ -1,7 +1,0 @@
-package org.thoughtcrime.securesms;
-
-public class Release {
-
-  public static final String PUSH_URL = "https://textsecure-service.whispersystems.org";
-//  public static final String PUSH_URL = "http://192.168.1.135:8080";
-}

--- a/src/org/thoughtcrime/securesms/dependencies/TextSecureCommunicationModule.java
+++ b/src/org/thoughtcrime/securesms/dependencies/TextSecureCommunicationModule.java
@@ -2,7 +2,7 @@ package org.thoughtcrime.securesms.dependencies;
 
 import android.content.Context;
 
-import org.thoughtcrime.securesms.Release;
+import org.thoughtcrime.securesms.BuildConfig;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.crypto.storage.TextSecureAxolotlStore;
 import org.thoughtcrime.securesms.jobs.AttachmentDownloadJob;
@@ -47,7 +47,7 @@ public class TextSecureCommunicationModule {
   }
 
   @Provides TextSecureAccountManager provideTextSecureAccountManager() {
-    return new TextSecureAccountManager(Release.PUSH_URL,
+    return new TextSecureAccountManager(BuildConfig.PUSH_URL,
                                         new TextSecurePushTrustStore(context),
                                         TextSecurePreferences.getLocalNumber(context),
                                         TextSecurePreferences.getPushServerPassword(context));
@@ -57,7 +57,7 @@ public class TextSecureCommunicationModule {
     return new TextSecureMessageSenderFactory() {
       @Override
       public TextSecureMessageSender create(MasterSecret masterSecret) {
-        return new TextSecureMessageSender(Release.PUSH_URL,
+        return new TextSecureMessageSender(BuildConfig.PUSH_URL,
                                            new TextSecurePushTrustStore(context),
                                            TextSecurePreferences.getLocalNumber(context),
                                            TextSecurePreferences.getPushServerPassword(context),
@@ -69,7 +69,7 @@ public class TextSecureCommunicationModule {
   }
 
   @Provides TextSecureMessageReceiver provideTextSecureMessageReceiver() {
-    return new TextSecureMessageReceiver(Release.PUSH_URL,
+    return new TextSecureMessageReceiver(BuildConfig.PUSH_URL,
                                          new TextSecurePushTrustStore(context),
                                          new DynamicCredentialsProvider(context));
   }

--- a/src/org/thoughtcrime/securesms/jobs/AvatarDownloadJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/AvatarDownloadJob.java
@@ -5,7 +5,7 @@ import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.util.Log;
 
-import org.thoughtcrime.securesms.Release;
+import org.thoughtcrime.securesms.BuildConfig;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.GroupDatabase;
@@ -95,7 +95,7 @@ public class AvatarDownloadJob extends MasterSecretJob {
   }
 
   private File downloadAttachment(String relay, long contentLocation) throws IOException {
-    PushServiceSocket socket = new PushServiceSocket(Release.PUSH_URL,
+    PushServiceSocket socket = new PushServiceSocket(BuildConfig.PUSH_URL,
                                                      new TextSecurePushTrustStore(context),
                                                      new StaticCredentialsProvider(TextSecurePreferences.getLocalNumber(context),
                                                                                    TextSecurePreferences.getPushServerPassword(context),

--- a/src/org/thoughtcrime/securesms/push/TextSecureCommunicationFactory.java
+++ b/src/org/thoughtcrime/securesms/push/TextSecureCommunicationFactory.java
@@ -2,7 +2,7 @@ package org.thoughtcrime.securesms.push;
 
 import android.content.Context;
 
-import org.thoughtcrime.securesms.Release;
+import org.thoughtcrime.securesms.BuildConfig;
 import org.thoughtcrime.securesms.crypto.SecurityEvent;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.crypto.storage.TextSecureAxolotlStore;
@@ -20,14 +20,14 @@ import static org.whispersystems.textsecure.api.TextSecureMessageSender.EventLis
 public class TextSecureCommunicationFactory {
 
   public static TextSecureAccountManager createManager(Context context) {
-    return new TextSecureAccountManager(Release.PUSH_URL,
+    return new TextSecureAccountManager(BuildConfig.PUSH_URL,
                                         new TextSecurePushTrustStore(context),
                                         TextSecurePreferences.getLocalNumber(context),
                                         TextSecurePreferences.getPushServerPassword(context));
   }
 
   public static TextSecureAccountManager createManager(Context context, String number, String password) {
-    return new TextSecureAccountManager(Release.PUSH_URL, new TextSecurePushTrustStore(context),
+    return new TextSecureAccountManager(BuildConfig.PUSH_URL, new TextSecurePushTrustStore(context),
                                         number, password);
   }
 


### PR DESCRIPTION
## espresso prerequisites & cleanup
1) move PUSH_URL from Release.java into BuildConfig.java
2) avoid redeclaration of proguard files, prevents future #3127
3) move all packagingOptions exclusions into a single closure

## espresso tests
1) bumped espresso-core dependency to 2.1
2) removed unecessary testing-support-lib dependency
3) fixed proguard-testing.pro rules
4) use TS staging server for all tests
5) wrote a bunch of espresso tests
6) simplified the androidTest source set definition
7) added rule to optionally include espressoTest/ dir in androidTest source set
8) added gradle.properties and test device numbers to .gitignore

// FREEBIE

we want to keep our espresso tests separate from our regular unit tests, ideally we would do this by defining a new build target called `espresso` or whatever but this doesn't work because although gradle was nice enough to give us `testBuildType` there is only one test source set, `androidTest`, and gradle still considers it to be a magic special case.

so instead we optionally include the `espressoTest/` directory into the `androidTest` source set, defaulting to not included, and overridden by setting the property `espresso` either through a `gradle.properties` file or via command line parameter.

personally I'd like to rename the `androidTest` directory `unitTest` or something more appropriate but kinda getting picky at that point :p

**warning: running the espresso tests will delete all contacts on your test device**