### PR TITLE
only create DB readers as needed

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationAdapter.java
+++ b/src/org/thoughtcrime/securesms/ConversationAdapter.java
@@ -158,7 +158,7 @@ public class ConversationAdapter extends CursorAdapter implements AbsListView.Re
 
     MessageRecord messageRecord = reader.getCurrent();
 
-    messageRecordCache.put(type + messageId, new SoftReference<MessageRecord>(messageRecord));
+    messageRecordCache.put(type + messageId, new SoftReference<>(messageRecord));
 
     return messageRecord;
   }

--- a/src/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
@@ -21,10 +21,13 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.database.sqlite.SQLiteQueryBuilder;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.Log;
 
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.model.MessageRecord;
+import org.whispersystems.libaxolotl.util.guava.Optional;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -222,30 +225,45 @@ public class MmsSmsDatabase extends Database {
     return db.rawQuery(query, null);
   }
 
-  public Reader readerFor(Cursor cursor, MasterSecret masterSecret) {
+  public Reader readerFor(@NonNull Cursor cursor, @Nullable MasterSecret masterSecret) {
     return new Reader(cursor, masterSecret);
   }
 
-  public Reader readerFor(Cursor cursor) {
+  public Reader readerFor(@NonNull Cursor cursor) {
     return new Reader(cursor);
   }
 
   public class Reader {
 
-    private final Cursor cursor;
-    private final EncryptingSmsDatabase.Reader smsReader;
-    private final MmsDatabase.Reader mmsReader;
+    private final Cursor                       cursor;
+    private final Optional<MasterSecret>       masterSecret;
+    private       EncryptingSmsDatabase.Reader smsReader;
+    private       MmsDatabase.Reader           mmsReader;
 
-    public Reader(Cursor cursor, MasterSecret masterSecret) {
+    public Reader(Cursor cursor, @Nullable MasterSecret masterSecret) {
       this.cursor       = cursor;
-      this.smsReader    = DatabaseFactory.getEncryptingSmsDatabase(context).readerFor(masterSecret, cursor);
-      this.mmsReader    = DatabaseFactory.getMmsDatabase(context).readerFor(masterSecret, cursor);
+      this.masterSecret = Optional.fromNullable(masterSecret);
     }
 
     public Reader(Cursor cursor) {
-      this.cursor = cursor;
-      this.smsReader = DatabaseFactory.getSmsDatabase(context).readerFor(cursor);
-      this.mmsReader = DatabaseFactory.getMmsDatabase(context).readerFor(null, cursor);
+      this(cursor, null);
+    }
+
+    private EncryptingSmsDatabase.Reader getSmsReader() {
+      if (smsReader == null) {
+        if (masterSecret.isPresent()) smsReader = DatabaseFactory.getEncryptingSmsDatabase(context).readerFor(masterSecret.get(), cursor);
+        else                          smsReader = DatabaseFactory.getSmsDatabase(context).readerFor(cursor);
+      }
+
+      return smsReader;
+    }
+
+    private MmsDatabase.Reader getMmsReader() {
+      if (mmsReader == null) {
+        mmsReader = DatabaseFactory.getMmsDatabase(context).readerFor(masterSecret.orNull(), cursor);
+      }
+
+      return mmsReader;
     }
 
     public MessageRecord getNext() {
@@ -259,9 +277,9 @@ public class MmsSmsDatabase extends Database {
       String type = cursor.getString(cursor.getColumnIndexOrThrow(TRANSPORT));
 
       if (MmsSmsDatabase.MMS_TRANSPORT.equals(type)) {
-        return mmsReader.getCurrent();
+        return getMmsReader().getCurrent();
       } else {
-        return smsReader.getCurrent();
+        return getSmsReader().getCurrent();
       }
     }
 


### PR DESCRIPTION
Another thing I noticed during the method tracing from scrolling in the conversation.

No matter what the item type, we create both an MmsDatabase reader and an SmsDatabase reader when almost always only one is used. Each of those readers create their own instance of MasterCipher, and each MasterCipher calls Cipher.getInstance() in its constructor which is not a particularly fast call.

I didn't want to edit MasterCipher (although @moxie0, might be worth looking into initializing those ciphers statically?), but this should help lower our object creation during scrolling on the UI thread. Lowers jank.