### PR TITLE
no more emoji pane fragment

### DIFF
--- a/res/layout/conversation_activity.xml
+++ b/res/layout/conversation_activity.xml
@@ -139,8 +139,10 @@
         </LinearLayout>
     </RelativeLayout>
 
-    <FrameLayout android:id="@+id/emoji_drawer"
-                 android:layout_width="match_parent"
-                 android:layout_height="wrap_content" />
+    <ViewStub android:id="@+id/emoji_drawer_stub"
+              android:inflatedId="@+id/emoji_drawer"
+              android:layout="@layout/emoji_drawer_stub"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content" />
 
 </LinearLayout>

--- a/res/layout/emoji_drawer_stub.xml
+++ b/res/layout/emoji_drawer_stub.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<org.thoughtcrime.securesms.components.emoji.EmojiDrawer
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_weight="1.1" />

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -41,6 +41,7 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.View.OnFocusChangeListener;
 import android.view.View.OnKeyListener;
+import android.view.ViewStub;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.ImageButton;
@@ -150,7 +151,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private AttachmentManager             attachmentManager;
   private BroadcastReceiver             securityUpdateReceiver;
   private BroadcastReceiver             groupUpdateReceiver;
-  private Optional<EmojiDrawer>         emojiDrawer;
+  private Optional<EmojiDrawer>         emojiDrawer = Optional.absent();
   private EmojiToggle                   emojiToggle;
 
   private Recipients recipients;
@@ -690,7 +691,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     attachButton   = (ImageButton) findViewById(R.id.attach_button);
     composeText    = (ComposeText) findViewById(R.id.embedded_text_editor);
     charactersLeft = (TextView)    findViewById(R.id.space_left);
-    emojiDrawer    = Optional.absent();
     emojiToggle    = (EmojiToggle) findViewById(R.id.emoji_toggle);
 
     attachmentAdapter = new AttachmentTypeSelectorAdapter(this);
@@ -720,15 +720,10 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
   private EmojiDrawer getEmojiDrawer() {
     if (emojiDrawer.isPresent()) return emojiDrawer.get();
-
-    EmojiDrawer emojiDrawerFragment = EmojiDrawer.newInstance();
-    emojiDrawerFragment.setComposeEditText(composeText);
-    getSupportFragmentManager().beginTransaction()
-                               .add(R.id.emoji_drawer, emojiDrawerFragment)
-                               .commit();
-    getSupportFragmentManager().executePendingTransactions();
-    emojiDrawer = Optional.of(emojiDrawerFragment);
-    return emojiDrawerFragment;
+    EmojiDrawer emojiDrawer = (EmojiDrawer)((ViewStub)findViewById(R.id.emoji_drawer_stub)).inflate();
+    emojiDrawer.setComposeEditText(composeText);
+    this.emojiDrawer = Optional.of(emojiDrawer);
+    return emojiDrawer;
   }
 
   private boolean isEmojiDrawerOpen() {

--- a/src/org/thoughtcrime/securesms/components/emoji/EmojiEditText.java
+++ b/src/org/thoughtcrime/securesms/components/emoji/EmojiEditText.java
@@ -17,9 +17,7 @@ public class EmojiEditText extends AppCompatEditText {
     super(context, attrs);
   }
 
-  public EmojiEditText(Context context, AttributeSet attrs,
-                       int defStyleAttr)
-  {
+  public EmojiEditText(Context context, AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
   }
 

--- a/src/org/thoughtcrime/securesms/components/emoji/EmojiPageView.java
+++ b/src/org/thoughtcrime/securesms/components/emoji/EmojiPageView.java
@@ -1,11 +1,10 @@
 package org.thoughtcrime.securesms.components.emoji;
 
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
-import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.v4.app.Fragment;
+import android.os.Build.VERSION_CODES;
+import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -13,25 +12,38 @@ import android.widget.AbsListView;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
 import android.widget.BaseAdapter;
+import android.widget.FrameLayout;
 import android.widget.GridView;
 import android.widget.ImageView;
 
 import org.thoughtcrime.securesms.R;
 
-public class EmojiPageFragment extends Fragment {
-  private static final String TAG = EmojiPageFragment.class.getSimpleName();
+public class EmojiPageView extends FrameLayout {
+  private static final String TAG = EmojiPageView.class.getSimpleName();
 
   private EmojiPageModel         model;
   private EmojiSelectionListener listener;
   private GridView               grid;
 
-  public static EmojiPageFragment newInstance(@NonNull EmojiPageModel model,
-                                              @Nullable EmojiSelectionListener listener)
-  {
-    EmojiPageFragment fragment = new EmojiPageFragment();
-    fragment.setModel(model);
-    fragment.setEmojiSelectedListener(listener);
-    return fragment;
+  public EmojiPageView(Context context) {
+    super(context);
+    init();
+  }
+
+  public EmojiPageView(Context context, AttributeSet attrs) {
+    super(context, attrs);
+    init();
+  }
+
+  public EmojiPageView(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    init();
+  }
+
+  @TargetApi(VERSION_CODES.LOLLIPOP)
+  public EmojiPageView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+    super(context, attrs, defStyleAttr, defStyleRes);
+    init();
   }
 
   public void onSelected() {
@@ -40,10 +52,8 @@ public class EmojiPageFragment extends Fragment {
     }
   }
 
-  @Nullable @Override public View onCreateView(LayoutInflater inflater, ViewGroup container,
-                                               Bundle savedInstanceState)
-  {
-    final View view = inflater.inflate(R.layout.emoji_grid_layout, container, false);
+  private void init() {
+    final View view = LayoutInflater.from(getContext()).inflate(R.layout.emoji_grid_layout, this, true);
     grid = (GridView) view.findViewById(R.id.emoji);
     grid.setColumnWidth(getResources().getDimensionPixelSize(R.dimen.emoji_drawer_size) + 2 * getResources().getDimensionPixelSize(R.dimen.emoji_drawer_item_padding));
     grid.setOnItemClickListener(new OnItemClickListener() {
@@ -51,12 +61,11 @@ public class EmojiPageFragment extends Fragment {
         if (listener != null) listener.onEmojiSelected((Integer)view.getTag());
       }
     });
-    grid.setAdapter(new EmojiGridAdapter(getActivity(), model));
-    return view;
   }
 
   public void setModel(EmojiPageModel model) {
     this.model = model;
+    grid.setAdapter(new EmojiGridAdapter(getContext(), model));
   }
 
   public void setEmojiSelectedListener(EmojiSelectionListener listener) {


### PR DESCRIPTION
It looks like the NPE is caused by the fragment throwing out instance state when configuration changes happen. This can be fixed by going back to using regular views, which is necessary anyway to move the emoji panel to a PopupWindow to avoid the window spazzing when opening the keyboard.