### PR TITLE
Fix #3739: Back press always goes to conversation list

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -392,7 +392,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     } else if (quickAttachmentDrawer.isOpen()) {
       quickAttachmentDrawer.close();
     } else {
-      super.onBackPressed();
+      handleReturnToConversationList();
     }
   }
 


### PR DESCRIPTION
fixes #3739

Before this change, pressing the back button would not have returned to the conversation list, as expected, when the conversation list hasn't been in the activity stack. 

This happend when the app has not been running in background, but a conversation is opened through an incoming notification.

Now it's the by Google defined behavior for this scenario: https://developer.android.com/training/implementing-navigation/temporal.html#SynthesizeBackStack

// FREEBIE