### PR TITLE
fix jpeg compression max limit issues

### DIFF
--- a/src/org/thoughtcrime/securesms/mms/MmsMediaConstraints.java
+++ b/src/org/thoughtcrime/securesms/mms/MmsMediaConstraints.java
@@ -1,7 +1,7 @@
 package org.thoughtcrime.securesms.mms;
 
 public class MmsMediaConstraints extends MediaConstraints {
-  private static final int MAX_IMAGE_DIMEN  = 1280;
+  private static final int MAX_IMAGE_DIMEN  = 1024;
   public  static final int MAX_MESSAGE_SIZE = 280 * 1024;
 
   @Override

--- a/src/org/thoughtcrime/securesms/mms/PushMediaConstraints.java
+++ b/src/org/thoughtcrime/securesms/mms/PushMediaConstraints.java
@@ -17,7 +17,7 @@ public class PushMediaConstraints extends MediaConstraints {
 
   @Override
   public int getImageMaxSize() {
-    return 300 * KB;
+    return 420 * KB;
   }
 
   @Override


### PR DESCRIPTION
1) Increase max image size when sending via push
2) Decrease max image dimen when sending via MMS

Fixes #3070
