### PR TITLE
Improve generated contact photos for names beginning with emoji

### DIFF
--- a/src/org/thoughtcrime/securesms/contacts/avatars/GeneratedContactPhoto.java
+++ b/src/org/thoughtcrime/securesms/contacts/avatars/GeneratedContactPhoto.java
@@ -33,6 +33,16 @@ public class GeneratedContactPhoto implements ContactPhoto {
                        .height(targetSize)
                        .textColor(inverted ? color : Color.WHITE)
                        .endConfig()
-                       .buildRound(String.valueOf(name.charAt(0)), inverted ? Color.WHITE : color);
+                       .buildRound(getCharacter(name), inverted ? Color.WHITE : color);
+  }
+
+  private String getCharacter(String name) {
+    String cleanedName = name.replaceAll("[^\\p{L}\\p{Nd}]+", "");
+
+    if (cleanedName.length() > 0) {
+      return String.valueOf(cleanedName.charAt(0));
+    } else {
+      return "#";
+    }
   }
 }


### PR DESCRIPTION
Improve the handling of contact names within the `GeneratedContactPhoto` class so that names beginning with emojis or non-language symbols (for any language, not just English) display an appropriate character instead of the missing unicode icon.

This should fix issue #3604.