### PR TITLE
add actionbar padding to conversation activity

### DIFF
--- a/res/layout/conversation_activity.xml
+++ b/res/layout/conversation_activity.xml
@@ -20,6 +20,7 @@
                     android:layout_weight="1"
                     android:orientation="vertical"
                     android:background="?conversation_background"
+                    android:paddingTop="?attr/actionBarSize"
                     android:gravity="bottom">
 
         <FrameLayout android:id="@+id/fragment_content"


### PR DESCRIPTION
Adding top padding to the main view of ConversationActivity should compensate for the ActionBar overlay mode that ConversationActivity started using because of direct capture.

Re: Issue #3627 
// FREEBIE