### PR TITLE
improve look and feel of batch selection

### DIFF
--- a/res/drawable-v21/received_bubble_background.xml
+++ b/res/drawable-v21/received_bubble_background.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-        android:color="@color/touch_highlight">
+        android:color="#44000000">
     <!--<item android:id="@android:id/mask" android:drawable="@drawable/received_bubble" />-->
     <item>
         <nine-patch android:src="@drawable/received_bubble" />

--- a/res/drawable-v21/received_bubble_background.xml
+++ b/res/drawable-v21/received_bubble_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+        android:color="@color/touch_highlight">
+    <!--<item android:id="@android:id/mask" android:drawable="@drawable/received_bubble" />-->
+    <item>
+        <nine-patch android:src="@drawable/received_bubble" />
+    </item>
+</ripple>

--- a/res/drawable-v21/sent_bubble_background.xml
+++ b/res/drawable-v21/sent_bubble_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+        android:color="@color/touch_highlight">
+    <!--<item android:id="@android:id/mask" android:drawable="@drawable/received_bubble" />-->
+    <item>
+        <nine-patch android:src="@drawable/sent_bubble" />
+    </item>
+</ripple>

--- a/res/drawable/conversation_item_sent_primary_text_states.xml
+++ b/res/drawable/conversation_item_sent_primary_text_states.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_selected="true" android:color="@color/white" />
+    <item android:color="#99000000" />
+</selector>

--- a/res/drawable/received_bubble_background.xml
+++ b/res/drawable/received_bubble_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <nine-patch android:src="@drawable/received_bubble" />
+    </item>
+</selector>

--- a/res/drawable/sent_bubble_background.xml
+++ b/res/drawable/sent_bubble_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <nine-patch android:src="@drawable/sent_bubble" />
+    </item>
+</selector>

--- a/res/layout/conversation_fragment.xml
+++ b/res/layout/conversation_fragment.xml
@@ -13,6 +13,7 @@
               android:transcriptMode="normal"
               android:scrollbarAlwaysDrawVerticalTrack="false"
               android:scrollbarStyle="insideOverlay"
+              android:listSelector="@color/transparent"
               android:stackFromBottom="true"
               android:fadingEdge="none"
               android:divider="@android:color/transparent"

--- a/res/layout/conversation_item_received.xml
+++ b/res/layout/conversation_item_received.xml
@@ -43,7 +43,7 @@
                       android:layout_toRightOf="@id/contact_photo"
                       android:layout_toEndOf="@id/contact_photo"
                       android:layout_marginRight="50dp"
-                      android:background="@drawable/received_bubble"
+                      android:background="@drawable/received_bubble_background"
                       android:orientation="vertical">
 
             <org.thoughtcrime.securesms.components.ThumbnailView

--- a/res/layout/conversation_item_sent.xml
+++ b/res/layout/conversation_item_sent.xml
@@ -52,7 +52,7 @@
                       android:layout_alignParentRight="true"
                       android:layout_marginLeft="50dp"
                       android:layout_marginRight="5dp"
-                      android:background="@drawable/sent_bubble"
+                      android:background="@drawable/sent_bubble_background"
                       android:orientation="vertical">
 
             <org.thoughtcrime.securesms.components.ThumbnailView

--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -127,6 +127,7 @@
 
     <declare-styleable name="AvatarImageView">
         <attr name="inverted" format="boolean"/>
+        <attr name="selectedColor" format="reference|color"/>
     </declare-styleable>
 
 </resources>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -119,7 +119,7 @@
 
 
         <item name="conversation_item_bubble_background">@color/white</item>
-        <item name="conversation_item_sent_text_primary_color">#99000000</item>
+        <item name="conversation_item_sent_text_primary_color">@drawable/conversation_item_sent_primary_text_states</item>
         <item name="conversation_item_sent_text_secondary_color">#bb000000</item>
         <item name="conversation_item_sent_text_indicator_tab_color">#99000000</item>
         <item name="conversation_item_received_text_primary_color">@color/white</item>

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -197,13 +197,19 @@ public class ConversationItem extends LinearLayout {
 
     if (batchSelected.contains(messageRecord)) {
       bodyBubble.getBackground().setColorFilter(getResources().getColor(R.color.textsecure_primary), Mode.MULTIPLY);
-    } else if (messageRecord.isOutgoing()) {
-      bodyBubble.getBackground().setColorFilter(defaultColor, PorterDuff.Mode.MULTIPLY);
+      bodyText.setSelected(true);
+      if (contactPhoto != null) contactPhoto.setSelected(true);
     } else {
-      bodyBubble.getBackground().setColorFilter(messageRecord.getIndividualRecipient()
-                                                             .getColor()
-                                                             .toConversationColor(context),
-                                                Mode.MULTIPLY);
+      bodyText.setSelected(false);
+      if (contactPhoto != null) contactPhoto.setSelected(false);
+      if (messageRecord.isOutgoing()) {
+        bodyBubble.getBackground().setColorFilter(defaultColor, PorterDuff.Mode.MULTIPLY);
+      } else {
+        bodyBubble.getBackground().setColorFilter(messageRecord.getIndividualRecipient()
+                                                               .getColor()
+                                                               .toConversationColor(context),
+                                                  Mode.MULTIPLY);
+      }
     }
 
     colors.recycle();

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -23,6 +23,7 @@ import android.content.Intent;
 import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
+import android.graphics.PorterDuff.Mode;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
@@ -167,7 +168,6 @@ public class ConversationItem extends LinearLayout {
     this.groupThread            = groupThread;
     this.pushDestination        = pushDestination;
 
-    setSelectionBackgroundDrawables(messageRecord);
     setBodyText(messageRecord);
 
     if (hasConversationBubble(messageRecord)) {
@@ -195,31 +195,18 @@ public class ConversationItem extends LinearLayout {
     TypedArray colors       = context.obtainStyledAttributes(attributes);
     int        defaultColor = colors.getColor(0, Color.WHITE);
 
-    if (messageRecord.isOutgoing()) {
+    if (batchSelected.contains(messageRecord)) {
+      bodyBubble.getBackground().setColorFilter(getResources().getColor(R.color.textsecure_primary), Mode.MULTIPLY);
+    } else if (messageRecord.isOutgoing()) {
       bodyBubble.getBackground().setColorFilter(defaultColor, PorterDuff.Mode.MULTIPLY);
     } else {
       bodyBubble.getBackground().setColorFilter(messageRecord.getIndividualRecipient()
                                                              .getColor()
                                                              .toConversationColor(context),
-                                                PorterDuff.Mode.MULTIPLY);
+                                                Mode.MULTIPLY);
     }
 
     colors.recycle();
-  }
-
-  private void setSelectionBackgroundDrawables(MessageRecord messageRecord) {
-    int[]      attributes = new int[]{R.attr.conversation_list_item_background_selected,
-                                      R.attr.conversation_item_background};
-
-    TypedArray drawables  = context.obtainStyledAttributes(attributes);
-
-    if (batchSelected.contains(messageRecord)) {
-      setBackgroundDrawable(drawables.getDrawable(0));
-    } else {
-      setBackgroundDrawable(drawables.getDrawable(1));
-    }
-
-    drawables.recycle();
   }
 
   private boolean hasConversationBubble(MessageRecord messageRecord) {

--- a/src/org/thoughtcrime/securesms/ConversationListItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationListItem.java
@@ -16,8 +16,13 @@
  */
 package org.thoughtcrime.securesms;
 
+import android.annotation.TargetApi;
 import android.content.Context;
+import android.content.res.ColorStateList;
 import android.graphics.Typeface;
+import android.graphics.drawable.RippleDrawable;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
 import android.os.Handler;
 import android.util.AttributeSet;
 import android.view.View;
@@ -102,6 +107,7 @@ public class ConversationListItem extends RelativeLayout
     }
 
     setBatchState(batchMode);
+    setRippleColor(recipients);
     this.contactPhotoImage.setAvatar(recipients, true);
   }
 
@@ -126,6 +132,14 @@ public class ConversationListItem extends RelativeLayout
     return distributionType;
   }
 
+  @TargetApi(VERSION_CODES.LOLLIPOP)
+  public void setRippleColor(Recipients recipients) {
+    if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
+      ((RippleDrawable)(getBackground()).mutate())
+          .setColor(ColorStateList.valueOf(recipients.getColor().toConversationColor(context)));
+    }
+  }
+
   @Override
   public void onModified(final Recipients recipients) {
     handler.post(new Runnable() {
@@ -133,6 +147,7 @@ public class ConversationListItem extends RelativeLayout
       public void run() {
         fromView.setText(recipients, read);
         contactPhotoImage.setAvatar(recipients, true);
+        setRippleColor(recipients);
       }
     });
   }

--- a/src/org/thoughtcrime/securesms/components/AvatarImageView.java
+++ b/src/org/thoughtcrime/securesms/components/AvatarImageView.java
@@ -3,53 +3,80 @@ package org.thoughtcrime.securesms.components;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.TypedArray;
+import android.graphics.PorterDuff.Mode;
 import android.provider.ContactsContract;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.View;
 import android.widget.ImageView;
+
+import com.amulyakhare.textdrawable.TextDrawable;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.color.MaterialColor;
 import org.thoughtcrime.securesms.contacts.avatars.ContactColors;
 import org.thoughtcrime.securesms.contacts.avatars.ContactPhotoFactory;
+import org.thoughtcrime.securesms.contacts.avatars.GeneratedContactPhoto;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.RecipientFactory;
 import org.thoughtcrime.securesms.recipients.Recipients;
 
 public class AvatarImageView extends ImageView {
 
-  private boolean inverted;
+  private boolean    inverted;
+  private int        selectedColor;
+  private Recipients recipients;
+  private boolean    quickContactEnabled;
 
   public AvatarImageView(Context context) {
-    super(context);
-    setScaleType(ScaleType.CENTER_CROP);
+    this(context, null);
   }
 
   public AvatarImageView(Context context, AttributeSet attrs) {
     super(context, attrs);
-    setScaleType(ScaleType.CENTER_CROP);
+    setScaleType(ScaleType.CENTER_INSIDE);
 
     if (attrs != null) {
       TypedArray typedArray = context.getTheme().obtainStyledAttributes(attrs, R.styleable.AvatarImageView, 0, 0);
-      inverted = typedArray.getBoolean(0, false);
+      inverted      = typedArray.getBoolean(0, false);
+      selectedColor = typedArray.getColor(1, getContext().getResources().getColor(R.color.textsecure_primary));
       typedArray.recycle();
     }
   }
 
-  public void setAvatar(@Nullable Recipients recipients, boolean quickContactEnabled) {
-    if (recipients != null) {
-      MaterialColor backgroundColor = recipients.getColor();
-      setImageDrawable(recipients.getContactPhoto().asDrawable(getContext(), backgroundColor.toConversationColor(getContext()), inverted));
-      setAvatarClickHandler(recipients, quickContactEnabled);
-    } else {
-      setImageDrawable(ContactPhotoFactory.getDefaultContactPhoto(null).asDrawable(getContext(), ContactColors.UNKNOWN_COLOR.toConversationColor(getContext()), inverted));
-      setOnClickListener(null);
-    }
+  @Override protected void drawableStateChanged() {
+    super.drawableStateChanged();
+    updateDrawable();
+    Log.w("AvatarImageView", "drawableStateChanged(), isSelected() " + isSelected());
+    Log.w("AvatarImageView", new Exception());
   }
 
+  public void setAvatar(@Nullable Recipients recipients, boolean quickContactEnabled) {
+    this.recipients = recipients;
+    this.quickContactEnabled = quickContactEnabled;
+    updateDrawable();
+  }
   public void setAvatar(@Nullable Recipient recipient, boolean quickContactEnabled) {
     setAvatar(RecipientFactory.getRecipientsFor(getContext(), recipient, true), quickContactEnabled);
+  }
+
+  private void updateDrawable() {
+    if (isSelected()) {
+      setImageResource(R.drawable.ic_check_white_24dp);
+      setBackgroundResource(R.drawable.circle_tintable);
+      getBackground().setColorFilter(selectedColor, Mode.MULTIPLY);
+    } else {
+      setBackgroundDrawable(null);
+      if (recipients != null) {
+        MaterialColor backgroundColor = recipients.getColor();
+        setImageDrawable(recipients.getContactPhoto().asDrawable(getContext(), backgroundColor.toConversationColor(getContext()), inverted));
+        setAvatarClickHandler(recipients, quickContactEnabled);
+      } else {
+        setImageDrawable(ContactPhotoFactory.getDefaultContactPhoto(null).asDrawable(getContext(), ContactColors.UNKNOWN_COLOR.toConversationColor(getContext()), inverted));
+        setOnClickListener(null);
+      }
+    }
   }
 
   private void setAvatarClickHandler(final Recipients recipients, boolean quickContactEnabled) {

--- a/src/org/thoughtcrime/securesms/contacts/avatars/GeneratedContactPhoto.java
+++ b/src/org/thoughtcrime/securesms/contacts/avatars/GeneratedContactPhoto.java
@@ -14,8 +14,8 @@ public class GeneratedContactPhoto implements ContactPhoto {
 
   private final String name;
 
-  GeneratedContactPhoto(@NonNull String name) {
-    this.name  = name;
+  public GeneratedContactPhoto(@NonNull String name) {
+    this.name = name;
   }
 
   @Override


### PR DESCRIPTION
This way the conversation bubbles themselves change color and ripple instead of their background, making our word of floating bubbles a bit more believable in the material world.

Also avatars that are selected will now show a checkmark in the list instead of the avatar. Many other apps do this, and I think it's a great way to indicate selected state.