### PR TITLE
store direct captures internally

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -299,7 +299,7 @@
               android:grantUriPermissions="true"
               android:authorities="org.thoughtcrime.provider.securesms" />
 
-    <provider android:name=".providers.MmsBodyProvider"
+    <provider android:name=".providers.BodyProvider"
               android:grantUriPermissions="true"
               android:authorities="org.thoughtcrime.provider.securesms.mms" />
 

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -258,7 +258,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       break;
     case CAPTURE_PHOTO:
       if (attachmentManager.getCaptureFile() != null) {
-        addAttachmentImage(Uri.fromFile(attachmentManager.getCaptureFile()));
+        addAttachmentImage(attachmentManager.getCaptureFile().getUri());
       }
       break;
     case GROUP_EDIT:
@@ -801,7 +801,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       attachmentManager.setImage(imageUri);
     } catch (IOException | BitmapDecodingException e) {
       Log.w(TAG, e);
-      attachmentManager.clear();
+      attachmentManager.abandon();
       Toast.makeText(this, R.string.ConversationActivity_sorry_there_was_an_error_setting_your_attachment,
                      Toast.LENGTH_LONG).show();
     }
@@ -811,12 +811,12 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     try {
       attachmentManager.setVideo(videoUri);
     } catch (IOException e) {
-      attachmentManager.clear();
+      attachmentManager.abandon();
       Toast.makeText(this, R.string.ConversationActivity_sorry_there_was_an_error_setting_your_attachment,
                      Toast.LENGTH_LONG).show();
       Log.w("ComposeMessageActivity", e);
     } catch (MediaTooLargeException e) {
-      attachmentManager.clear();
+      attachmentManager.abandon();
 
       Toast.makeText(this, getString(R.string.ConversationActivity_sorry_the_selected_video_exceeds_message_size_restrictions,
                                      (MmsMediaConstraints.MAX_MESSAGE_SIZE/1024)),
@@ -829,12 +829,12 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     try {
       attachmentManager.setAudio(audioUri);
     } catch (IOException e) {
-      attachmentManager.clear();
+      attachmentManager.abandon();
       Toast.makeText(this, R.string.ConversationActivity_sorry_there_was_an_error_setting_your_attachment,
                      Toast.LENGTH_LONG).show();
       Log.w("ComposeMessageActivity", e);
     } catch (MediaTooLargeException e) {
-      attachmentManager.clear();
+      attachmentManager.abandon();
       Toast.makeText(this, getString(R.string.ConversationActivity_sorry_the_selected_audio_exceeds_message_size_restrictions,
                                      (MmsMediaConstraints.MAX_MESSAGE_SIZE/1024)),
                      Toast.LENGTH_LONG).show();

--- a/src/org/thoughtcrime/securesms/mms/IncomingLollipopMmsConnection.java
+++ b/src/org/thoughtcrime/securesms/mms/IncomingLollipopMmsConnection.java
@@ -26,7 +26,7 @@ import android.support.annotation.Nullable;
 import android.telephony.SmsManager;
 import android.util.Log;
 
-import org.thoughtcrime.securesms.providers.MmsBodyProvider;
+import org.thoughtcrime.securesms.providers.BodyProvider;
 import org.thoughtcrime.securesms.util.Hex;
 import org.thoughtcrime.securesms.util.Util;
 
@@ -63,7 +63,7 @@ public class IncomingLollipopMmsConnection extends LollipopMmsConnection impleme
     beginTransaction();
 
     try {
-      MmsBodyProvider.Pointer pointer = MmsBodyProvider.makeTemporaryPointer(getContext());
+      BodyProvider.Pointer pointer = BodyProvider.makeMmsBodyPointer(getContext());
 
       Log.w(TAG, "downloading multimedia from " + contentLocation + " to " + pointer.getUri());
       SmsManager.getDefault().downloadMultimediaMessage(getContext(),

--- a/src/org/thoughtcrime/securesms/mms/OutgoingLollipopMmsConnection.java
+++ b/src/org/thoughtcrime/securesms/mms/OutgoingLollipopMmsConnection.java
@@ -26,7 +26,7 @@ import android.support.annotation.Nullable;
 import android.telephony.SmsManager;
 import android.util.Log;
 
-import org.thoughtcrime.securesms.providers.MmsBodyProvider;
+import org.thoughtcrime.securesms.providers.BodyProvider;
 import org.thoughtcrime.securesms.transport.UndeliverableMessageException;
 import org.thoughtcrime.securesms.util.Util;
 
@@ -62,7 +62,7 @@ public class OutgoingLollipopMmsConnection extends LollipopMmsConnection impleme
   public @Nullable synchronized SendConf send(@NonNull byte[] pduBytes) throws UndeliverableMessageException {
     beginTransaction();
     try {
-      MmsBodyProvider.Pointer pointer = MmsBodyProvider.makeTemporaryPointer(getContext());
+      BodyProvider.Pointer pointer = BodyProvider.makeMmsBodyPointer(getContext());
       Util.copy(new ByteArrayInputStream(pduBytes), pointer.getOutputStream());
 
       SmsManager.getDefault().sendMultimediaMessage(getContext(),


### PR DESCRIPTION
Anecdotal evidence suggests that direct capture wasn't working using the external storage directory for some people (would just return to the ConversationActivity with nothing attached).

This seems nicer as it limits the visibility of the captured photo at least a bit better since it's not in the /sdcard/ location.