### PR TITLE
prevent early callback death

### DIFF
--- a/src/org/thoughtcrime/securesms/components/emoji/EmojiEditText.java
+++ b/src/org/thoughtcrime/securesms/components/emoji/EmojiEditText.java
@@ -1,11 +1,14 @@
 package org.thoughtcrime.securesms.components.emoji;
 
 import android.content.Context;
+import android.graphics.drawable.Drawable.Callback;
 import android.support.v7.widget.AppCompatEditText;
 import android.util.AttributeSet;
 
 
 public class EmojiEditText extends AppCompatEditText {
+  private final Callback callback = new PostInvalidateCallback(this);
+
   public EmojiEditText(Context context) {
     super(context);
   }
@@ -31,7 +34,7 @@ public class EmojiEditText extends AppCompatEditText {
     final char[]       chars = Character.toChars(codePoint);
     final CharSequence text  = EmojiProvider.getInstance(getContext()).emojify(new String(chars),
                                                                                EmojiProvider.EMOJI_SMALL,
-                                                                               new PostInvalidateCallback(this));
+                                                                               callback);
 
     getText().replace(Math.min(start, end), Math.max(start, end), text);
     setSelection(end + chars.length);

--- a/src/org/thoughtcrime/securesms/components/emoji/EmojiTextView.java
+++ b/src/org/thoughtcrime/securesms/components/emoji/EmojiTextView.java
@@ -1,10 +1,13 @@
 package org.thoughtcrime.securesms.components.emoji;
 
 import android.content.Context;
+import android.graphics.drawable.Drawable.Callback;
 import android.support.v7.widget.AppCompatTextView;
 import android.util.AttributeSet;
 
 public class EmojiTextView extends AppCompatTextView {
+  private final Callback callback = new PostInvalidateCallback(this);
+
   public EmojiTextView(Context context) {
     super(context);
   }
@@ -20,7 +23,7 @@ public class EmojiTextView extends AppCompatTextView {
   @Override public void setText(CharSequence text, BufferType type) {
     super.setText(EmojiProvider.getInstance(getContext()).emojify(text,
                                                                   EmojiProvider.EMOJI_SMALL,
-                                                                  new PostInvalidateCallback(this)),
+                                                                  callback),
                   BufferType.SPANNABLE);
   }
 }


### PR DESCRIPTION
android is so dumb.

In its documentation for `setCallback(Drawable)`: "Bind a Drawable.Callback object to this Drawable. Required for clients that want to support animated drawables."

In its code: 
```java

public final void setCallback(Callback cb) {
    mCallback = new WeakReference<Callback>(cb);
}
```

There were no hard references for the callback so it was just getting GC'd and then nothing was being redrawn.

Deep breath.
Fixes #3255
