### PR TITLE
fix checkbox overlap with fastscroll

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ repositories {
 
 dependencies {
     compile 'me.leolin:ShortcutBadger:1.1.0-WS1'
-    compile 'se.emilsjolander:stickylistheaders:2.2.0'
+    compile 'se.emilsjolander:stickylistheaders:2.7.0'
     compile 'com.google.android.gms:play-services-base:6.5.87'
     compile 'com.jpardogo.materialtabstrip:library:1.0.9'
     compile 'org.w3c:smil:1.0.0'
@@ -90,7 +90,7 @@ dependencies {
 dependencyVerification {
     verify = [
             'me.leolin:ShortcutBadger:3142d017234bfa0cdd69ccded7cc5ea63f13b97574803c8c616c9bbeaad33ad9',
-            'se.emilsjolander:stickylistheaders:89146b46c96fea0e40200474a2625cda10fe94891e4128f53cdb42375091b9b6',
+            'se.emilsjolander:stickylistheaders:a08ca948aa6b220f09d82f16bbbac395f6b78897e9eeac6a9f0b0ba755928eeb',
             'com.google.android.gms:play-services-base:832cb6b3130e871db6a412c4ab585656dbcc5e7948101f190186757785703f75',
             'com.jpardogo.materialtabstrip:library:c6ef812fba4f74be7dc4a905faa4c2908cba261a94c13d4f96d5e67e4aad4aaa',
             'org.w3c:smil:085dc40f2bb249651578bfa07499fd08b16ad0886dbe2c4078586a408da62f9b',

--- a/res/layout/push_contact_selection_list_item.xml
+++ b/res/layout/push_contact_selection_list_item.xml
@@ -4,7 +4,7 @@
                 xmlns:android="http://schemas.android.com/apk/res/android"
                 android:layout_width="match_parent"
                 android:layout_height="?android:attr/listPreferredItemHeight"
-                android:paddingRight="25dip">
+                android:paddingRight="50dp">
 
     <ImageView
         android:id="@+id/contact_photo_image"

--- a/src/org/thoughtcrime/securesms/PushContactSelectionListFragment.java
+++ b/src/org/thoughtcrime/securesms/PushContactSelectionListFragment.java
@@ -123,7 +123,7 @@ public class PushContactSelectionListFragment extends    Fragment
       @Override
       public void onTextChanged(CharSequence charSequence, int i, int i2, int i3) {
         cursorFilter = charSequence.toString();
-        getLoaderManager().restartLoader(0, null, PushContactSelectionListFragment.this);
+        update();
       }
 
       @Override
@@ -151,8 +151,6 @@ public class PushContactSelectionListFragment extends    Fragment
   public void onLoadFinished(Loader<Cursor> loader, Cursor data) {
     ((CursorAdapter) listView.getAdapter()).changeCursor(data);
     emptyText.setText(R.string.contact_selection_group_activity__no_contacts);
-    if (data != null && data.getCount() < 40) listView.setFastScrollAlwaysVisible(false);
-    else                                      listView.setFastScrollAlwaysVisible(true);
   }
 
   @Override


### PR DESCRIPTION
Styling the fastscroll and changing its size is nontrivial, so I'm going to wait until we convert to a RecyclerView to make it fancier. In the mean time, updated the sticky list headers library to fix a memory leak.