### PR TITLE
fix Uri.parse NPE in notifier

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -76,6 +76,7 @@ import me.leolin.shortcutbadger.ShortcutBadger;
  */
 
 public class MessageNotifier {
+  private static final String TAG = MessageNotifier.class.getSimpleName();
 
   public static final int NOTIFICATION_ID = 1338;
 
@@ -300,10 +301,16 @@ public class MessageNotifier {
 
       String ringtone = TextSecurePreferences.getNotificationRingtone(context);
 
-      if (ringtone == null)
+      if (ringtone == null) {
+        Log.w(TAG, "ringtone preference was null.");
         return;
+      }
+      Uri uri = Uri.parse(ringtone);
+      if (uri == null) {
+        Log.w(TAG, "couldn't parse ringtone uri " + ringtone);
+        return;
+      }
 
-      Uri uri            = Uri.parse(ringtone);
       MediaPlayer player = new MediaPlayer();
       player.setAudioStreamType(AudioManager.STREAM_NOTIFICATION);
       player.setDataSource(context, uri);


### PR DESCRIPTION
```
E/AndroidRuntime(31289): java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String android.net.Uri.getScheme()' on a null object reference
E/AndroidRuntime(31289): 	at android.content.ContentResolver.openAssetFileDescriptor(ContentResolver.java:924)
E/AndroidRuntime(31289): 	at android.content.ContentResolver.openAssetFileDescriptor(ContentResolver.java:868)
E/AndroidRuntime(31289): 	at android.media.MediaPlayer.setDataSource(MediaPlayer.java:989)
E/AndroidRuntime(31289): 	at android.media.MediaPlayer.setDataSource(MediaPlayer.java:957)
E/AndroidRuntime(31289): 	at org.thoughtcrime.securesms.notifications.MessageNotifier.sendInThreadNotification(MessageNotifier.java:309)
E/AndroidRuntime(31289): 	at org.thoughtcrime.securesms.notifications.MessageNotifier.updateNotification(MessageNotifier.java:129)
E/AndroidRuntime(31289): 	at org.thoughtcrime.securesms.jobs.PushDecryptJob.handleTextMessage(PushDecryptJob.java:222)
E/AndroidRuntime(31289): 	at org.thoughtcrime.securesms.jobs.PushDecryptJob.handleMessage(PushDecryptJob.java:111)
E/AndroidRuntime(31289): 	at org.thoughtcrime.securesms.jobs.PushDecryptJob.onRun(PushDecryptJob.java:87)
E/AndroidRuntime(31289): 	at org.thoughtcrime.securesms.jobs.MasterSecretJob.onRun(MasterSecretJob.java:18)
E/AndroidRuntime(31289): 	at org.whispersystems.jobqueue.JobConsumer.runJob(JobConsumer.java:76)
E/AndroidRuntime(31289): 	at org.whispersystems.jobqueue.JobConsumer.run(JobConsumer.java:46)
```