### PR TITLE
Disable quick capture on popup

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -172,14 +172,14 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private   View                      composePanel;
   private   View                      composeBubble;
 
-  private AttachmentTypeSelectorAdapter attachmentAdapter;
-  private AttachmentManager             attachmentManager;
-  private BroadcastReceiver             securityUpdateReceiver;
-  private BroadcastReceiver             groupUpdateReceiver;
-  private Optional<EmojiPopup>          emojiPopup = Optional.absent();
-  private EmojiToggle                   emojiToggle;
-  private HidingImageButton             quickAttachmentToggle;
-  private QuickAttachmentDrawer         quickAttachmentDrawer;
+  private   AttachmentTypeSelectorAdapter attachmentAdapter;
+  private   AttachmentManager             attachmentManager;
+  private   BroadcastReceiver             securityUpdateReceiver;
+  private   BroadcastReceiver             groupUpdateReceiver;
+  private   Optional<EmojiPopup>          emojiPopup = Optional.absent();
+  private   EmojiToggle                   emojiToggle;
+  protected HidingImageButton             quickAttachmentToggle;
+  private   QuickAttachmentDrawer         quickAttachmentDrawer;
 
   private Recipients recipients;
   private long       threadId;
@@ -845,7 +845,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       quickAttachmentDrawer.setListener(this);
       quickAttachmentToggle.setOnClickListener(new QuickAttachmentToggleListener());
     } else {
-      quickAttachmentToggle.setVisibility(View.GONE);
+      quickAttachmentToggle.disable();
     }
   }
 

--- a/src/org/thoughtcrime/securesms/ConversationPopupActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationPopupActivity.java
@@ -56,6 +56,7 @@ public class ConversationPopupActivity extends ConversationActivity {
   protected void onResume() {
     super.onResume();
     composeText.requestFocus();
+    quickAttachmentToggle.disable();
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/components/camera/HidingImageButton.java
+++ b/src/org/thoughtcrime/securesms/components/camera/HidingImageButton.java
@@ -26,6 +26,7 @@ public class HidingImageButton extends ImageButton {
   }
 
   public void hide() {
+    if (!isEnabled()) return;
     final Animation animation = AnimationUtils.loadAnimation(getContext(), R.anim.slide_to_right);
     animation.setAnimationListener(new AnimationListener() {
       @Override public void onAnimationStart(Animation animation) {}
@@ -38,6 +39,7 @@ public class HidingImageButton extends ImageButton {
   }
 
   public void show() {
+    if (!isEnabled()) return;
     setVisibility(VISIBLE);
     animateWith(AnimationUtils.loadAnimation(getContext(), R.anim.slide_from_right));
   }
@@ -46,5 +48,10 @@ public class HidingImageButton extends ImageButton {
     animation.setDuration(150);
     animation.setInterpolator(new FastOutSlowInInterpolator());
     startAnimation(animation);
+  }
+
+  public void disable() {
+    setVisibility(GONE);
+    setEnabled(false);
   }
 }


### PR DESCRIPTION
Also fixes case where devices without camera support would end up seeing the capture toggle.