### PR TITLE
warm database caches asynchronously at app start

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -18,11 +18,19 @@ package org.thoughtcrime.securesms;
 
 import android.app.Application;
 import android.content.Context;
+import android.os.AsyncTask;
 import android.os.StrictMode;
 import android.os.StrictMode.ThreadPolicy;
 import android.os.StrictMode.VmPolicy;
+import android.preference.PreferenceManager;
+import android.util.Log;
+
+import com.google.i18n.phonenumbers.NumberParseException;
+import com.google.i18n.phonenumbers.PhoneNumberUtil;
 
 import org.thoughtcrime.securesms.crypto.PRNGFixes;
+import org.thoughtcrime.securesms.database.CanonicalAddressDatabase;
+import org.thoughtcrime.securesms.database.TextSecureDirectory;
 import org.thoughtcrime.securesms.dependencies.AxolotlStorageModule;
 import org.thoughtcrime.securesms.dependencies.InjectableType;
 import org.thoughtcrime.securesms.dependencies.TextSecureCommunicationModule;
@@ -48,6 +56,7 @@ import dagger.ObjectGraph;
  * @author Moxie Marlinspike
  */
 public class ApplicationContext extends Application implements DependencyInjector {
+  private static final String TAG = ApplicationContext.class.getSimpleName();
 
   private JobManager jobManager;
   private ObjectGraph objectGraph;
@@ -65,6 +74,7 @@ public class ApplicationContext extends Application implements DependencyInjecto
     initializeDependencyInjection();
     initializeJobManager();
     initializeGcmCheck();
+    initializeCaches();
   }
 
   @Override
@@ -121,4 +131,24 @@ public class ApplicationContext extends Application implements DependencyInjecto
     }
   }
 
+  private void initializeCaches() {
+    new AsyncTask<Context,Void,Void>() {
+      @Override protected Void doInBackground(Context... contexts) {
+        final long    startMillis = System.currentTimeMillis();
+        final Context context     = contexts[0];
+
+        CanonicalAddressDatabase.getInstance(context).fillCache();
+        TextSecureDirectory.getInstance(context).fillCache();
+        if (TextSecurePreferences.isPushRegistered(context)) {
+          try {
+            PhoneNumberUtil.getInstance().parse(TextSecurePreferences.getLocalNumber(context), null);
+          } catch (NumberParseException dgaf) {
+            Log.w(TAG, "failed to warm libphonenumber with the localized phone number");
+          }
+        }
+        Log.w(TAG, "cache warming took " + (System.currentTimeMillis() - startMillis) + "ms");
+        return null;
+      }
+    }.execute(this);
+  }
 }

--- a/src/org/thoughtcrime/securesms/database/CanonicalAddressDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/CanonicalAddressDatabase.java
@@ -64,17 +64,15 @@ public class CanonicalAddressDatabase {
 
   private CanonicalAddressDatabase(Context context) {
     databaseHelper = new DatabaseHelper(context, DATABASE_NAME, null, DATABASE_VERSION);
-    fillCache();
   }
 
   public void reset(Context context) {
     DatabaseHelper old  = this.databaseHelper;
     this.databaseHelper = new DatabaseHelper(context.getApplicationContext(), DATABASE_NAME, null, DATABASE_VERSION);
     old.close();
-    fillCache();
   }
 
-  private void fillCache() {
+  public void fillCache() {
     Cursor cursor = null;
 
     try {


### PR DESCRIPTION
Previously, CanonicalAddressDatabase was reading the entire database synchronously on the UI thread, and TextSecureDirectory was doing main thread I/O every time we checked if a number was a TextSecure user. On my slow phone, this was taking multiple seconds.

This change
* Adds a caching layer for TextSecureDirectory
* Fills the TextSecureDirectory and CanoncalAddressDatabase caches asynchronously on app start
* Asynchronously loads the libphonenumber metadata from disk by calling it's `parse()` method on our local phone number (if it exists). Otherwise, this was another ~1000ms operation on the UI thread the first time a conversation was opened.