### PR TITLE
Fix direct capture layout issues

### DIFF
--- a/res/layout/conversation_activity.xml
+++ b/res/layout/conversation_activity.xml
@@ -6,19 +6,20 @@
         android:id="@+id/layout_container"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent"
-        android:background="?conversation_background"
         android:orientation="vertical">
 
 <org.thoughtcrime.securesms.components.camera.QuickAttachmentDrawer
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/quick_attachment_drawer"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/black">
 
     <RelativeLayout android:layout_width="fill_parent"
                     android:layout_height="fill_parent"
                     android:layout_weight="1"
                     android:orientation="vertical"
+                    android:background="?conversation_background"
                     android:gravity="bottom">
 
         <FrameLayout android:id="@+id/fragment_content"

--- a/src/org/thoughtcrime/securesms/components/camera/CameraView.java
+++ b/src/org/thoughtcrime/securesms/components/camera/CameraView.java
@@ -19,6 +19,7 @@ import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.pm.ActivityInfo;
+import android.graphics.Color;
 import android.hardware.Camera;
 import android.hardware.Camera.PreviewCallback;
 import android.os.Build;
@@ -29,6 +30,7 @@ import android.util.Log;
 import android.view.OrientationEventListener;
 import android.view.Surface;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
 import java.io.IOException;
@@ -36,7 +38,6 @@ import java.util.concurrent.CountDownLatch;
 
 import com.commonsware.cwac.camera.CameraHost;
 import com.commonsware.cwac.camera.CameraHost.FailureReason;
-import com.commonsware.cwac.camera.PreviewStrategy;
 
 import org.thoughtcrime.securesms.ApplicationContext;
 import org.thoughtcrime.securesms.util.Util;
@@ -85,11 +86,12 @@ public class CameraView extends FrameLayout {
     } else {
       previewStrategy = new SurfacePreviewStrategy(this);
     }
+    addView(previewStrategy.getWidget());
   }
 
   @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
   public void onResume() {
-    addView(previewStrategy.getWidget());
+    Log.w(TAG, "onResume()");
     final CameraHost host = getHost();
     submitTask(new SerializedAsyncTask<FailureReason>() {
       @Override protected FailureReason onRunBackground() {
@@ -120,6 +122,8 @@ public class CameraView extends FrameLayout {
         synchronized (CameraView.this) {
           CameraView.this.notifyAll();
         }
+        previewCreated();
+        initPreview();
         requestLayout();
         invalidate();
       }
@@ -127,7 +131,7 @@ public class CameraView extends FrameLayout {
   }
 
   public void onPause() {
-    removeView(previewStrategy.getWidget());
+    Log.w(TAG, "onPause()");
     submitTask(new SerializedAsyncTask<Void>() {
       @Override protected void onPreMain() {
         cameraReady = false;
@@ -155,7 +159,6 @@ public class CameraView extends FrameLayout {
 
   @Override
   protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-    super.onMeasure(widthMeasureSpec, heightMeasureSpec);
 
     if (getMeasuredWidth() > 0 && getMeasuredHeight() > 0 && camera != null && cameraReady) {
       Camera.Size newSize = null;
@@ -194,13 +197,14 @@ public class CameraView extends FrameLayout {
         }
       }
     }
+    super.onMeasure(widthMeasureSpec, heightMeasureSpec);
   }
 
   // based on CameraPreview.java from ApiDemos
 
   @SuppressWarnings("SuspiciousNameCombination") @Override
   protected void onLayout(boolean changed, int l, int t, int r, int b) {
-    if (changed && getChildCount() > 0) {
+    if (getChildCount() > 0) {
       final View child         = getChildAt(0);
       final int  width         = r - l;
       final int  height        = b - t;
@@ -309,6 +313,8 @@ public class CameraView extends FrameLayout {
   }
 
   private void stopPreview() {
+    Log.w(TAG, "stopPreview()");
+    camera.startPreview();
     inPreview = false;
     getHost().autoFocusUnavailable();
     camera.stopPreview();
@@ -491,7 +497,7 @@ public class CameraView extends FrameLayout {
   private abstract class PostInitializationTask<Result> extends SerializedAsyncTask<Result> {
     @Override protected void onWait() {
       synchronized (CameraView.this) {
-        while (camera == null || previewSize == null) {
+        while (camera == null || previewSize == null || !previewStrategy.isReady()) {
           Util.wait(CameraView.this, 0);
         }
       }

--- a/src/org/thoughtcrime/securesms/components/camera/PreviewStrategy.java
+++ b/src/org/thoughtcrime/securesms/components/camera/PreviewStrategy.java
@@ -1,0 +1,12 @@
+package org.thoughtcrime.securesms.components.camera;
+
+import android.hardware.Camera;
+import android.media.MediaRecorder;
+import android.view.View;
+
+import java.io.IOException;
+
+@SuppressWarnings("deprecation")
+public interface PreviewStrategy extends com.commonsware.cwac.camera.PreviewStrategy {
+  boolean isReady();
+}

--- a/src/org/thoughtcrime/securesms/components/camera/QuickAttachmentDrawer.java
+++ b/src/org/thoughtcrime/securesms/components/camera/QuickAttachmentDrawer.java
@@ -274,7 +274,6 @@ public class QuickAttachmentDrawer extends ViewGroup {
   private void setDrawerState(DrawerState drawerState) {
     switch (drawerState) {
     case COLLAPSED:
-      slideOffset = COLLAPSED_ANCHOR_POINT;
       fullScreenButton.setImageResource(R.drawable.quick_camera_fullscreen);
       if (listener != null) listener.onAttachmentDrawerClosed();
       break;
@@ -283,21 +282,26 @@ public class QuickAttachmentDrawer extends ViewGroup {
         setDrawerState(DrawerState.FULL_EXPANDED);
         return;
       }
-      Log.w(TAG, "HALF_EXPANDED init");
       quickCamera.onResume();
-      slideOffset = halfExpandedAnchorPoint;
       fullScreenButton.setImageResource(R.drawable.quick_camera_fullscreen);
       if (listener != null) listener.onAttachmentDrawerOpened();
       break;
     case FULL_EXPANDED:
       quickCamera.onResume();
-      slideOffset = FULL_EXPANDED_ANCHOR_POINT;
       fullScreenButton.setImageResource(isFullscreenOnly() ? R.drawable.quick_camera_hide
                                                            : R.drawable.quick_camera_exit_fullscreen);
       if (listener != null) listener.onAttachmentDrawerOpened();
       break;
     }
     this.drawerState = drawerState;
+  }
+
+  public float getTargetSlideOffset() {
+    switch (drawerState) {
+    case FULL_EXPANDED: return FULL_EXPANDED_ANCHOR_POINT;
+    case HALF_EXPANDED: return halfExpandedAnchorPoint;
+    default: return COLLAPSED_ANCHOR_POINT;
+    }
   }
 
   public DrawerState getDrawerState() {
@@ -308,7 +312,7 @@ public class QuickAttachmentDrawer extends ViewGroup {
     DrawerState oldDrawerState = this.drawerState;
     setDrawerState(requestedDrawerState);
     if (oldDrawerState != drawerState) {
-      slideTo(slideOffset);
+      slideTo(getTargetSlideOffset());
     }
   }
 
@@ -333,6 +337,7 @@ public class QuickAttachmentDrawer extends ViewGroup {
     public void onViewDragStateChanged(int state) {
       if (dragHelper.getViewDragState() == ViewDragHelper.STATE_IDLE) {
         setDrawerState(drawerState);
+        slideOffset = getTargetSlideOffset();
         requestLayout();
       }
     }
@@ -374,6 +379,7 @@ public class QuickAttachmentDrawer extends ViewGroup {
         }
 
         setDrawerState(drawerState);
+        float slideOffset = getTargetSlideOffset();
         dragHelper.captureChildView(coverView, 0);
         Log.w(TAG, String.format("setting cover at %d",  computeCoverBottomPosition(slideOffset) - coverView.getHeight()));
         dragHelper.settleCapturedViewAt(coverView.getLeft(), computeCoverBottomPosition(slideOffset) - coverView.getHeight());

--- a/src/org/thoughtcrime/securesms/components/camera/SurfacePreviewStrategy.java
+++ b/src/org/thoughtcrime/securesms/components/camera/SurfacePreviewStrategy.java
@@ -21,8 +21,6 @@ import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.View;
 
-import com.commonsware.cwac.camera.PreviewStrategy;
-
 import java.io.IOException;
 
 class SurfacePreviewStrategy implements PreviewStrategy,
@@ -31,6 +29,7 @@ class SurfacePreviewStrategy implements PreviewStrategy,
   private final CameraView cameraView;
   private SurfaceView preview=null;
   private SurfaceHolder previewHolder=null;
+  private boolean ready = false;
 
   @SuppressWarnings("deprecation")
   SurfacePreviewStrategy(CameraView cameraView) {
@@ -44,14 +43,14 @@ class SurfacePreviewStrategy implements PreviewStrategy,
   @Override
   public void surfaceCreated(SurfaceHolder holder) {
     Log.w(TAG, "surfaceCreated()");
-    cameraView.previewCreated();
+    ready = true;
+    synchronized (cameraView) { cameraView.notifyAll(); }
   }
 
   @Override
   public void surfaceChanged(SurfaceHolder holder, int format,
                              int width, int height) {
     Log.w(TAG, "surfaceChanged()");
-    cameraView.initPreview();
   }
 
   @Override
@@ -74,5 +73,10 @@ class SurfacePreviewStrategy implements PreviewStrategy,
   @Override
   public View getWidget() {
     return(preview);
+  }
+
+  @Override
+  public boolean isReady() {
+    return ready;
   }
 }

--- a/src/org/thoughtcrime/securesms/components/camera/TexturePreviewStrategy.java
+++ b/src/org/thoughtcrime/securesms/components/camera/TexturePreviewStrategy.java
@@ -22,8 +22,6 @@ import android.util.Log;
 import android.view.TextureView;
 import android.view.View;
 
-import com.commonsware.cwac.camera.PreviewStrategy;
-
 import java.io.IOException;
 
 @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
@@ -45,9 +43,7 @@ class TexturePreviewStrategy implements PreviewStrategy,
                                         int width, int height) {
     Log.w(TAG, "onSurfaceTextureAvailable()");
     this.surface=surface;
-
-    cameraView.previewCreated();
-    cameraView.initPreview();
+    synchronized (cameraView) { cameraView.notifyAll(); }
   }
 
   @Override
@@ -72,7 +68,6 @@ class TexturePreviewStrategy implements PreviewStrategy,
 
   @Override
   public void attach(Camera camera) throws IOException {
-    Log.w(TAG, "attach(Camera)");
     camera.setPreviewTexture(surface);
   }
 
@@ -85,6 +80,11 @@ class TexturePreviewStrategy implements PreviewStrategy,
       throw new IllegalStateException(
           "Cannot use TextureView with MediaRecorder");
     }
+  }
+
+  @Override
+  public boolean isReady() {
+    return widget.isAvailable();
   }
 
   @Override


### PR DESCRIPTION
* The "drag twitch" is no longer present, making the experience much smoother.
* The Conversation List should no longer be visible as the camera opens, as I added a black background (@turtlekiosk originally had that but I accidentally removed in when rebasing `conversation_activity.xml`, my bad).
* It turns out we were doing the camera pause logic on the main thread still so the UI thread hang should be gone as well. I don't know why CWAC-Camera added and removed the SurfaceView/TextureView on resume and pause, but it seems to work fine adding it once and just waiting until the views are ready before continuing initialization. So I went that route.