### PR TITLE
fix the AdvancedPreferenceFragmentTest

### DIFF
--- a/test/androidTestEspresso/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragmentTest.java
+++ b/test/androidTestEspresso/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragmentTest.java
@@ -97,7 +97,7 @@ public class AdvancedPreferenceFragmentTest extends TextSecureEspressoTestCase<C
     loadActivity(ConversationListActivity.class, STATE_REGISTERED);
     clickAdvancedSettingAndCheckState();
     AdvancedPreferenceFragmentActions.clickTextSecureMessages();
-    onView(withText(R.string.ApplicationPreferencesActivity_disable_push_messages))
+    onView(withText(R.string.ApplicationPreferencesActivity_disable_textsecure_messages))
           .check(matches(isDisplayed()));
     onView(withText(android.R.string.cancel)).perform(click());
   }


### PR DESCRIPTION
fix the AdvancedPreferenceFragmentTest to use new string resource introduced in 0cf92061700e9fa00bb833cc64ed328d192763e5

// FREEBIE