### PR TITLE
use better ImageView properties

### DIFF
--- a/res/layout/thumbnail_view.xml
+++ b/res/layout/thumbnail_view.xml
@@ -6,6 +6,7 @@
             android:id="@+id/thumbnail_image"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:scaleType="fitCenter"
             android:adjustViewBounds="true"
             android:contentDescription="@string/conversation_item__mms_image_description"
             android:layout_margin="@dimen/media_bubble_border_width"

--- a/src/org/thoughtcrime/securesms/components/ThumbnailView.java
+++ b/src/org/thoughtcrime/securesms/components/ThumbnailView.java
@@ -193,13 +193,14 @@ public class ThumbnailView extends FrameLayout {
     }
 
     return  Glide.with(getContext()).load(new DecryptableUri(masterSecret, slide.getThumbnailUri()))
+                                    .asBitmap()
                                     .centerCrop();
   }
 
   private GenericRequestBuilder buildPlaceholderGlideRequest(Slide slide) {
     return Glide.with(getContext()).load(slide.getPlaceholderRes(getContext().getTheme()))
-                                   .fitCenter()
-                                   .crossFade();
+                                   .asBitmap()
+                                   .fitCenter();
   }
 
   private void animateOutProgress() {


### PR DESCRIPTION
should reduce memory consumption

It looks like the default ImageView scaleType doesn't allow Glide to safely resize properly, whereas fitCenter does. It's also recommended to force loading as a bitmap with `toBitmap()` if you're not using other features like gif to make sure the pool is used. We can revisit this with gif support.