### PR TITLE
finish MessageRecipientAsyncTask when context is destroyed

### DIFF
--- a/src/org/thoughtcrime/securesms/MessageDetailsActivity.java
+++ b/src/org/thoughtcrime/securesms/MessageDetailsActivity.java
@@ -256,6 +256,7 @@ public class MessageDetailsActivity extends PassphraseRequiredActionBarActivity 
       Context context = getContext();
       if (context == null) {
         Log.w(TAG, "associated context is destroyed, finishing early");
+        return null;
       }
 
       Recipients recipients;


### PR DESCRIPTION
Did you guys forgot a return there?
`context = null` would be used otherwiese some lines below: https://github.com/WhisperSystems/TextSecure/blob/master/src/org/thoughtcrime/securesms/MessageDetailsActivity.java#L265