### PR TITLE
add "Notification settings" to menu in ConversationActivity

### DIFF
--- a/res/menu/conversation.xml
+++ b/res/menu/conversation.xml
@@ -10,4 +10,6 @@
     <item android:title="@string/conversation__menu_delete_thread"
           android:id="@+id/menu_delete_thread" />
 
+    <item android:title="@string/conversation__menu_notification_settings"
+          android:id="@+id/menu_notification_settings" />
 </menu>

--- a/res/menu/conversation_unmuted.xml
+++ b/res/menu/conversation_unmuted.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <item android:title="@string/conversation_unmuted__mute_notifications"
-          android:id="@+id/menu_mute_notifications" />
-
-</menu>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -888,15 +888,13 @@
     <!-- conversation_muted -->
     <string name="conversation_muted__unmute">Unmute</string>
 
-    <!-- conversation_unmuted -->
-    <string name="conversation_unmuted__mute_notifications">Mute notifications</string>
-
     <!-- conversation -->
     <string name="conversation__menu_add_attachment">Add attachment</string>
     <string name="conversation__menu_update_group">Update group</string>
     <string name="conversation__menu_leave_group">Leave group</string>
     <string name="conversation__menu_delete_thread">Delete thread</string>
     <string name="conversation__menu_view_media">All images</string>
+    <string name="conversation__menu_notification_settings">Notification settings</string>
 
     <!-- conversation_callable -->
     <string name="conversation_add_to_contacts__menu_add_to_contacts">Add to contacts</string>
@@ -947,8 +945,9 @@
 
     <!-- transport_selection_list_item -->
     <string name="transport_selection_list_item__transport_icon">Transport icon</string>
-    <string name="MuteDialog_mute_notifications">Mute notifications</string>
 
+    <!-- MuteDialog -->
+    <string name="MuteDialog_mute_notifications">Mute notifications</string>
 
     <!-- EOF -->
 

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -310,7 +310,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     inflater.inflate(R.menu.conversation, menu);
 
     if (recipients != null && recipients.isMuted()) inflater.inflate(R.menu.conversation_muted, menu);
-    else                                            inflater.inflate(R.menu.conversation_unmuted, menu);
 
     if (isSingleConversation() && getRecipients().getPrimaryRecipient().getContactUri() == null) {
       inflater.inflate(R.menu.conversation_add_to_contacts, menu);
@@ -337,7 +336,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     case R.id.menu_edit_group:                handleEditPushGroup();                             return true;
     case R.id.menu_leave:                     handleLeavePushGroup();                            return true;
     case R.id.menu_invite:                    handleInviteLink();                                return true;
-    case R.id.menu_mute_notifications:        handleMuteNotifications();                         return true;
+    case R.id.menu_notification_settings:     handleNotificationSettings();                      return true;
     case R.id.menu_unmute_notifications:      handleUnmuteNotifications();                       return true;
     case android.R.id.home:                   handleReturnToConversationList();                  return true;
     }
@@ -364,23 +363,10 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     finish();
   }
 
-  private void handleMuteNotifications() {
-    MuteDialog.show(this, new MuteDialog.MuteSelectionListener() {
-      @Override
-      public void onMuted(final long until) {
-        recipients.setMuted(until);
-
-        new AsyncTask<Void, Void, Void>() {
-          @Override
-          protected Void doInBackground(Void... params) {
-            DatabaseFactory.getRecipientPreferenceDatabase(ConversationActivity.this)
-                           .setMuted(recipients, until);
-
-            return null;
-          }
-        }.execute();
-      }
-    });
+  private void handleNotificationSettings() {
+    Intent intent = new Intent(ConversationActivity.this, RecipientPreferenceActivity.class);
+    intent.putExtra(RecipientPreferenceActivity.RECIPIENTS_EXTRA, recipients.getIds());
+    startActivity(intent);
   }
 
   private void handleUnmuteNotifications() {


### PR DESCRIPTION
This removes `Mute notifications`from the menu and adds `Notification settings` which will open the `RecipientPreferenceActivity`. When a conversation is muted `Unmute` will be still in the menu.

Fixes #3395

 // FREEBIE