### PR TITLE
give dev build its own appId

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -7,11 +7,11 @@
 
     <uses-sdk tools:overrideLibrary="com.amulyakhare.textdrawable,com.astuetz.pagerslidingtabstrip,pl.tajchert.waitingdots"/>
 
-    <permission android:name="org.thoughtcrime.securesms.ACCESS_SECRETS"
+    <permission android:name="${applicationId}.ACCESS_SECRETS"
                 android:label="Access to TextSecure Secrets"
                 android:protectionLevel="signature" />
 
-    <uses-permission android:name="org.thoughtcrime.securesms.ACCESS_SECRETS"/>
+    <uses-permission android:name="${applicationId}.ACCESS_SECRETS"/>
     <uses-permission android:name="android.permission.READ_PROFILE"/>
     <uses-permission android:name="android.permission.WRITE_PROFILE"/>
     <uses-permission android:name="android.permission.BROADCAST_WAP_PUSH"
@@ -35,9 +35,9 @@
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
 
-    <permission android:name="org.thoughtcrime.securesms.permission.C2D_MESSAGE"
+    <permission android:name="${applicationId}.permission.C2D_MESSAGE"
                 android:protectionLevel="signature" />
-    <uses-permission android:name="org.thoughtcrime.securesms.permission.C2D_MESSAGE" />
+    <uses-permission android:name="${applicationId}.permission.C2D_MESSAGE" />
 
     <application android:name=".ApplicationContext"
                  android:icon="@drawable/icon"
@@ -318,11 +318,11 @@
 
     <provider android:name=".providers.PartProvider"
               android:grantUriPermissions="true"
-              android:authorities="org.thoughtcrime.provider.securesms" />
+              android:authorities="${applicationId}.provider" />
 
     <provider android:name=".providers.MmsBodyProvider"
               android:grantUriPermissions="true"
-              android:authorities="org.thoughtcrime.provider.securesms.mms" />
+              android:authorities="${applicationId}.provider.mms" />
 
     <receiver android:name=".service.RegistrationNotifier"
               android:exported="false">

--- a/build.gradle
+++ b/build.gradle
@@ -154,6 +154,7 @@ android {
     }
 
     defaultConfig {
+        applicationId "org.thoughtcrime.securesms"
         minSdkVersion 9
         targetSdkVersion 22
 
@@ -211,9 +212,19 @@ android {
         dev.initWith(buildTypes.debug)
         dev {
             buildConfigField "boolean", "DEV_BUILD", "true"
+            applicationIdSuffix ".dev"
+            versionNameSuffix "-dev"
         }
     }
 
+    productFlavors {
+      prod {
+        // defaults
+      }
+      staging {
+        buildConfigField "String", "PUSH_URL", "\"https://textsecure-service-staging.whispersystems.org\""
+      }
+    }
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'


### PR DESCRIPTION
Refactors build.gradle and AndroidManifest.xml so that dev builds package names are suffixed with ".dev", allowing them to coexist peacefully with the production build from play store.

Also made prod and staging build flavors, so you can have either a stagingDev or prodDev build.