### PR TITLE
hide controls when camera drawer isn't open

### DIFF
--- a/res/layout/quick_attachment_drawer.xml
+++ b/res/layout/quick_attachment_drawer.xml
@@ -4,6 +4,7 @@
     <org.thoughtcrime.securesms.components.camera.QuickCamera
         android:id="@+id/quick_camera"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:visibility="gone" />
 
 </merge>

--- a/src/org/thoughtcrime/securesms/components/camera/QuickAttachmentDrawer.java
+++ b/src/org/thoughtcrime/securesms/components/camera/QuickAttachmentDrawer.java
@@ -128,6 +128,7 @@ public class QuickAttachmentDrawer extends ViewGroup {
     }
     shutterButton.setOnClickListener(new ShutterClickListener());
     fullScreenButton.setOnClickListener(new FullscreenClickListener());
+    controls.setVisibility(GONE);
     addView(controls, controlsIndex > -1 ? controlsIndex : indexOfChild(quickCamera) + 1);
   }
 
@@ -273,8 +274,12 @@ public class QuickAttachmentDrawer extends ViewGroup {
     }
 
     if (slideOffset == COLLAPSED_ANCHOR_POINT && quickCamera.isStarted()) {
+      controls.setVisibility(GONE);
+      quickCamera.setVisibility(GONE);
       quickCamera.onPause();
     } else if (slideOffset != COLLAPSED_ANCHOR_POINT && !quickCamera.isStarted()) {
+      controls.setVisibility(VISIBLE);
+      quickCamera.setVisibility(VISIBLE);
       quickCamera.onResume();
     }
   }

--- a/src/org/thoughtcrime/securesms/components/camera/QuickCamera.java
+++ b/src/org/thoughtcrime/securesms/components/camera/QuickCamera.java
@@ -43,7 +43,6 @@ import java.util.List;
     super(context, attrs, defStyle);
     cameraHost = new QuickCameraHost(context);
     setHost(cameraHost);
-    setClickable(false);
   }
 
   @Override


### PR DESCRIPTION
Actually fixes the problem. Camera operations were still clickable behind the background of the composition input.