### PR TITLE
fix enter send behaviour

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -245,7 +245,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     initializeSecurity();
     initializeEnabledCheck();
     initializeMmsEnabledCheck();
-    updateIme();
+    composeText.setTransport(sendButton.getSelectedTransport());
 
     titleView.setTitle(recipients);
     setActionBarColor(recipients.getColor());
@@ -266,13 +266,9 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
   @Override public void onConfigurationChanged(Configuration newConfig) {
     super.onConfigurationChanged(newConfig);
-    updateIme();
+    composeText.setTransport(sendButton.getSelectedTransport());
     quickAttachmentDrawer.onConfigurationChanged();
     hideEmojiDrawer(false);
-  }
-
-  private boolean isLandscape() {
-    return getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE;
   }
 
   @Override
@@ -761,27 +757,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     }.execute();
   }
 
-  private void updateIme() {
-    int imeOptions = (composeText.getImeOptions() & ~EditorInfo.IME_MASK_ACTION) | EditorInfo.IME_ACTION_SEND;
-    int inputType  = composeText.getInputType();
-    if (TextSecurePreferences.isEnterSendsEnabled(this)) {
-      if (isLandscape()) {
-        composeText.setImeActionLabel(sendButton.getSelectedTransport().getComposeHint(), EditorInfo.IME_ACTION_SEND);
-        inputType |= InputType.TYPE_TEXT_FLAG_MULTI_LINE;
-      } else {
-        composeText.setImeActionLabel(null, 0);
-        inputType &= ~InputType.TYPE_TEXT_FLAG_MULTI_LINE;
-      }
-      imeOptions &= ~EditorInfo.IME_FLAG_NO_ENTER_ACTION;
-    } else {
-      inputType  |= InputType.TYPE_TEXT_FLAG_MULTI_LINE;
-      imeOptions |= EditorInfo.IME_FLAG_NO_ENTER_ACTION;
-    }
-
-    composeText.setInputType(inputType);
-    composeText.setImeOptions(imeOptions);
-  }
-
   private void initializeViews() {
     titleView      = (ConversationTitleView)     getSupportActionBar().getCustomView();
     buttonToggle   = (AnimatingToggle)           findViewById(R.id.button_toggle);
@@ -829,9 +804,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       @Override
       public void onChange(TransportOption newTransport) {
         calculateCharactersRemaining();
-        updateIme();
-        composeText.setHint(newTransport.getComposeHint());
-        composeText.setInputType(composeText.getInputType());
+        composeText.setTransport(newTransport);
         buttonToggle.getBackground().setColorFilter(newTransport.getBackgroundColor(), Mode.MULTIPLY);
       }
     });

--- a/src/org/thoughtcrime/securesms/components/ComposeText.java
+++ b/src/org/thoughtcrime/securesms/components/ComposeText.java
@@ -1,16 +1,20 @@
 package org.thoughtcrime.securesms.components;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.support.annotation.NonNull;
-import android.support.v7.widget.AppCompatEditText;
+import android.text.InputType;
 import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.TextUtils;
 import android.text.TextUtils.TruncateAt;
 import android.text.style.RelativeSizeSpan;
 import android.util.AttributeSet;
+import android.view.inputmethod.EditorInfo;
 
+import org.thoughtcrime.securesms.TransportOption;
 import org.thoughtcrime.securesms.components.emoji.EmojiEditText;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
 
 public class ComposeText extends EmojiEditText {
   public ComposeText(Context context) {
@@ -47,5 +51,31 @@ public class ComposeText extends EmojiEditText {
     }
 
     append(invite);
+  }
+
+  private boolean isLandscape() {
+    return getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE;
+  }
+
+  public void setTransport(TransportOption transport) {
+    final boolean enterSends = TextSecurePreferences.isEnterSendsEnabled(getContext());
+
+    int imeOptions = (getImeOptions() & ~EditorInfo.IME_MASK_ACTION) | EditorInfo.IME_ACTION_SEND;
+    int inputType  = getInputType();
+
+    if (isLandscape()) setImeActionLabel(transport.getComposeHint(), EditorInfo.IME_ACTION_SEND);
+    else               setImeActionLabel(null, 0);
+
+    inputType  = !isLandscape() && enterSends
+               ? inputType & ~InputType.TYPE_TEXT_FLAG_MULTI_LINE
+               : inputType | InputType.TYPE_TEXT_FLAG_MULTI_LINE;
+
+    imeOptions = enterSends
+               ? imeOptions & ~EditorInfo.IME_FLAG_NO_ENTER_ACTION
+               : imeOptions | EditorInfo.IME_FLAG_NO_ENTER_ACTION;
+
+    setInputType(inputType);
+    setImeOptions(imeOptions);
+    setHint(transport.getComposeHint());
   }
 }


### PR DESCRIPTION
fixes #3725

I could not find a way to make the weird-looking text go away on Google Keyboard in landscape mode. When you set the label, there doesn't appear to be a way to have that not hang around. It's either that or we can just have enter not be send in landscape mode. Which I think would also be acceptable.