### PR TITLE
fix messages with push flag *and* sms flag set...

### DIFF
--- a/src/org/thoughtcrime/securesms/database/MmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MmsDatabase.java
@@ -378,7 +378,7 @@ public class MmsDatabase extends MessagingDatabase {
   }
 
   public void markAsForcedSms(long messageId) {
-    updateMailboxBitmask(messageId, 0, Types.MESSAGE_FORCE_SMS_BIT);
+    updateMailboxBitmask(messageId, Types.PUSH_MESSAGE_BIT, Types.MESSAGE_FORCE_SMS_BIT);
     notifyConversationListeners(getThreadIdForMessage(messageId));
   }
 

--- a/src/org/thoughtcrime/securesms/database/SmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/SmsDatabase.java
@@ -198,7 +198,7 @@ public class SmsDatabase extends MessagingDatabase {
   }
 
   public void markAsForcedSms(long id) {
-    updateTypeBitmask(id, 0, Types.MESSAGE_FORCE_SMS_BIT);
+    updateTypeBitmask(id, Types.PUSH_MESSAGE_BIT, Types.MESSAGE_FORCE_SMS_BIT);
   }
 
   public void markAsDecryptFailed(long id) {

--- a/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -135,7 +135,7 @@ public abstract class MessageRecord extends DisplayRecord {
   }
 
   public boolean isPush() {
-    return SmsDatabase.Types.isPushType(type);
+    return SmsDatabase.Types.isPushType(type) && !SmsDatabase.Types.isForcedSms(type);
   }
 
   public boolean isForcedSms() {


### PR DESCRIPTION
The insecure message approval logic sets the message as forced SMS but doesn't unset the push flag, so all our view logic was displaying insecure-fallback SMS messages as push without a lock. 

origin: https://github.com/WhisperSystems/TextSecure/blob/master/src/org/thoughtcrime/securesms/ConversationItem.java#L511