### PR TITLE
Enable media message forwarding

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -250,9 +250,32 @@ public class ConversationFragment extends ListFragment
   }
 
   private void handleForwardMessage(MessageRecord message) {
+    if (message.isMms()) handleForwardMediaMessage((MediaMmsMessageRecord)message);
+    else                 handleForwardTextMessage(message);
+  }
+
+  private void handleForwardTextMessage(MessageRecord message) {
     Intent composeIntent = new Intent(getActivity(), ShareActivity.class);
     composeIntent.putExtra(Intent.EXTRA_TEXT, message.getDisplayBody().toString());
     startActivity(composeIntent);
+  }
+
+  private void handleForwardMediaMessage(final MediaMmsMessageRecord message) {
+    message.fetchMediaSlide(new FutureTaskListener<Slide>() {
+      @Override
+      public void onSuccess(Slide slide) {
+        Intent composeIntent = new Intent(getActivity(), ShareActivity.class);
+        composeIntent.putExtra(Intent.EXTRA_TEXT, message.getDisplayBody().toString());
+        composeIntent.putExtra(Intent.EXTRA_STREAM, slide.getUri());
+        composeIntent.setType(slide.getContentType());
+        startActivity(composeIntent);
+      }
+
+      @Override
+      public void onFailure(Throwable error) {
+        handleForwardTextMessage(message);
+      }
+    });
   }
 
   private void handleResendMessage(final MessageRecord message) {

--- a/src/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/org/thoughtcrime/securesms/ShareActivity.java
@@ -158,6 +158,8 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity
     if (type == null) {
       String extension = MimeTypeMap.getFileExtensionFromUrl(uri.toString());
       type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
+
+      if (type == null) return getIntent().getType();
     }
 
     return type;

--- a/src/org/thoughtcrime/securesms/mms/PartAuthority.java
+++ b/src/org/thoughtcrime/securesms/mms/PartAuthority.java
@@ -16,8 +16,8 @@ import java.io.InputStream;
 
 public class PartAuthority {
 
-  private static final String PART_URI_STRING   = "content://org.thoughtcrime.securesms/part";
-  private static final String THUMB_URI_STRING  = "content://org.thoughtcrime.securesms/thumb";
+  private static final String PART_URI_STRING   = "content://org.thoughtcrime.provider.securesms/part";
+  private static final String THUMB_URI_STRING  = "content://org.thoughtcrime.provider.securesms/thumb";
   private static final Uri    PART_CONTENT_URI  = Uri.parse(PART_URI_STRING);
   private static final Uri    THUMB_CONTENT_URI = Uri.parse(THUMB_URI_STRING);
 
@@ -29,8 +29,8 @@ public class PartAuthority {
 
   static {
     uriMatcher = new UriMatcher(UriMatcher.NO_MATCH);
-    uriMatcher.addURI("org.thoughtcrime.securesms", "part/*/#", PART_ROW);
-    uriMatcher.addURI("org.thoughtcrime.securesms", "thumb/*/#", THUMB_ROW);
+    uriMatcher.addURI("org.thoughtcrime.provider.securesms", "part/*/#", PART_ROW);
+    uriMatcher.addURI("org.thoughtcrime.provider.securesms", "thumb/*/#", THUMB_ROW);
     uriMatcher.addURI(CaptureProvider.AUTHORITY, CaptureProvider.EXPECTED_PATH, CAPTURE_ROW);
   }
 
@@ -69,5 +69,9 @@ public class PartAuthority {
   public static Uri getThumbnailUri(PartDatabase.PartId partId) {
     Uri uri = Uri.withAppendedPath(THUMB_CONTENT_URI, String.valueOf(partId.getUniqueId()));
     return ContentUris.withAppendedId(uri, partId.getRowId());
+  }
+
+  public static boolean isPartAuthorityPart(Uri uri) {
+    return uri.getAuthority().equals(PART_CONTENT_URI.getAuthority());
   }
 }


### PR DESCRIPTION
This is a stew mainly of #2886 with some nice chunks of #2236 

- Tested forwarding to existing as well as new (group-)convos.
- Tested on a 5.0.2 device and KK emulator. Couldn't get a play service enabled GB emu - can't use a new TS installation without play services... :disappointed: 

All media works fine as well as text and text + media.