### PR TITLE
update IME action label

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -823,6 +823,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
         calculateCharactersRemaining();
         composeText.setHint(newTransport.getComposeHint());
         composeText.setImeActionLabel(newTransport.getComposeHint(), EditorInfo.IME_ACTION_SEND);
+        composeText.setInputType(composeText.getInputType());
         buttonToggle.getBackground().setColorFilter(newTransport.getBackgroundColor(), Mode.MULTIPLY);
       }
     });


### PR DESCRIPTION
The TextView source code accesses its local InputMethodManager instance through a private message. I looked at the source and tested on GB and LP, and while there's no way to force an IME input restart, TextView does this every time you `setInputType()`, so it's the way to do it with the least reflection and hand-waving.

fixes #3623
