### PR TITLE
inflate transport popup opportunistically

### DIFF
--- a/src/org/thoughtcrime/securesms/components/SendButton.java
+++ b/src/org/thoughtcrime/securesms/components/SendButton.java
@@ -9,6 +9,7 @@ import org.thoughtcrime.securesms.TransportOption;
 import org.thoughtcrime.securesms.TransportOptions;
 import org.thoughtcrime.securesms.TransportOptions.OnTransportChangedListener;
 import org.thoughtcrime.securesms.TransportOptionsPopup;
+import org.whispersystems.libaxolotl.util.guava.Optional;
 
 public class SendButton extends ImageButton
     implements TransportOptions.OnTransportChangedListener,
@@ -16,28 +17,26 @@ public class SendButton extends ImageButton
                View.OnLongClickListener
 {
 
-  private final TransportOptions      transportOptions;
-  private final TransportOptionsPopup transportOptionsPopup;
+  private final TransportOptions transportOptions;
+
+  private Optional<TransportOptionsPopup> transportOptionsPopup = Optional.absent();
 
   @SuppressWarnings("unused")
   public SendButton(Context context) {
     super(context);
-    this.transportOptions      = initializeTransportOptions(false);
-    this.transportOptionsPopup = initializeTransportOptionsPopup();
+    this.transportOptions = initializeTransportOptions(false);
   }
 
   @SuppressWarnings("unused")
   public SendButton(Context context, AttributeSet attrs) {
     super(context, attrs);
-    this.transportOptions      = initializeTransportOptions(false);
-    this.transportOptionsPopup = initializeTransportOptionsPopup();
+    this.transportOptions = initializeTransportOptions(false);
   }
 
   @SuppressWarnings("unused")
   public SendButton(Context context, AttributeSet attrs, int defStyle) {
     super(context, attrs, defStyle);
-    this.transportOptions      = initializeTransportOptions(false);
-    this.transportOptionsPopup = initializeTransportOptionsPopup();
+    this.transportOptions = initializeTransportOptions(false);
   }
 
   private TransportOptions initializeTransportOptions(boolean media) {
@@ -49,8 +48,11 @@ public class SendButton extends ImageButton
     return transportOptions;
   }
 
-  private TransportOptionsPopup initializeTransportOptionsPopup() {
-    return new TransportOptionsPopup(getContext(), this, this);
+  private TransportOptionsPopup getTransportOptionsPopup() {
+    if (!transportOptionsPopup.isPresent()) {
+      transportOptionsPopup = Optional.of(new TransportOptionsPopup(getContext(), this, this));
+    }
+    return transportOptionsPopup.get();
   }
 
   public boolean isManualSelection() {
@@ -80,7 +82,7 @@ public class SendButton extends ImageButton
   @Override
   public void onSelected(TransportOption option) {
     transportOptions.setSelectedTransport(option.getType());
-    transportOptionsPopup.dismiss();
+    getTransportOptionsPopup().dismiss();
   }
 
   @Override
@@ -92,7 +94,7 @@ public class SendButton extends ImageButton
   @Override
   public boolean onLongClick(View v) {
     if (transportOptions.getEnabledTransports().size() > 1) {
-      transportOptionsPopup.display(transportOptions.getEnabledTransports());
+      getTransportOptionsPopup().display(transportOptions.getEnabledTransports());
       return true;
     }
 


### PR DESCRIPTION
another thing I noticed during trace when opening a conversation. ListPopupWindow inflation can take up to ~100ms, so trimming that down until a user actually needs it since most of the time it won't be necessary.