### PR TITLE
Convert AsyncTask to IntentService

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -247,6 +247,8 @@
     </service>
 
     <service android:name=".ExportFragment$ExportPlaintextService" android:exported="false"/>
+    <service android:name=".ImportFragment$ImportPlaintextBackupService" android:exported="false"/>
+    <service android:name=".ImportFragment$ImportEncryptedBackupService" android:exported="false"/>
 
 
     <receiver android:name=".gcm.GcmBroadcastReceiver" android:permission="com.google.android.c2dm.permission.SEND" >

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -253,6 +253,7 @@
     <service android:name=".PassphraseChangeActivity$ChangePassphraseService" android:exported="false"/>
     <service android:name=".ConversationListActivity$MarkAllRead" android:exported="false"/>
     <service android:name=".MediaPreviewActivity$FetchImage" android:exported="false"/>
+    <service android:name=".GroupCreateActivity$DecodeCropAndSetService" android:exported="false"/>
 
 
     <receiver android:name=".gcm.GcmBroadcastReceiver" android:permission="com.google.android.c2dm.permission.SEND" >

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -254,6 +254,7 @@
     <service android:name=".ConversationListActivity$MarkAllRead" android:exported="false"/>
     <service android:name=".MediaPreviewActivity$FetchImage" android:exported="false"/>
     <service android:name=".GroupCreateActivity$DecodeCropAndSetService" android:exported="false"/>
+    <service android:name=".preferences.MmsPreferencesFragment$LoadApnDefaultsService" android:exported="false"/>
 
 
     <receiver android:name=".gcm.GcmBroadcastReceiver" android:permission="com.google.android.c2dm.permission.SEND" >

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -252,6 +252,7 @@
     <service android:name=".PassphraseCreateActivity$SecretGenerator" android:exported="false"/>
     <service android:name=".PassphraseChangeActivity$ChangePassphraseService" android:exported="false"/>
     <service android:name=".ConversationListActivity$MarkAllRead" android:exported="false"/>
+    <service android:name=".MediaPreviewActivity$FetchImage" android:exported="false"/>
 
 
     <receiver android:name=".gcm.GcmBroadcastReceiver" android:permission="com.google.android.c2dm.permission.SEND" >

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -251,6 +251,7 @@
     <service android:name=".ImportFragment$ImportEncryptedBackupService" android:exported="false"/>
     <service android:name=".PassphraseCreateActivity$SecretGenerator" android:exported="false"/>
     <service android:name=".PassphraseChangeActivity$ChangePassphraseService" android:exported="false"/>
+    <service android:name=".ConversationListActivity$MarkAllRead" android:exported="false"/>
 
 
     <receiver android:name=".gcm.GcmBroadcastReceiver" android:permission="com.google.android.c2dm.permission.SEND" >

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -250,6 +250,7 @@
     <service android:name=".ImportFragment$ImportPlaintextBackupService" android:exported="false"/>
     <service android:name=".ImportFragment$ImportEncryptedBackupService" android:exported="false"/>
     <service android:name=".PassphraseCreateActivity$SecretGenerator" android:exported="false"/>
+    <service android:name=".PassphraseChangeActivity$ChangePassphraseService" android:exported="false"/>
 
 
     <receiver android:name=".gcm.GcmBroadcastReceiver" android:permission="com.google.android.c2dm.permission.SEND" >

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -246,6 +246,8 @@
         </intent-filter>
     </service>
 
+    <service android:name=".ExportFragment$ExportPlaintextService" android:exported="false"/>
+
 
     <receiver android:name=".gcm.GcmBroadcastReceiver" android:permission="com.google.android.c2dm.permission.SEND" >
         <intent-filter>

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -249,6 +249,7 @@
     <service android:name=".ExportFragment$ExportPlaintextService" android:exported="false"/>
     <service android:name=".ImportFragment$ImportPlaintextBackupService" android:exported="false"/>
     <service android:name=".ImportFragment$ImportEncryptedBackupService" android:exported="false"/>
+    <service android:name=".PassphraseCreateActivity$SecretGenerator" android:exported="false"/>
 
 
     <receiver android:name=".gcm.GcmBroadcastReceiver" android:permission="com.google.android.c2dm.permission.SEND" >

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -16,14 +16,15 @@
  */
 package org.thoughtcrime.securesms;
 
+import android.app.IntentService;
 import android.content.Intent;
 import android.database.ContentObserver;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 import android.support.v7.app.ActionBar;
 import android.util.Log;
+import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v7.widget.SearchView;
 import android.view.Menu;
@@ -195,14 +196,9 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
   }
 
   private void handleMarkAllRead() {
-    new AsyncTask<Void, Void, Void>() {
-      @Override
-      protected Void doInBackground(Void... params) {
-        DatabaseFactory.getThreadDatabase(ConversationListActivity.this).setAllThreadsRead();
-        MessageNotifier.updateNotification(ConversationListActivity.this, masterSecret);
-        return null;
-      }
-    }.execute();
+    Intent markAllRead = new Intent(this, MarkAllRead.class);
+    markAllRead.putExtra("masterSecret", masterSecret);
+    startService(markAllRead);
   }
 
   private void initializeContactUpdatesReceiver() {
@@ -224,5 +220,17 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
 
     getContentResolver().registerContentObserver(ContactsContract.Contacts.CONTENT_URI,
                                                  true, observer);
+  }
+
+  public static class MarkAllRead extends IntentService {
+    public MarkAllRead() {
+      super("MarkAllRead");
+    }
+
+    public void onHandleIntent(Intent intent) {
+      MasterSecret masterSecret = (MasterSecret) intent.getParcelableExtra("masterSecret");
+      DatabaseFactory.getThreadDatabase(this).setAllThreadsRead();
+      MessageNotifier.updateNotification(this, masterSecret);
+    }
   }
 }

--- a/src/org/thoughtcrime/securesms/mms/LegacyMmsConnection.java
+++ b/src/org/thoughtcrime/securesms/mms/LegacyMmsConnection.java
@@ -207,8 +207,9 @@ public abstract class LegacyMmsConnection {
     }};
   }
 
-  public static class Apn {
+  public static class Apn implements java.io.Serializable {
 
+    private static final long serialVersionUID = -7017083351546877014L;
     public static Apn EMPTY = new Apn("", "", "", "", "");
 
     private final String mmsc;


### PR DESCRIPTION
Hi `TextSecure` developers, I'm doing research on Android async programming, particularly on 
AsyncTask and IntentService. AsyncTask can lead to memory leak and losing task result when GUI is recreated during task running (such as orientation change). [This article](http://bon-app-etit.blogspot.com/2013/04/the-dark-side-of-asynctask.html) describes the problems very well. 

We discussed with some Android experts and they agree with this issue, and claim that AsyncTask can be considered only for short tasks (less than 1 second). However, using IntentService (or AsyncTaskLoader) can avoid such problems since their lifecycles are independent from `Activity`/`Fragment`.

In `TextSecure`, the AsyncTasks are declared as non-static inner classes of `Activity`/`Fragment`. So the above issue can occur (especially for relatively long tasks).

I refactored 9 AsyncTasks in `TextSecure` to IntentService (in 8 separate commits), with the help of a refactoring tool we developed. Do you think using IntentService should be better in some of these 9  scenario? Do you want to merge some commits in this pr? Thanks.