### PR TITLE
gradle cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,10 +78,7 @@ dependencies {
     androidTestCompile ('com.squareup.assertj:assertj-android:1.0.0') {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
-    androidTestCompile ('com.android.support.test.espresso:espresso-core:2.0') {
-        exclude group: 'javax.inject'
-    }
-    androidTestCompile 'com.android.support.test:testing-support-lib:0.1'
+    androidTestCompile 'com.android.support.test:runner:0.2'
 }
 
 dependencyVerification {

--- a/build.gradle
+++ b/build.gradle
@@ -155,6 +155,8 @@ android {
         exclude 'LICENSE'
         exclude 'NOTICE'
         exclude 'asm-license.txt'
+        exclude 'META-INF/LICENSE'
+        exclude 'META-INF/NOTICE'
     }
 
     signingConfigs {
@@ -205,11 +207,6 @@ android {
             aidl.srcDirs = ['androidTest/java']
             renderscript.srcDirs = ['androidTest/java']
         }
-    }
-
-    packagingOptions {
-        exclude 'META-INF/LICENSE'
-        exclude 'META-INF/NOTICE'
     }
 
      lintOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -180,19 +180,7 @@ android {
         }
         release {
             minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'),
-                          'proguard-google-play-services.pro',
-                          'proguard-dagger.pro',
-                          'proguard-jackson.pro',
-                          'proguard-sqlite.pro',
-                          'proguard-appcompat-v7.pro',
-                          'proguard-square-okhttp.pro',
-                          'proguard-square-okio.pro',
-                          'proguard-spongycastle.pro',
-                          'proguard-rounded-image-view.pro',
-                          'proguard-glide.pro',
-                          'proguard-shortcutbadger.pro',
-                          'proguard.cfg'
+            proguardFiles = buildTypes.debug.proguardFiles
             signingConfig signingConfigs.release
         }
         testing.initWith(buildTypes.debug)


### PR DESCRIPTION
1) avoid redeclaration of proguard files, prevents future #3127
2) move all packagingOptions exclusions into a single closure
3) remove unused espresso dep, replace testing-support-lib

// FREEBIE