### PR TITLE
add previewFormat logging to QuickCamera

### DIFF
--- a/src/org/thoughtcrime/securesms/components/camera/QuickCamera.java
+++ b/src/org/thoughtcrime/securesms/components/camera/QuickCamera.java
@@ -81,6 +81,7 @@ import java.util.List;
         final Rect croppingRect = getCroppedRect(previewSize, previewRect, rotation);
 
         Log.w(TAG, "previewSize: " + previewSize.width + "x" + previewSize.height);
+        Log.w(TAG, "previewFormat: " + cameraParameters.getPreviewFormat());
         Log.w(TAG, "croppingRect: " + croppingRect.toString());
         Log.w(TAG, "rotation: " + rotation);
         new AsyncTask<byte[], Void, byte[]>() {


### PR DESCRIPTION
to help diagnose #3752. Android's documentation says the preview will always come back in NV21 and all cameras support that format, but now I don't trust that.