### PR TITLE
👀 the 💥😐

### DIFF
--- a/src/org/thoughtcrime/securesms/components/emoji/EmojiSpan.java
+++ b/src/org/thoughtcrime/securesms/components/emoji/EmojiSpan.java
@@ -9,17 +9,28 @@ import android.widget.TextView;
 import org.thoughtcrime.securesms.R;
 
 public class EmojiSpan extends AnimatingImageSpan {
+  private final int            size;
+  private final FontMetricsInt fm;
+
   public EmojiSpan(@NonNull Drawable drawable, @NonNull TextView tv) {
     super(drawable, tv);
-    FontMetricsInt fm = tv.getPaint().getFontMetricsInt();
-    final int size = fm != null ? Math.abs(fm.descent) + Math.abs(fm.ascent)
-                                : tv.getResources().getDimensionPixelSize(R.dimen.conversation_item_body_text_size);
+    fm   = tv.getPaint().getFontMetricsInt();
+    size = fm != null ? Math.abs(fm.descent) + Math.abs(fm.ascent)
+                      : tv.getResources().getDimensionPixelSize(R.dimen.conversation_item_body_text_size);
     getDrawable().setBounds(0, 0, size, size);
   }
 
   @Override public int getSize(Paint paint, CharSequence text, int start, int end,
                                FontMetricsInt fm)
   {
-    return getDrawable().getBounds().right;
+    if (fm != null && this.fm != null) {
+      fm.ascent  = this.fm.ascent;
+      fm.descent = this.fm.descent;
+      fm.top     = this.fm.top;
+      fm.bottom  = this.fm.bottom;
+      return size;
+    } else {
+      return super.getSize(paint, text, start, end, fm);
+    }
   }
 }


### PR DESCRIPTION
turns out they do want you to modify the FontMetricsInt argument they pass in to getSize(). This works and still solves the issue it was originally meant to solve.

tested on GB/LP

fixes #3753