### PR TITLE
Transition in RecipientActivity and hide keyboard on ContactSelection (#3523, #3704 and #3706)

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -202,6 +202,7 @@
 
     <activity android:name=".NewConversationActivity"
               android:theme="@style/TextSecure.LightNoActionBar"
+              android:windowSoftInputMode="stateHidden"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
     <activity android:name=".PushContactSelectionActivity"

--- a/res/layout/contact_selection_activity.xml
+++ b/res/layout/contact_selection_activity.xml
@@ -45,16 +45,16 @@
                     android:layout_gravity="center"
                     android:gravity="center">
 
-                <ImageView android:id="@+id/search_dialpad"
+                <ImageView android:id="@+id/search_keyboard"
                            android:layout_width="wrap_content"
                            android:layout_height="wrap_content"
                            android:layout_gravity="center_vertical"
                            android:gravity="center_vertical"
                            android:clickable="true"
                            android:background="@drawable/circle_touch_highlight_background"
-                           android:src="@drawable/ic_dialpad_white_24dp" />
+                           android:src="@drawable/ic_keyboard_white_24dp" />
 
-                <ImageView android:id="@+id/search_keyboard"
+                <ImageView android:id="@+id/search_dialpad"
                            android:layout_width="wrap_content"
                            android:layout_height="wrap_content"
                            android:layout_gravity="center_vertical"
@@ -62,7 +62,7 @@
                            android:clickable="true"
                            android:visibility="gone"
                            android:background="@drawable/circle_touch_highlight_background"
-                           android:src="@drawable/ic_keyboard_white_24dp" />
+                           android:src="@drawable/ic_dialpad_white_24dp" />
 
 
                 <ImageView android:id="@+id/search_clear"

--- a/src/org/thoughtcrime/securesms/ContactSelectionActivity.java
+++ b/src/org/thoughtcrime/securesms/ContactSelectionActivity.java
@@ -27,6 +27,7 @@ import android.text.InputType;
 import android.text.TextWatcher;
 import android.util.Log;
 import android.view.View;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.ImageView;
 
@@ -57,6 +58,7 @@ public abstract class ContactSelectionActivity extends PassphraseRequiredActionB
   private final DynamicLanguage dynamicLanguage = new DynamicLanguage();
 
   protected ContactSelectionListFragment contactsFragment;
+  private InputMethodManager inputMethodManager;
 
   private   Toolbar         toolbar;
   private   EditText        searchText;
@@ -108,11 +110,15 @@ public abstract class ContactSelectionActivity extends PassphraseRequiredActionB
     contactsFragment.setOnContactSelectedListener(this);
     contactsFragment.setOnRefreshListener(this);
 
+    inputMethodManager = (InputMethodManager) getSystemService(this.INPUT_METHOD_SERVICE);
+
+
     this.keyboardToggle.setOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View v) {
         searchText.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PERSON_NAME);
         toggle.display(dialpadToggle);
+        inputMethodManager.showSoftInput(searchText, 1);
       }
     });
 
@@ -121,6 +127,7 @@ public abstract class ContactSelectionActivity extends PassphraseRequiredActionB
       public void onClick(View v) {
         searchText.setInputType(InputType.TYPE_CLASS_PHONE);
         toggle.display(keyboardToggle);
+        inputMethodManager.showSoftInput(searchText, 1);
       }
     });
 

--- a/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
+++ b/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
@@ -98,7 +98,9 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
   public boolean onOptionsItemSelected(MenuItem item) {
     super.onOptionsItemSelected(item);
     switch (item.getItemId()) {
-      case android.R.id.home: finish(); return true;
+      case android.R.id.home:
+        super.onBackPressed();
+        return true;
     }
 
     return false;


### PR DESCRIPTION
##### This Pullrequest contains 3 very small and trivial fixes: ####
- RecipientActivity: Use the transition that happens on onBackPressed() in onOptionsItemSelected()

As a result the transition moving the contact name in the actionbar of the conversation view is applied not only on a backbutton press, but also when pressing the home-arrow in the actionbar.
Should fix #3523


- ContactSelection: Hide the keyboard when user wants to send a new message and the ContactSelection view is opened.

Most people probably don't want to search for their contacts at the first, but immediately click on them in  their contact list, as stated in the corresponding issue.
Fixes #3704

- ContactSelection: Pressing the toggle button now brings up the keyboard.

Furthermore I changed the keyboard as the default for the toggle button instead of the dial pad, because people would like to input real names instead of phone numbers most of the times and since the keyboard ist hidden by default the keyboard should appear first when clicking the toggle button.
Fixes #3706

All commits are FREEBIES.