### PR TITLE
fix for issue #2891: Alignment of the keyboard / Smiley switch for long texts

### DIFF
--- a/res/drawable-v21/touch_highlight_background.xml
+++ b/res/drawable-v21/touch_highlight_background.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@color/touch_highlight">
+    <item
+        android:id="@android:id/mask"
+        android:drawable="@android:color/white" />
+</ripple>

--- a/res/layout/conversation_activity.xml
+++ b/res/layout/conversation_activity.xml
@@ -70,8 +70,8 @@
                 <org.thoughtcrime.securesms.components.emoji.EmojiToggle
                         android:id="@+id/emoji_toggle"
                         android:layout_width="wrap_content"
-                        android:layout_height="fill_parent"
-                        android:layout_gravity="center_vertical"
+                        android:layout_height="48dp"
+                        android:layout_gravity="bottom"
                         android:background="@drawable/touch_highlight_background"
                         android:contentDescription="@string/conversation_activity__emoji_toggle_description"
                         android:padding="10dp"/>
@@ -100,8 +100,8 @@
                 <org.thoughtcrime.securesms.components.SendButton
                     android:id="@+id/send_button"
                     android:layout_width="wrap_content"
-                    android:layout_height="fill_parent"
-                    android:layout_gravity="center_vertical"
+                    android:layout_height="48dp"
+                    android:layout_gravity="bottom"
                     android:background="@drawable/touch_highlight_background"
                     android:contentDescription="@string/conversation_activity__send"
                     android:nextFocusLeft="@+id/embedded_text_editor"


### PR DESCRIPTION
FREEBIE

Simple fix for issue #2891 and added ripple effect with the same color for conversation button backgrounds.  Tested on Nexus 6 and Galaxy SII, no visual change to UI (aside from alignment).

Just getting familiar with the codebase, I'll check out something more complex once I'm more acclimated.