### PR TITLE
revert to android gradle plugin 1.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:1.0.1'
         classpath files('libs/gradle-witness.jar')
     }
 }


### PR DESCRIPTION
revert to android gradle plugin 1.0.1 until we figure out why 1.2.3 can't produce the automation build type.

// FREEBIE