### PR TITLE
"spirit guide" is appropriative and unnecessary

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -20,7 +20,7 @@ Truths which we believe to be self-evident:
    concepts better than others has proven to be, for the most part, false.
    If anything, "power users" are more dangerous than the rest, and we
    should avoid exposing dangerous functionality to them.
-1. **If it's "like PGP," it's wrong.**  PGP is our spirit guide for what
+1. **If it's "like PGP," it's wrong.**  PGP is our guide for what
    not to do.
 1. **It's an asynchronous world.**  Be wary of anything that is
    anti-asynchronous: ACKs, protocol confirmations, or any protocol-level


### PR DESCRIPTION
For more details on why to avoid this language, see [this post](http://aquariusmoonrising.tumblr.com/post/58763812891/why-you-shouldnt-use-the-term-spirit-animal).  Plus, it doesn't even really make sense here; even in the bastardized pop-cultural sense, "spirit guide" or "spirit animals" would be *helpful* things and PGP is more in [this vein](http://despair.com/products/mistakes).