### PR TITLE
Update "TextSecure messages" preferences strings

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -21,11 +21,11 @@
     </string>
     <string name="ApplicationPreferencesActivity_disable">Disable</string>
     <string name="ApplicationPreferencesActivity_unregistering">Unregistering...</string>
-    <string name="ApplicationPreferencesActivity_unregistering_for_data_based_communication">Unregistering for data based communication</string>
-    <string name="ApplicationPreferencesActivity_disable_push_messages">Disable push messages?</string>
-    <string name="ApplicationPreferencesActivity_this_will_disable_push_messages">
-        This will disable push messages by unregistering you from the server.
-        You will need to re-register your phone number to use push messages again in the future.
+    <string name="ApplicationPreferencesActivity_unregistering_from_textsecure_messages">Unregistering from TextSecure messages</string>
+    <string name="ApplicationPreferencesActivity_disable_textsecure_messages">Disable TextSecure messages?</string>
+    <string name="ApplicationPreferencesActivity_this_will_disable_textsecure_messages">
+        This will disable TextSecure messages by unregistering you from the server.
+        You will need to re-register your phone number to use TextSecure messages again in the future.
     </string>
     <string name="ApplicationPreferencesActivity_error_connecting_to_server">Error connecting to server!</string>
     <string name="ApplicationPreferencesActivity_sms_enabled">SMS Enabled</string>

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -133,7 +133,7 @@ public class AdvancedPreferenceFragment extends PreferenceFragment {
       private final CheckBoxPreference checkBoxPreference;
 
       public DisablePushMessagesTask(final CheckBoxPreference checkBoxPreference) {
-        super(getActivity(), R.string.ApplicationPreferencesActivity_unregistering, R.string.ApplicationPreferencesActivity_unregistering_for_data_based_communication);
+        super(getActivity(), R.string.ApplicationPreferencesActivity_unregistering, R.string.ApplicationPreferencesActivity_unregistering_from_textsecure_messages);
         this.checkBoxPreference = checkBoxPreference;
       }
 
@@ -178,8 +178,8 @@ public class AdvancedPreferenceFragment extends PreferenceFragment {
       if (((CheckBoxPreference)preference).isChecked()) {
         AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(getActivity());
         builder.setIconAttribute(R.attr.dialog_info_icon);
-        builder.setTitle(R.string.ApplicationPreferencesActivity_disable_push_messages);
-        builder.setMessage(R.string.ApplicationPreferencesActivity_this_will_disable_push_messages);
+        builder.setTitle(R.string.ApplicationPreferencesActivity_disable_textsecure_messages);
+        builder.setMessage(R.string.ApplicationPreferencesActivity_this_will_disable_textsecure_messages);
         builder.setNegativeButton(android.R.string.cancel, null);
         builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
           @Override


### PR DESCRIPTION
Fixes #3253
Follow up to #2682 

* Changed "push messages" to "TextSecure messages"
* Changed "data based communication" to "TextSecure messages"

Before:

![sidebyeach-before-pr](https://cloud.githubusercontent.com/assets/11031903/7788625/f0253878-027d-11e5-8827-34ebcc5a91c1.png)

After:

![sidebyeach-after-pr-02](https://cloud.githubusercontent.com/assets/11031903/7876535/665dc5e0-0608-11e5-8232-2258842d5e81.png)


