### PR TITLE
skip camera layout when preview is zero-sized

### DIFF
--- a/src/org/thoughtcrime/securesms/components/camera/CameraView.java
+++ b/src/org/thoughtcrime/securesms/components/camera/CameraView.java
@@ -224,6 +224,11 @@ public class CameraView extends FrameLayout {
         previewHeight = height;
       }
 
+      if (previewHeight == 0 || previewWidth == 0) {
+        Log.w(TAG, "skipping layout due to zero-width/height preview size");
+        return;
+      }
+
       boolean useFirstStrategy = (width * previewHeight > height * previewWidth);
       boolean useFullBleed     = getHost().useFullBleedPreview();
 


### PR DESCRIPTION
Couldn't reproduce, but the stack trace was straightforward.  We shouldn't be layout out children until we have a valid preview frame.