### PR TITLE
Left-To-Right gesture to navigate back to conversation list from single conversation

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -35,20 +35,15 @@ import android.os.Build;
 import android.os.Bundle;
 import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
+import android.support.v4.view.GestureDetectorCompat;
 import android.support.v4.view.WindowCompat;
 import android.text.Editable;
-import android.text.InputType;
 import android.text.TextWatcher;
 import android.util.Log;
-import android.view.KeyEvent;
-import android.view.Menu;
-import android.view.MenuInflater;
-import android.view.MenuItem;
-import android.view.View;
+import android.view.*;
 import android.view.View.OnClickListener;
 import android.view.View.OnFocusChangeListener;
 import android.view.View.OnKeyListener;
-import android.view.ViewStub;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
@@ -146,20 +141,22 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 {
   private static final String TAG = ConversationActivity.class.getSimpleName();
 
-  public static final String RECIPIENTS_EXTRA        = "recipients";
-  public static final String THREAD_ID_EXTRA         = "thread_id";
-  public static final String DRAFT_TEXT_EXTRA        = "draft_text";
-  public static final String DRAFT_IMAGE_EXTRA       = "draft_image";
-  public static final String DRAFT_AUDIO_EXTRA       = "draft_audio";
-  public static final String DRAFT_VIDEO_EXTRA       = "draft_video";
-  public static final String DISTRIBUTION_TYPE_EXTRA = "distribution_type";
+  public static final  String RECIPIENTS_EXTRA         = "recipients";
+  public static final  String THREAD_ID_EXTRA          = "thread_id";
+  public static final  String DRAFT_TEXT_EXTRA         = "draft_text";
+  public static final  String DRAFT_IMAGE_EXTRA        = "draft_image";
+  public static final  String DRAFT_AUDIO_EXTRA        = "draft_audio";
+  public static final  String DRAFT_VIDEO_EXTRA        = "draft_video";
+  public static final  String DISTRIBUTION_TYPE_EXTRA  = "distribution_type";
 
-  private static final int PICK_IMAGE        = 1;
-  private static final int PICK_VIDEO        = 2;
-  private static final int PICK_AUDIO        = 3;
-  private static final int PICK_CONTACT_INFO = 4;
-  private static final int GROUP_EDIT        = 5;
-  private static final int TAKE_PHOTO        = 6;
+  private static final int PICK_IMAGE               = 1;
+  private static final int PICK_VIDEO               = 2;
+  private static final int PICK_AUDIO               = 3;
+  private static final int PICK_CONTACT_INFO        = 4;
+  private static final int GROUP_EDIT               = 5;
+  private static final int TAKE_PHOTO               = 6;
+  private static final int SWIPE_MIN_DISTANCE       = 120;
+  private static final int SWIPE_THRESHOLD_VELOCITY = 200;
 
   private   MasterSecret              masterSecret;
   protected ComposeText               composeText;
@@ -174,20 +171,23 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private   View                      composePanel;
   private   View                      composeBubble;
 
-  private   AttachmentTypeSelectorAdapter attachmentAdapter;
-  private   AttachmentManager             attachmentManager;
-  private   BroadcastReceiver             securityUpdateReceiver;
-  private   BroadcastReceiver             groupUpdateReceiver;
-  private   Optional<EmojiDrawer>         emojiDrawer = Optional.absent();
-  private   EmojiToggle                   emojiToggle;
-  protected HidingImageButton             quickAttachmentToggle;
-  private   QuickAttachmentDrawer         quickAttachmentDrawer;
+  private AttachmentTypeSelectorAdapter attachmentAdapter;
+  private AttachmentManager             attachmentManager;
+  private BroadcastReceiver             securityUpdateReceiver;
+  private BroadcastReceiver             groupUpdateReceiver;
+  private Optional<EmojiDrawer> emojiDrawer = Optional.absent();
+  private   EmojiToggle           emojiToggle;
+  protected HidingImageButton     quickAttachmentToggle;
+  private   QuickAttachmentDrawer quickAttachmentDrawer;
+
+  private GestureDetectorCompat gestureDetector;
+  private GestureDetectorListener gestureDetectorListener = new GestureDetectorListener();
 
   private Recipients recipients;
   private long       threadId;
   private int        distributionType;
   private boolean    isEncryptedConversation;
-  private boolean    isMmsEnabled = true;
+  private boolean isMmsEnabled = true;
 
   private DynamicTheme    dynamicTheme    = new DynamicTheme();
   private DynamicLanguage dynamicLanguage = new DynamicLanguage();
@@ -207,13 +207,14 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     setContentView(R.layout.conversation_activity);
 
     fragment = initFragment(R.id.fragment_content, new ConversationFragment(),
-                            masterSecret, dynamicLanguage.getCurrentLocale());
+            masterSecret, dynamicLanguage.getCurrentLocale());
 
     initializeReceivers();
     initializeActionBar();
     initializeViews();
     initializeResources();
     initializeDraft();
+    initializeGestureDetector();
   }
 
   @Override
@@ -264,7 +265,8 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     quickAttachmentDrawer.onPause();
   }
 
-  @Override public void onConfigurationChanged(Configuration newConfig) {
+  @Override
+  public void onConfigurationChanged(Configuration newConfig) {
     super.onConfigurationChanged(newConfig);
     composeText.setTransport(sendButton.getSelectedTransport());
     quickAttachmentDrawer.onConfigurationChanged();
@@ -289,29 +291,29 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     if (data == null && reqCode != TAKE_PHOTO || resultCode != RESULT_OK) return;
 
     switch (reqCode) {
-    case PICK_IMAGE:
-      addAttachmentImage(masterSecret, data.getData());
-      break;
-    case PICK_VIDEO:
-      addAttachmentVideo(data.getData());
-      break;
-    case PICK_AUDIO:
-      addAttachmentAudio(data.getData());
-      break;
-    case PICK_CONTACT_INFO:
-      addAttachmentContactInfo(data.getData());
-      break;
-    case GROUP_EDIT:
-      this.recipients = RecipientFactory.getRecipientsForIds(this, data.getLongArrayExtra(GroupCreateActivity.GROUP_RECIPIENT_EXTRA), true);
-      titleView.setTitle(recipients);
-      setBlockedUserState(recipients);
-      supportInvalidateOptionsMenu();
-      break;
-    case TAKE_PHOTO:
-      if (attachmentManager.getCaptureUri() != null) {
-        addAttachmentImage(masterSecret, attachmentManager.getCaptureUri());
-      }
-      break;
+      case PICK_IMAGE:
+        addAttachmentImage(masterSecret, data.getData());
+        break;
+      case PICK_VIDEO:
+        addAttachmentVideo(data.getData());
+        break;
+      case PICK_AUDIO:
+        addAttachmentAudio(data.getData());
+        break;
+      case PICK_CONTACT_INFO:
+        addAttachmentContactInfo(data.getData());
+        break;
+      case GROUP_EDIT:
+        this.recipients = RecipientFactory.getRecipientsForIds(this, data.getLongArrayExtra(GroupCreateActivity.GROUP_RECIPIENT_EXTRA), true);
+        titleView.setTitle(recipients);
+        setBlockedUserState(recipients);
+        supportInvalidateOptionsMenu();
+        break;
+      case TAKE_PHOTO:
+        if (attachmentManager.getCaptureUri() != null) {
+          addAttachmentImage(masterSecret, attachmentManager.getCaptureUri());
+        }
+        break;
     }
   }
 
@@ -347,7 +349,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     inflater.inflate(R.menu.conversation, menu);
 
     if (recipients != null && recipients.isMuted()) inflater.inflate(R.menu.conversation_muted, menu);
-    else                                            inflater.inflate(R.menu.conversation_unmuted, menu);
+    else                                             inflater.inflate(R.menu.conversation_unmuted, menu);
 
     if (isSingleConversation() && getRecipients().getPrimaryRecipient().getContactUri() == null) {
       inflater.inflate(R.menu.conversation_add_to_contacts, menu);
@@ -361,23 +363,23 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   public boolean onOptionsItemSelected(MenuItem item) {
     super.onOptionsItemSelected(item);
     switch (item.getItemId()) {
-    case R.id.menu_call:                      handleDial(getRecipients().getPrimaryRecipient()); return true;
-    case R.id.menu_delete_thread:             handleDeleteThread();                              return true;
-    case R.id.menu_add_attachment:            handleAddAttachment();                             return true;
-    case R.id.menu_view_media:                handleViewMedia();                                 return true;
-    case R.id.menu_add_to_contacts:           handleAddToContacts();                             return true;
-    case R.id.menu_abort_session:             handleAbortSecureSession();                        return true;
-    case R.id.menu_verify_identity:           handleVerifyIdentity();                            return true;
-    case R.id.menu_group_recipients:          handleDisplayGroupRecipients();                    return true;
-    case R.id.menu_distribution_broadcast:    handleDistributionBroadcastEnabled(item);          return true;
-    case R.id.menu_distribution_conversation: handleDistributionConversationEnabled(item);       return true;
-    case R.id.menu_edit_group:                handleEditPushGroup();                             return true;
-    case R.id.menu_leave:                     handleLeavePushGroup();                            return true;
-    case R.id.menu_invite:                    handleInviteLink();                                return true;
-    case R.id.menu_mute_notifications:        handleMuteNotifications();                         return true;
-    case R.id.menu_unmute_notifications:      handleUnmuteNotifications();                       return true;
-    case R.id.menu_conversation_settings:     handleConversationSettings();                      return true;
-    case android.R.id.home:                   handleReturnToConversationList();                  return true;
+      case R.id.menu_call:                      handleDial(getRecipients().getPrimaryRecipient()); return true;
+      case R.id.menu_delete_thread:             handleDeleteThread();                              return true;
+      case R.id.menu_add_attachment:            handleAddAttachment();                             return true;
+      case R.id.menu_view_media:                handleViewMedia();                                 return true;
+      case R.id.menu_add_to_contacts:           handleAddToContacts();                             return true;
+      case R.id.menu_abort_session:             handleAbortSecureSession();                        return true;
+      case R.id.menu_verify_identity:           handleVerifyIdentity();                            return true;
+      case R.id.menu_group_recipients:          handleDisplayGroupRecipients();                    return true;
+      case R.id.menu_distribution_broadcast:    handleDistributionBroadcastEnabled(item);          return true;
+      case R.id.menu_distribution_conversation: handleDistributionConversationEnabled(item);       return true;
+      case R.id.menu_edit_group:                handleEditPushGroup();                             return true;
+      case R.id.menu_leave:                     handleLeavePushGroup();                            return true;
+      case R.id.menu_invite:                    handleInviteLink();                                return true;
+      case R.id.menu_mute_notifications:        handleMuteNotifications();                         return true;
+      case R.id.menu_unmute_notifications:      handleUnmuteNotifications();                       return true;
+      case R.id.menu_conversation_settings:     handleConversationSettings();                      return true;
+      case android.R.id.home:                   handleReturnToConversationList();                  return true;
     }
 
     return false;
@@ -420,7 +422,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
           @Override
           protected Void doInBackground(Void... params) {
             DatabaseFactory.getRecipientPreferenceDatabase(ConversationActivity.this)
-                           .setMuted(recipients, until);
+                    .setMuted(recipients, until);
 
             return null;
           }
@@ -498,7 +500,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
           final Context context = getApplicationContext();
 
           OutgoingEndSessionMessage endSessionMessage =
-              new OutgoingEndSessionMessage(new OutgoingTextMessage(getRecipients(), "TERMINATE"));
+                  new OutgoingEndSessionMessage(new OutgoingTextMessage(getRecipients(), "TERMINATE"));
 
           new AsyncTask<OutgoingEndSessionMessage, Void, Long>() {
             @Override
@@ -546,12 +548,12 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
           DatabaseFactory.getGroupDatabase(self).setActive(groupId, false);
 
           GroupContext context = GroupContext.newBuilder()
-                                             .setId(ByteString.copyFrom(groupId))
-                                             .setType(GroupContext.Type.QUIT)
-                                             .build();
+                  .setId(ByteString.copyFrom(groupId))
+                  .setType(GroupContext.Type.QUIT)
+                  .build();
 
           OutgoingGroupMediaMessage outgoingMessage = new OutgoingGroupMediaMessage(self, getRecipients(),
-                                                                                    context, null);
+                  context, null);
           MessageSender.send(self, masterSecret, outgoingMessage, threadId, false);
           DatabaseFactory.getGroupDatabase(self).remove(groupId, TextSecurePreferences.getLocalNumber(self));
           initializeEnabledCheck();
@@ -780,7 +782,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     emojiToggle           = (EmojiToggle)           findViewById(R.id.emoji_toggle);
     titleView             = (ConversationTitleView) getSupportActionBar().getCustomView();
     unblockButton         = (Button)                findViewById(R.id.unblock_button);
-    composePanel          = findViewById(R.id.bottom_panel);
+    composePanel          =                         findViewById(R.id.bottom_panel);
     quickAttachmentDrawer = (QuickAttachmentDrawer) findViewById(R.id.quick_attachment_drawer);
     quickAttachmentToggle = (HidingImageButton)     findViewById(R.id.quick_attachment_toggle);
 
@@ -846,6 +848,11 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     getSupportActionBar().setCustomView(R.layout.conversation_title_view);
     getSupportActionBar().setDisplayShowCustomEnabled(true);
     getSupportActionBar().setDisplayShowTitleEnabled(false);
+  }
+
+  private void initializeGestureDetector(){
+    gestureDetector = new GestureDetectorCompat(this, gestureDetectorListener);
+    gestureDetector.setOnDoubleTapListener(gestureDetectorListener);
   }
 
   private EmojiDrawer getEmojiDrawer() {
@@ -937,11 +944,11 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     };
 
     registerReceiver(securityUpdateReceiver,
-                     new IntentFilter(SecurityEvent.SECURITY_UPDATE_EVENT),
-                     KeyCachingService.KEY_PERMISSION, null);
+            new IntentFilter(SecurityEvent.SECURITY_UPDATE_EVENT),
+            KeyCachingService.KEY_PERMISSION, null);
 
     registerReceiver(groupUpdateReceiver,
-                     new IntentFilter(GroupDatabase.DATABASE_UPDATE_ACTION));
+            new IntentFilter(GroupDatabase.DATABASE_UPDATE_ACTION));
   }
 
   //////// Helper Methods
@@ -1121,7 +1128,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
     if (characterState.charactersRemaining <= 15 || characterState.messagesSpent > 1) {
       charactersLeft.setText(characterState.charactersRemaining + "/" + characterState.maxMessageSize
-                                 + " (" + characterState.messagesSpent + ")");
+              + " (" + characterState.messagesSpent + ")");
       charactersLeft.setVisibility(View.VISIBLE);
     } else {
       charactersLeft.setVisibility(View.GONE);
@@ -1326,6 +1333,67 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   // Listeners
+
+  @Override
+  public boolean dispatchTouchEvent(MotionEvent event) {
+    View v = getCurrentFocus();
+    gestureDetector.onTouchEvent(event);
+    return super.dispatchTouchEvent(event);
+  }
+
+  private class GestureDetectorListener implements GestureDetector.OnGestureListener, GestureDetector.OnDoubleTapListener {
+    @Override
+    public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
+      Log.d(TAG, "GestureDetecorListener:onFling() fired");
+      if (isLeftToRightFling(e1, e2, velocityX, velocityY)) {
+        handleReturnToConversationList();
+        return false; // Left to right
+      }
+      return false;
+    }
+    private boolean isLeftToRightFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityYÏ){
+     return  e2.getX() - e1.getX() > SWIPE_MIN_DISTANCE && Math.abs(velocityX) > SWIPE_THRESHOLD_VELOCITY;
+    }
+    @Override
+    public boolean onDown(MotionEvent motionEvent) {
+      return false;
+    }
+
+    @Override
+    public void onShowPress(MotionEvent motionEvent) {
+
+    }
+
+    @Override
+    public boolean onSingleTapUp(MotionEvent motionEvent) {
+      return false;
+    }
+
+    @Override
+    public boolean onScroll(MotionEvent motionEvent, MotionEvent motionEvent1, float v, float v1) {
+      return false;
+    }
+
+    @Override
+    public void onLongPress(MotionEvent motionEvent) {
+
+    }
+
+    @Override
+    public boolean onSingleTapConfirmed(MotionEvent motionEvent) {
+      return false;
+    }
+
+    @Override
+    public boolean onDoubleTap(MotionEvent motionEvent) {
+      return false;
+    }
+
+    @Override
+    public boolean onDoubleTapEvent(MotionEvent motionEvent) {
+      return false;
+    }
+  }
 
   private class AttachmentTypeListener implements DialogInterface.OnClickListener {
     @Override

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -171,16 +171,16 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private   View                      composePanel;
   private   View                      composeBubble;
 
-  private AttachmentTypeSelectorAdapter attachmentAdapter;
-  private AttachmentManager             attachmentManager;
-  private BroadcastReceiver             securityUpdateReceiver;
-  private BroadcastReceiver             groupUpdateReceiver;
-  private Optional<EmojiDrawer> emojiDrawer = Optional.absent();
-  private   EmojiToggle           emojiToggle;
-  protected HidingImageButton     quickAttachmentToggle;
-  private   QuickAttachmentDrawer quickAttachmentDrawer;
+  private   AttachmentTypeSelectorAdapter attachmentAdapter;
+  private   AttachmentManager             attachmentManager;
+  private   BroadcastReceiver             securityUpdateReceiver;
+  private   BroadcastReceiver             groupUpdateReceiver;
+  private   Optional<EmojiDrawer>         emojiDrawer = Optional.absent();
+  private   EmojiToggle                   emojiToggle;
+  protected HidingImageButton             quickAttachmentToggle;
+  private   QuickAttachmentDrawer         quickAttachmentDrawer;
 
-  private GestureDetectorCompat gestureDetector;
+  private GestureDetectorCompat   gestureDetector;
   private GestureDetectorListener gestureDetectorListener = new GestureDetectorListener();
 
   private Recipients recipients;
@@ -207,7 +207,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     setContentView(R.layout.conversation_activity);
 
     fragment = initFragment(R.id.fragment_content, new ConversationFragment(),
-            masterSecret, dynamicLanguage.getCurrentLocale());
+                            masterSecret, dynamicLanguage.getCurrentLocale());
 
     initializeReceivers();
     initializeActionBar();
@@ -291,29 +291,29 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     if (data == null && reqCode != TAKE_PHOTO || resultCode != RESULT_OK) return;
 
     switch (reqCode) {
-      case PICK_IMAGE:
-        addAttachmentImage(masterSecret, data.getData());
-        break;
-      case PICK_VIDEO:
-        addAttachmentVideo(data.getData());
-        break;
-      case PICK_AUDIO:
-        addAttachmentAudio(data.getData());
-        break;
-      case PICK_CONTACT_INFO:
-        addAttachmentContactInfo(data.getData());
-        break;
-      case GROUP_EDIT:
-        this.recipients = RecipientFactory.getRecipientsForIds(this, data.getLongArrayExtra(GroupCreateActivity.GROUP_RECIPIENT_EXTRA), true);
-        titleView.setTitle(recipients);
-        setBlockedUserState(recipients);
-        supportInvalidateOptionsMenu();
-        break;
-      case TAKE_PHOTO:
-        if (attachmentManager.getCaptureUri() != null) {
-          addAttachmentImage(masterSecret, attachmentManager.getCaptureUri());
-        }
-        break;
+    case PICK_IMAGE:
+      addAttachmentImage(masterSecret, data.getData());
+      break;
+    case PICK_VIDEO:
+      addAttachmentVideo(data.getData());
+      break;
+    case PICK_AUDIO:
+      addAttachmentAudio(data.getData());
+      break;
+    case PICK_CONTACT_INFO:
+      addAttachmentContactInfo(data.getData());
+      break;
+    case GROUP_EDIT:
+      this.recipients = RecipientFactory.getRecipientsForIds(this, data.getLongArrayExtra(GroupCreateActivity.GROUP_RECIPIENT_EXTRA), true);
+      titleView.setTitle(recipients);
+      setBlockedUserState(recipients);
+      supportInvalidateOptionsMenu();
+      break;
+    case TAKE_PHOTO:
+      if (attachmentManager.getCaptureUri() != null) {
+        addAttachmentImage(masterSecret, attachmentManager.getCaptureUri());
+      }
+      break;
     }
   }
 
@@ -363,23 +363,23 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   public boolean onOptionsItemSelected(MenuItem item) {
     super.onOptionsItemSelected(item);
     switch (item.getItemId()) {
-      case R.id.menu_call:                      handleDial(getRecipients().getPrimaryRecipient()); return true;
-      case R.id.menu_delete_thread:             handleDeleteThread();                              return true;
-      case R.id.menu_add_attachment:            handleAddAttachment();                             return true;
-      case R.id.menu_view_media:                handleViewMedia();                                 return true;
-      case R.id.menu_add_to_contacts:           handleAddToContacts();                             return true;
-      case R.id.menu_abort_session:             handleAbortSecureSession();                        return true;
-      case R.id.menu_verify_identity:           handleVerifyIdentity();                            return true;
-      case R.id.menu_group_recipients:          handleDisplayGroupRecipients();                    return true;
-      case R.id.menu_distribution_broadcast:    handleDistributionBroadcastEnabled(item);          return true;
-      case R.id.menu_distribution_conversation: handleDistributionConversationEnabled(item);       return true;
-      case R.id.menu_edit_group:                handleEditPushGroup();                             return true;
-      case R.id.menu_leave:                     handleLeavePushGroup();                            return true;
-      case R.id.menu_invite:                    handleInviteLink();                                return true;
-      case R.id.menu_mute_notifications:        handleMuteNotifications();                         return true;
-      case R.id.menu_unmute_notifications:      handleUnmuteNotifications();                       return true;
-      case R.id.menu_conversation_settings:     handleConversationSettings();                      return true;
-      case android.R.id.home:                   handleReturnToConversationList();                  return true;
+    case R.id.menu_call:                      handleDial(getRecipients().getPrimaryRecipient()); return true;
+    case R.id.menu_delete_thread:             handleDeleteThread();                              return true;
+    case R.id.menu_add_attachment:            handleAddAttachment();                             return true;
+    case R.id.menu_view_media:                handleViewMedia();                                 return true;
+    case R.id.menu_add_to_contacts:           handleAddToContacts();                             return true;
+    case R.id.menu_abort_session:             handleAbortSecureSession();                        return true;
+    case R.id.menu_verify_identity:           handleVerifyIdentity();                            return true;
+    case R.id.menu_group_recipients:          handleDisplayGroupRecipients();                    return true;
+    case R.id.menu_distribution_broadcast:    handleDistributionBroadcastEnabled(item);          return true;
+    case R.id.menu_distribution_conversation: handleDistributionConversationEnabled(item);       return true;
+    case R.id.menu_edit_group:                handleEditPushGroup();                             return true;
+    case R.id.menu_leave:                     handleLeavePushGroup();                            return true;
+    case R.id.menu_invite:                    handleInviteLink();                                return true;
+    case R.id.menu_mute_notifications:        handleMuteNotifications();                         return true;
+    case R.id.menu_unmute_notifications:      handleUnmuteNotifications();                       return true;
+    case R.id.menu_conversation_settings:     handleConversationSettings();                      return true;
+    case android.R.id.home:                   handleReturnToConversationList();                  return true;
     }
 
     return false;
@@ -500,7 +500,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
           final Context context = getApplicationContext();
 
           OutgoingEndSessionMessage endSessionMessage =
-                  new OutgoingEndSessionMessage(new OutgoingTextMessage(getRecipients(), "TERMINATE"));
+              new OutgoingEndSessionMessage(new OutgoingTextMessage(getRecipients(), "TERMINATE"));
 
           new AsyncTask<OutgoingEndSessionMessage, Void, Long>() {
             @Override
@@ -553,7 +553,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
                                              .build();
 
           OutgoingGroupMediaMessage outgoingMessage = new OutgoingGroupMediaMessage(self, getRecipients(),
-                  context, null);
+                                                                                    context, null);
           MessageSender.send(self, masterSecret, outgoingMessage, threadId, false);
           DatabaseFactory.getGroupDatabase(self).remove(groupId, TextSecurePreferences.getLocalNumber(self));
           initializeEnabledCheck();
@@ -1128,7 +1128,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
     if (characterState.charactersRemaining <= 15 || characterState.messagesSpent > 1) {
       charactersLeft.setText(characterState.charactersRemaining + "/" + characterState.maxMessageSize
-              + " (" + characterState.messagesSpent + ")");
+                                 + " (" + characterState.messagesSpent + ")");
       charactersLeft.setVisibility(View.VISIBLE);
     } else {
       charactersLeft.setVisibility(View.GONE);

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1341,7 +1341,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     return super.dispatchTouchEvent(event);
   }
 
-  private class GestureDetectorListener implements GestureDetector.OnGestureListener, GestureDetector.OnDoubleTapListener {
+  private class GestureDetectorListener extends GestureDetector.SimpleOnGestureListener {
     @Override
     public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
       Log.d(TAG, "GestureDetecorListener:onFling() fired");
@@ -1350,45 +1350,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     }
     private boolean isLeftToRightFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY){
      return  e2.getX() - e1.getX() > SWIPE_MIN_DISTANCE && Math.abs(velocityX) > SWIPE_THRESHOLD_VELOCITY;
-    }
-    @Override
-    public boolean onDown(MotionEvent motionEvent) {
-      return false;
-    }
-
-    @Override
-    public void onShowPress(MotionEvent motionEvent) {
-
-    }
-
-    @Override
-    public boolean onSingleTapUp(MotionEvent motionEvent) {
-      return false;
-    }
-
-    @Override
-    public boolean onScroll(MotionEvent motionEvent, MotionEvent motionEvent1, float v, float v1) {
-      return false;
-    }
-
-    @Override
-    public void onLongPress(MotionEvent motionEvent) {
-
-    }
-
-    @Override
-    public boolean onSingleTapConfirmed(MotionEvent motionEvent) {
-      return false;
-    }
-
-    @Override
-    public boolean onDoubleTap(MotionEvent motionEvent) {
-      return false;
-    }
-
-    @Override
-    public boolean onDoubleTapEvent(MotionEvent motionEvent) {
-      return false;
     }
   }
 

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -157,7 +157,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private static final int TAKE_PHOTO               = 6;
   private static final int SWIPE_MIN_DISTANCE       = 120;
   private static final int SWIPE_THRESHOLD_VELOCITY = 200;
-  private static final int SWIPE_VERTICAL_TOLERANCE = 150;
+  private static final int SWIPE_VERTICAL_TOLERANCE = 165;
 
   private   MasterSecret              masterSecret;
   protected ComposeText               composeText;
@@ -1345,12 +1345,11 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private class GestureDetectorListener extends GestureDetector.SimpleOnGestureListener {
     @Override
     public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
-      if (isLeftToRightFling(e1, e2, velocityX, velocityY)) handleReturnToConversationList();
+      if (!isEmojiDrawerOpen() && isLeftToRightFling(e1, e2, velocityX, velocityY))
+        handleReturnToConversationList();
       return false;
     }
     private boolean isLeftToRightFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY){
-      Log.d(TAG, "e1_y: " + e1.getY()+ ", e2_y: " + e2.getY() + ", vertical distance: "
-                 + Math.abs(e2.getY()-e1.getY()) + ", with velocityY = " + velocityY);
       return e2.getX() - e1.getX() > SWIPE_MIN_DISTANCE &&
              Math.abs(e2.getY() - e1.getY()) < SWIPE_VERTICAL_TOLERANCE &&
              Math.abs(velocityX) > SWIPE_THRESHOLD_VELOCITY;

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -157,6 +157,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private static final int TAKE_PHOTO               = 6;
   private static final int SWIPE_MIN_DISTANCE       = 120;
   private static final int SWIPE_THRESHOLD_VELOCITY = 200;
+  private static final int SWIPE_VERTICAL_TOLERANCE = 150;
 
   private   MasterSecret              masterSecret;
   protected ComposeText               composeText;
@@ -1344,12 +1345,15 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private class GestureDetectorListener extends GestureDetector.SimpleOnGestureListener {
     @Override
     public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
-      Log.d(TAG, "GestureDetecorListener:onFling() fired");
       if (isLeftToRightFling(e1, e2, velocityX, velocityY)) handleReturnToConversationList();
       return false;
     }
     private boolean isLeftToRightFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY){
-     return  e2.getX() - e1.getX() > SWIPE_MIN_DISTANCE && Math.abs(velocityX) > SWIPE_THRESHOLD_VELOCITY;
+      Log.d(TAG, "e1_y: " + e1.getY()+ ", e2_y: " + e2.getY() + ", vertical distance: "
+                 + Math.abs(e2.getY()-e1.getY()) + ", with velocityY = " + velocityY);
+      return e2.getX() - e1.getX() > SWIPE_MIN_DISTANCE &&
+             Math.abs(e2.getY() - e1.getY()) < SWIPE_VERTICAL_TOLERANCE &&
+             Math.abs(velocityX) > SWIPE_THRESHOLD_VELOCITY;
     }
   }
 

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -38,14 +38,21 @@ import android.support.annotation.NonNull;
 import android.support.v4.view.GestureDetectorCompat;
 import android.support.v4.view.WindowCompat;
 import android.text.Editable;
+import android.text.InputType;
 import android.text.TextWatcher;
 import android.util.Log;
-import android.view.*;
+import android.view.KeyEvent;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.View.OnFocusChangeListener;
 import android.view.View.OnKeyListener;
+import android.view.ViewStub;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
+import android.view.MotionEvent;
 import android.widget.Button;
 import android.widget.ImageButton;
 import android.widget.TextView;
@@ -141,13 +148,13 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 {
   private static final String TAG = ConversationActivity.class.getSimpleName();
 
-  public static final  String RECIPIENTS_EXTRA         = "recipients";
-  public static final  String THREAD_ID_EXTRA          = "thread_id";
-  public static final  String DRAFT_TEXT_EXTRA         = "draft_text";
-  public static final  String DRAFT_IMAGE_EXTRA        = "draft_image";
-  public static final  String DRAFT_AUDIO_EXTRA        = "draft_audio";
-  public static final  String DRAFT_VIDEO_EXTRA        = "draft_video";
-  public static final  String DISTRIBUTION_TYPE_EXTRA  = "distribution_type";
+  public static final String RECIPIENTS_EXTRA        = "recipients";
+  public static final String THREAD_ID_EXTRA         = "thread_id";
+  public static final String DRAFT_TEXT_EXTRA        = "draft_text";
+  public static final String DRAFT_IMAGE_EXTRA       = "draft_image";
+  public static final String DRAFT_AUDIO_EXTRA       = "draft_audio";
+  public static final String DRAFT_VIDEO_EXTRA       = "draft_video";
+  public static final String DISTRIBUTION_TYPE_EXTRA = "distribution_type";
 
   private static final int PICK_IMAGE               = 1;
   private static final int PICK_VIDEO               = 2;
@@ -266,8 +273,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     quickAttachmentDrawer.onPause();
   }
 
-  @Override
-  public void onConfigurationChanged(Configuration newConfig) {
+  @Override public void onConfigurationChanged(Configuration newConfig) {
     super.onConfigurationChanged(newConfig);
     composeText.setTransport(sendButton.getSelectedTransport());
     quickAttachmentDrawer.onConfigurationChanged();
@@ -853,7 +859,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
   private void initializeGestureDetector(){
     gestureDetector = new GestureDetectorCompat(this, gestureDetectorListener);
-    gestureDetector.setOnDoubleTapListener(gestureDetectorListener);
   }
 
   private void initializeResources() {
@@ -1337,7 +1342,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
   @Override
   public boolean dispatchTouchEvent(MotionEvent event) {
-    View v = getCurrentFocus();
     gestureDetector.onTouchEvent(event);
     return super.dispatchTouchEvent(event);
   }

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1348,7 +1348,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       if (isLeftToRightFling(e1, e2, velocityX, velocityY)) handleReturnToConversationList();
       return false;
     }
-    private boolean isLeftToRightFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityYÏ){
+    private boolean isLeftToRightFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY){
      return  e2.getX() - e1.getX() > SWIPE_MIN_DISTANCE && Math.abs(velocityX) > SWIPE_THRESHOLD_VELOCITY;
     }
     @Override

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1345,14 +1345,20 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private class GestureDetectorListener extends GestureDetector.SimpleOnGestureListener {
     @Override
     public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
-      if (!isEmojiDrawerOpen() && isLeftToRightFling(e1, e2, velocityX, velocityY))
+      if (isLeftToRightFling(e1, e2, velocityX, velocityY)
+          && (!isEmojiDrawerOpen() || isAboveKeyboard(e1, e2))) {
         handleReturnToConversationList();
+      }
       return false;
     }
     private boolean isLeftToRightFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY){
       return e2.getX() - e1.getX() > SWIPE_MIN_DISTANCE &&
              Math.abs(e2.getY() - e1.getY()) < SWIPE_VERTICAL_TOLERANCE &&
              Math.abs(velocityX) > SWIPE_THRESHOLD_VELOCITY;
+    }
+    private boolean isAboveKeyboard(MotionEvent e1, MotionEvent e2) {
+      float keyboardHeight = container.getKeyboardHeight();
+      return e1.getY() < keyboardHeight && e2.getY() < keyboardHeight;
     }
   }
 

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -187,7 +187,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private long       threadId;
   private int        distributionType;
   private boolean    isEncryptedConversation;
-  private boolean isMmsEnabled = true;
+  private boolean    isMmsEnabled = true;
 
   private DynamicTheme    dynamicTheme    = new DynamicTheme();
   private DynamicLanguage dynamicLanguage = new DynamicLanguage();
@@ -349,7 +349,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     inflater.inflate(R.menu.conversation, menu);
 
     if (recipients != null && recipients.isMuted()) inflater.inflate(R.menu.conversation_muted, menu);
-    else                                             inflater.inflate(R.menu.conversation_unmuted, menu);
+    else                                            inflater.inflate(R.menu.conversation_unmuted, menu);
 
     if (isSingleConversation() && getRecipients().getPrimaryRecipient().getContactUri() == null) {
       inflater.inflate(R.menu.conversation_add_to_contacts, menu);
@@ -422,7 +422,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
           @Override
           protected Void doInBackground(Void... params) {
             DatabaseFactory.getRecipientPreferenceDatabase(ConversationActivity.this)
-                    .setMuted(recipients, until);
+                           .setMuted(recipients, until);
 
             return null;
           }
@@ -548,9 +548,9 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
           DatabaseFactory.getGroupDatabase(self).setActive(groupId, false);
 
           GroupContext context = GroupContext.newBuilder()
-                  .setId(ByteString.copyFrom(groupId))
-                  .setType(GroupContext.Type.QUIT)
-                  .build();
+                                             .setId(ByteString.copyFrom(groupId))
+                                             .setType(GroupContext.Type.QUIT)
+                                             .build();
 
           OutgoingGroupMediaMessage outgoingMessage = new OutgoingGroupMediaMessage(self, getRecipients(),
                   context, null);
@@ -1345,10 +1345,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     @Override
     public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
       Log.d(TAG, "GestureDetecorListener:onFling() fired");
-      if (isLeftToRightFling(e1, e2, velocityX, velocityY)) {
-        handleReturnToConversationList();
-        return false; // Left to right
-      }
+      if (isLeftToRightFling(e1, e2, velocityX, velocityY)) handleReturnToConversationList();
       return false;
     }
     private boolean isLeftToRightFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityYÏ){


### PR DESCRIPTION
Gestures are a really powerful UX element and they are a perfectly suit for the scenario of navigating back from a single conversation to the conversation list.
I'm referring to this issue: https://github.com/WhisperSystems/TextSecure/issues/584

The back button is much more inconvenient than having the possibility to navigate between multiple conversations with only taps and a back-swipe-gesture. 

![ts-conversation-swipe](https://cloud.githubusercontent.com/assets/3121306/8890077/69479c0a-32f3-11e5-999e-c5952e0edf65.gif)


IMHO this feature can be enabled by default. If any user does not like it - he just don't need to use it; it's not disturbing in any way.

I used the GestureDetectorCompat from the support library ~~but someone might please test it on a ~2.3 device~~, tested on LP and GB.

~~But on both phones swiping/scrolling up and just a bit to the right switches back to the conversation list.~~ fixed

//FREEBIE