### PR TITLE
gifs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     compile 'org.w3c:smil:1.0.0'
     compile 'org.apache.httpcomponents:httpclient-android:4.3.5'
     compile 'com.github.chrisbanes.photoview:library:1.2.3'
-    compile 'com.github.bumptech.glide:glide:3.6.0'
+    compile 'com.github.bumptech.glide:glide:3.6.1'
     compile 'com.makeramen:roundedimageview:2.1.0'
     compile 'com.pnikosis:materialish-progress:1.5'
     compile 'de.greenrobot:eventbus:2.4.0'
@@ -108,7 +108,7 @@ dependencyVerification {
             'org.w3c:smil:085dc40f2bb249651578bfa07499fd08b16ad0886dbe2c4078586a408da62f9b',
             'org.apache.httpcomponents:httpclient-android:6f56466a9bd0d42934b90bfbfe9977a8b654c058bf44a12bdc2877c4e1f033f1',
             'com.github.chrisbanes.photoview:library:8b5344e206f125e7ba9d684008f36c4992d03853c57e5814125f88496126e3cc',
-            'com.github.bumptech.glide:glide:adf657e6bddccb168a29e18ab0954043af46a9b5c736d8c3193c9783fd83d69e',
+            'com.github.bumptech.glide:glide:4718ac4c57ebabe56e673dc3265950b9dbf940d1c43c0adc363e8b95c0abdf75',
             'com.makeramen:roundedimageview:1f5a1865796b308c6cdd114acc6e78408b110f0a62fc63553278fbeacd489cd1',
             'com.pnikosis:materialish-progress:d71d80e00717a096784482aee21001a9d299fec3833e4ebd87739ed36cf77c54',
             'de.greenrobot:eventbus:61d743a748156a372024d083de763b9e91ac2dcb3f6a1cbc74995c7ddab6e968',

--- a/res/layout/conversation_activity.xml
+++ b/res/layout/conversation_activity.xml
@@ -55,7 +55,6 @@
                                 android:id="@+id/attachment_thumbnail"
                                 android:layout_width="230dp"
                                 android:layout_height="150dp"
-                                app:riv_corner_radius="3dp"
                                 android:contentDescription="@string/conversation_activity__attachment_thumbnail"/>
                     </FrameLayout>
 

--- a/res/layout/conversation_activity.xml
+++ b/res/layout/conversation_activity.xml
@@ -55,7 +55,8 @@
                                 android:id="@+id/attachment_thumbnail"
                                 android:layout_width="230dp"
                                 android:layout_height="150dp"
-                                android:contentDescription="@string/conversation_activity__attachment_thumbnail"/>
+                                android:contentDescription="@string/conversation_activity__attachment_thumbnail"
+                                app:backgroundColorHint="?conversation_background" />
                     </FrameLayout>
 
                     <ImageView android:id="@+id/remove_image_button"

--- a/res/layout/conversation_item_received.xml
+++ b/res/layout/conversation_item_received.xml
@@ -54,8 +54,6 @@
                     android:adjustViewBounds="true"
                     android:contentDescription="@string/conversation_item__mms_image_description"
                     android:visibility="gone"
-                    app:riv_corner_radius="@dimen/message_bubble_corner_radius"
-                    app:riv_border_width="0dp"
                     tools:src="@drawable/ic_video_light"
                     tools:visibility="visible" />
 

--- a/res/layout/conversation_item_sent.xml
+++ b/res/layout/conversation_item_sent.xml
@@ -65,8 +65,6 @@
                     android:adjustViewBounds="true"
                     android:contentDescription="@string/conversation_item__mms_image_description"
                     android:visibility="gone"
-                    app:riv_corner_radius="@dimen/message_bubble_corner_radius"
-                    app:riv_border_width="0dp"
                     tools:src="@drawable/ic_video_light"
                     tools:visibility="visible" />
 

--- a/res/layout/group_create_activity.xml
+++ b/res/layout/group_create_activity.xml
@@ -25,7 +25,6 @@
                 android:layout_width="70dp"
                 android:layout_height="70dp"
                 position="bottom_right"
-                app:riv_oval="true"
                 android:layout_marginRight="10dp"
                 android:src="@drawable/ic_group_photo"
                 android:contentDescription="@string/GroupCreateActivity_avatar_content_description" />

--- a/res/layout/thumbnail_view.xml
+++ b/res/layout/thumbnail_view.xml
@@ -2,15 +2,13 @@
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
        xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <com.makeramen.roundedimageview.RoundedImageView
-            android:id="@+id/thumbnail_image"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:scaleType="fitCenter"
-            android:adjustViewBounds="true"
-            android:contentDescription="@string/conversation_item__mms_image_description"
-            android:layout_margin="@dimen/media_bubble_border_width"
-            app:riv_corner_radius="@dimen/message_bubble_corner_radius" />
+    <ImageView android:id="@+id/thumbnail_image"
+               android:layout_width="match_parent"
+               android:layout_height="match_parent"
+               android:adjustViewBounds="true"
+               android:scaleType="fitCenter"
+               android:contentDescription="@string/conversation_item__mms_image_description"
+               android:layout_margin="@dimen/media_bubble_border_width" />
 
     <com.pnikosis.materialishprogress.ProgressWheel
             android:id="@+id/progress_wheel"

--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -130,4 +130,7 @@
         <attr name="inverted" format="boolean"/>
     </declare-styleable>
 
+    <declare-styleable name="ThumbnailView">
+        <attr name="backgroundColorHint" format="color" />
+    </declare-styleable>
 </resources>

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -211,11 +211,13 @@ public class ConversationItem extends LinearLayout {
   private void setBubbleState(MessageRecord messageRecord) {
     if (messageRecord.isOutgoing()) {
       bodyBubble.getBackground().setColorFilter(defaultBubbleColor, PorterDuff.Mode.MULTIPLY);
+      mediaThumbnail.setBackgroundColorHint(defaultBubbleColor);
     } else {
-      bodyBubble.getBackground().setColorFilter(messageRecord.getIndividualRecipient()
-                                                             .getColor()
-                                                             .toConversationColor(context),
-                                                PorterDuff.Mode.MULTIPLY);
+      int color = messageRecord.getIndividualRecipient()
+                               .getColor()
+                               .toConversationColor(context);
+      bodyBubble.getBackground().setColorFilter(color, PorterDuff.Mode.MULTIPLY);
+      mediaThumbnail.setBackgroundColorHint(color);
     }
 
   }

--- a/src/org/thoughtcrime/securesms/components/ImageDivet.java
+++ b/src/org/thoughtcrime/securesms/components/ImageDivet.java
@@ -7,11 +7,9 @@ import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 import android.widget.ImageView;
 
-import com.makeramen.roundedimageview.RoundedImageView;
-
 import org.thoughtcrime.securesms.R;
 
-public class ImageDivet extends RoundedImageView {
+public class ImageDivet extends ImageView {
   private static final float CORNER_OFFSET = 12F;
   private static final String[] POSITIONS  = new String[] {"bottom_right"};
 

--- a/src/org/thoughtcrime/securesms/components/ThumbnailView.java
+++ b/src/org/thoughtcrime/securesms/components/ThumbnailView.java
@@ -3,7 +3,9 @@ package org.thoughtcrime.securesms.components;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.graphics.Bitmap;
+import android.graphics.Color;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.support.annotation.NonNull;
@@ -15,13 +17,18 @@ import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
 import android.view.animation.Animation.AnimationListener;
 import android.widget.FrameLayout;
+import android.widget.ImageView;
 
+import com.bumptech.glide.BitmapTypeRequest;
 import com.bumptech.glide.DrawableTypeRequest;
 import com.bumptech.glide.GenericRequestBuilder;
 import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.resource.bitmap.CenterCrop;
+import com.bumptech.glide.load.resource.bitmap.FitCenter;
+import com.bumptech.glide.load.resource.bitmap.GlideBitmapDrawable;
+import com.bumptech.glide.load.resource.drawable.GlideDrawable;
 import com.bumptech.glide.request.RequestListener;
 import com.bumptech.glide.request.target.Target;
-import com.makeramen.roundedimageview.RoundedImageView;
 import com.pnikosis.materialishprogress.ProgressWheel;
 
 import org.thoughtcrime.securesms.R;
@@ -32,6 +39,7 @@ import org.thoughtcrime.securesms.mms.Slide;
 import org.thoughtcrime.securesms.mms.SlideDeck;
 import org.thoughtcrime.securesms.util.FutureTaskListener;
 import org.thoughtcrime.securesms.util.ListenableFutureTask;
+import org.thoughtcrime.securesms.mms.RoundedCorners;
 import org.thoughtcrime.securesms.util.Util;
 
 import de.greenrobot.event.EventBus;
@@ -40,9 +48,11 @@ import ws.com.google.android.mms.pdu.PduPart;
 public class ThumbnailView extends FrameLayout {
   private static final String TAG = ThumbnailView.class.getSimpleName();
 
-  private boolean          showProgress = true;
-  private RoundedImageView image;
-  private ProgressWheel    progress;
+  private boolean       showProgress = true;
+  private ImageView     image;
+  private ProgressWheel progress;
+  private int           backgroundColorHint;
+  private int           radius;
 
   private ListenableFutureTask<SlideDeck> slideDeckFuture        = null;
   private SlideDeckListener               slideDeckListener      = null;
@@ -61,8 +71,15 @@ public class ThumbnailView extends FrameLayout {
   public ThumbnailView(Context context, AttributeSet attrs, int defStyle) {
     super(context, attrs, defStyle);
     inflate(context, R.layout.thumbnail_view, this);
-    image    = (RoundedImageView) findViewById(R.id.thumbnail_image);
-    progress = (ProgressWheel)    findViewById(R.id.progress_wheel);
+    radius   = getResources().getDimensionPixelSize(R.dimen.message_bubble_corner_radius);
+    image    = (ImageView)     findViewById(R.id.thumbnail_image);
+    progress = (ProgressWheel) findViewById(R.id.progress_wheel);
+
+    if (attrs != null) {
+      TypedArray typedArray = context.getTheme().obtainStyledAttributes(attrs, R.styleable.ThumbnailView, 0, 0);
+      backgroundColorHint = typedArray.getColor(0, Color.BLACK);
+      typedArray.recycle();
+    }
   }
 
   @Override protected void onAttachedToWindow() {
@@ -80,11 +97,15 @@ public class ThumbnailView extends FrameLayout {
     if (this.slide != null && event.partId.equals(this.slide.getPart().getPartId())) {
       Util.runOnMain(new Runnable() {
         @Override public void run() {
-          progress.setInstantProgress(((float) event.progress) / event.total);
+          progress.setInstantProgress(((float)event.progress) / event.total);
           if (event.progress >= event.total) animateOutProgress();
         }
       });
     }
+  }
+
+  public void setBackgroundColorHint(int color) {
+    this.backgroundColorHint = color;
   }
 
   public void setImageResource(@Nullable MasterSecret masterSecret,
@@ -182,8 +203,9 @@ public class ThumbnailView extends FrameLayout {
     if (masterSecret == null) request = Glide.with(getContext()).load(slide.getThumbnailUri());
     else                      request = Glide.with(getContext()).load(new DecryptableUri(masterSecret, slide.getThumbnailUri()));
 
-    return request.asBitmap()
-                  .fitCenter()
+    return request.fitCenter()
+                  .transform(new FitCenter(getContext()),
+                             new RoundedCorners(getContext(), radius, backgroundColorHint))
                   .listener(new PduThumbnailSetListener(slide.getPart()));
   }
 
@@ -192,9 +214,10 @@ public class ThumbnailView extends FrameLayout {
       throw new IllegalStateException("null MasterSecret when loading non-draft thumbnail");
     }
 
-    return  Glide.with(getContext()).load(new DecryptableUri(masterSecret, slide.getThumbnailUri()))
-                                    .asBitmap()
-                                    .centerCrop();
+    return Glide.with(getContext()).load(new DecryptableUri(masterSecret, slide.getThumbnailUri()))
+                                   .crossFade()
+                                   .transform(new CenterCrop(getContext()),
+                                              new RoundedCorners(getContext(), radius, backgroundColorHint));
   }
 
   private GenericRequestBuilder buildPlaceholderGlideRequest(Slide slide) {
@@ -282,7 +305,7 @@ public class ThumbnailView extends FrameLayout {
     }
   }
 
-  private static class PduThumbnailSetListener implements RequestListener<Object, Bitmap> {
+  private static class PduThumbnailSetListener implements RequestListener<Object, GlideDrawable> {
     private PduPart part;
 
     public PduThumbnailSetListener(@NonNull PduPart part) {
@@ -290,13 +313,15 @@ public class ThumbnailView extends FrameLayout {
     }
 
     @Override
-    public boolean onException(Exception e, Object model, Target<Bitmap> target, boolean isFirstResource) {
+    public boolean onException(Exception e, Object model, Target<GlideDrawable> target, boolean isFirstResource) {
       return false;
     }
 
     @Override
-    public boolean onResourceReady(Bitmap resource, Object model, Target<Bitmap> target, boolean isFromMemoryCache, boolean isFirstResource) {
-      part.setThumbnail(resource);
+    public boolean onResourceReady(GlideDrawable resource, Object model, Target<GlideDrawable> target, boolean isFromMemoryCache, boolean isFirstResource) {
+      if (resource instanceof GlideBitmapDrawable) {
+        part.setThumbnail(((GlideBitmapDrawable)resource).getBitmap());
+      }
       return false;
     }
   }

--- a/src/org/thoughtcrime/securesms/components/ThumbnailView.java
+++ b/src/org/thoughtcrime/securesms/components/ThumbnailView.java
@@ -4,7 +4,6 @@ import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
@@ -19,12 +18,10 @@ import android.view.animation.Animation.AnimationListener;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 
-import com.bumptech.glide.BitmapTypeRequest;
 import com.bumptech.glide.DrawableTypeRequest;
 import com.bumptech.glide.GenericRequestBuilder;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.resource.bitmap.CenterCrop;
-import com.bumptech.glide.load.resource.bitmap.FitCenter;
 import com.bumptech.glide.load.resource.bitmap.GlideBitmapDrawable;
 import com.bumptech.glide.load.resource.drawable.GlideDrawable;
 import com.bumptech.glide.request.RequestListener;
@@ -176,6 +173,7 @@ public class ThumbnailView extends FrameLayout {
   private GenericRequestBuilder buildGlideRequest(@NonNull Slide slide,
                                                   @Nullable MasterSecret masterSecret)
   {
+    Log.w(TAG, "slide type " + slide.getContentType());
     final GenericRequestBuilder builder;
     if (slide.getThumbnailUri() != null) {
       builder = buildThumbnailGlideRequest(slide, masterSecret);
@@ -203,9 +201,7 @@ public class ThumbnailView extends FrameLayout {
     if (masterSecret == null) request = Glide.with(getContext()).load(slide.getThumbnailUri());
     else                      request = Glide.with(getContext()).load(new DecryptableUri(masterSecret, slide.getThumbnailUri()));
 
-    return request.fitCenter()
-                  .transform(new FitCenter(getContext()),
-                             new RoundedCorners(getContext(), radius, backgroundColorHint))
+    return request.transform(new RoundedCorners(getContext(), false, radius, backgroundColorHint))
                   .listener(new PduThumbnailSetListener(slide.getPart()));
   }
 
@@ -216,8 +212,7 @@ public class ThumbnailView extends FrameLayout {
 
     return Glide.with(getContext()).load(new DecryptableUri(masterSecret, slide.getThumbnailUri()))
                                    .crossFade()
-                                   .transform(new CenterCrop(getContext()),
-                                              new RoundedCorners(getContext(), radius, backgroundColorHint));
+                                   .transform(new RoundedCorners(getContext(), true, radius, backgroundColorHint));
   }
 
   private GenericRequestBuilder buildPlaceholderGlideRequest(Slide slide) {
@@ -320,10 +315,10 @@ public class ThumbnailView extends FrameLayout {
     @Override
     public boolean onResourceReady(GlideDrawable resource, Object model, Target<GlideDrawable> target, boolean isFromMemoryCache, boolean isFirstResource) {
       if (resource instanceof GlideBitmapDrawable) {
+        Log.w(TAG, "onResourceReady() for a Bitmap. Saving.");
         part.setThumbnail(((GlideBitmapDrawable)resource).getBitmap());
       }
       return false;
     }
   }
-
 }

--- a/src/org/thoughtcrime/securesms/components/ZoomingImageView.java
+++ b/src/org/thoughtcrime/securesms/components/ZoomingImageView.java
@@ -7,7 +7,9 @@ import android.util.AttributeSet;
 import android.widget.ImageView;
 
 import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.resource.drawable.GlideDrawable;
 import com.bumptech.glide.request.target.BitmapImageViewTarget;
+import com.bumptech.glide.request.target.GlideDrawableImageViewTarget;
 
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.mms.DecryptableStreamUriLoader.DecryptableUri;
@@ -32,11 +34,10 @@ public class ZoomingImageView extends ImageView {
   public void setImageUri(MasterSecret masterSecret, Uri uri) {
     Glide.with(getContext())
          .load(new DecryptableUri(masterSecret, uri))
-         .asBitmap()
          .dontTransform()
          .dontAnimate()
-         .into(new BitmapImageViewTarget(this) {
-           @Override protected void setResource(Bitmap resource) {
+         .into(new GlideDrawableImageViewTarget(this) {
+           @Override protected void setResource(GlideDrawable resource) {
              super.setResource(resource);
              attacher.update();
            }

--- a/src/org/thoughtcrime/securesms/contacts/avatars/BitmapContactPhoto.java
+++ b/src/org/thoughtcrime/securesms/contacts/avatars/BitmapContactPhoto.java
@@ -7,6 +7,7 @@ import android.widget.ImageView;
 
 import com.makeramen.roundedimageview.RoundedDrawable;
 
+
 public class BitmapContactPhoto implements ContactPhoto {
 
   private final Bitmap bitmap;

--- a/src/org/thoughtcrime/securesms/contacts/avatars/BitmapContactPhoto.java
+++ b/src/org/thoughtcrime/securesms/contacts/avatars/BitmapContactPhoto.java
@@ -7,7 +7,6 @@ import android.widget.ImageView;
 
 import com.makeramen.roundedimageview.RoundedDrawable;
 
-
 public class BitmapContactPhoto implements ContactPhoto {
 
   private final Bitmap bitmap;

--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -38,6 +38,7 @@ import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.providers.CaptureProvider;
 import org.thoughtcrime.securesms.recipients.Recipients;
 import org.thoughtcrime.securesms.util.BitmapDecodingException;
+import org.thoughtcrime.securesms.util.MediaUtil;
 
 import java.io.IOException;
 
@@ -68,22 +69,14 @@ public class AttachmentManager {
     AlphaAnimation animation = new AlphaAnimation(1.0f, 0.0f);
     animation.setDuration(200);
     animation.setAnimationListener(new Animation.AnimationListener() {
-      @Override
-      public void onAnimationStart(Animation animation) {
-
-      }
-
-      @Override
-      public void onAnimationEnd(Animation animation) {
+      @Override public void onAnimationStart(Animation animation) {}
+      @Override public void onAnimationRepeat(Animation animation) {}
+      @Override public void onAnimationEnd(Animation animation) {
         slideDeck.clear();
         attachmentView.setVisibility(View.GONE);
         attachmentListener.onAttachmentChanged();
       }
 
-      @Override
-      public void onAnimationRepeat(Animation animation) {
-
-      }
     });
 
     attachmentView.startAnimation(animation);
@@ -95,7 +88,11 @@ public class AttachmentManager {
   }
 
   public void setImage(MasterSecret masterSecret, Uri image) throws IOException, BitmapDecodingException {
-    setMedia(new ImageSlide(context, masterSecret, image), masterSecret);
+    if (MediaUtil.getMimeType(context, image).startsWith("image/gif")) {
+      setMedia(new GifSlide(context, masterSecret, image), masterSecret);
+    } else {
+      setMedia(new ImageSlide(context, masterSecret, image), masterSecret);
+    }
   }
 
   public void setVideo(Uri video) throws IOException, MediaTooLargeException {
@@ -147,7 +144,6 @@ public class AttachmentManager {
   public Uri getCaptureUri() {
     return captureUri;
   }
-
 
   public void setCaptureUri(Uri captureUri) {
     this.captureUri = captureUri;

--- a/src/org/thoughtcrime/securesms/mms/GifSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/GifSlide.java
@@ -1,0 +1,27 @@
+package org.thoughtcrime.securesms.mms;
+
+import android.content.Context;
+import android.net.Uri;
+
+import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.util.BitmapDecodingException;
+
+import java.io.IOException;
+
+import ws.com.google.android.mms.pdu.PduPart;
+
+public class GifSlide extends ImageSlide {
+  public GifSlide(Context context, MasterSecret masterSecret, PduPart part) {
+    super(context, masterSecret, part);
+  }
+
+  public GifSlide(Context context, MasterSecret masterSecret, Uri uri)
+      throws IOException, BitmapDecodingException
+  {
+    super(context, masterSecret, uri);
+  }
+
+  @Override public Uri getThumbnailUri() {
+    return getPart().getDataUri();
+  }
+}

--- a/src/org/thoughtcrime/securesms/mms/ImageSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/ImageSlide.java
@@ -24,6 +24,7 @@ import android.support.annotation.DrawableRes;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.util.BitmapDecodingException;
+import org.thoughtcrime.securesms.util.MediaUtil;
 
 import java.io.IOException;
 
@@ -38,7 +39,7 @@ public class ImageSlide extends Slide {
   }
 
   public ImageSlide(Context context, MasterSecret masterSecret, Uri uri) throws IOException, BitmapDecodingException {
-    super(context, masterSecret, constructPartFromUri(uri));
+    super(context, masterSecret, constructPartFromUri(context, uri));
   }
 
   @Override
@@ -62,13 +63,15 @@ public class ImageSlide extends Slide {
     return true;
   }
 
-  private static PduPart constructPartFromUri(Uri uri)
+  private static PduPart constructPartFromUri(Context context, Uri uri)
       throws IOException, BitmapDecodingException
   {
     PduPart part = new PduPart();
 
+    final String mimeType = MediaUtil.getMimeType(context, uri);
+
     part.setDataUri(uri);
-    part.setContentType(ContentType.IMAGE_JPEG.getBytes());
+    part.setContentType((mimeType != null ? mimeType : ContentType.IMAGE_JPEG).getBytes());
     part.setContentId((System.currentTimeMillis()+"").getBytes());
     part.setName(("Image" + System.currentTimeMillis()).getBytes());
 

--- a/src/org/thoughtcrime/securesms/mms/MediaConstraints.java
+++ b/src/org/thoughtcrime/securesms/mms/MediaConstraints.java
@@ -25,15 +25,18 @@ public abstract class MediaConstraints {
   public abstract int getImageMaxHeight(Context context);
   public abstract int getImageMaxSize();
 
+  public abstract int getGifMaxSize();
+
   public abstract int getVideoMaxSize();
 
   public abstract int getAudioMaxSize();
 
   public boolean isSatisfied(Context context, MasterSecret masterSecret, PduPart part) {
     try {
-      return (MediaUtil.isImage(part) && part.getDataSize() <= getImageMaxSize() && isWithinBounds(context, masterSecret, part.getDataUri())) ||
-             (MediaUtil.isAudio(part) && part.getDataSize() <= getAudioMaxSize()) ||
-             (MediaUtil.isVideo(part) && part.getDataSize() <= getVideoMaxSize()) ||
+      return (MediaUtil.isGif(part)    && part.getDataSize() <= getGifMaxSize()) ||
+             (MediaUtil.isImage(part)  && part.getDataSize() <= getImageMaxSize() && isWithinBounds(context, masterSecret, part.getDataUri())) ||
+             (MediaUtil.isAudio(part)  && part.getDataSize() <= getAudioMaxSize()) ||
+             (MediaUtil.isVideo(part)  && part.getDataSize() <= getVideoMaxSize()) ||
              (!MediaUtil.isImage(part) && !MediaUtil.isAudio(part) && !MediaUtil.isVideo(part));
     } catch (IOException ioe) {
       Log.w(TAG, "Failed to determine if media's constraints are satisfied.", ioe);
@@ -49,7 +52,7 @@ public abstract class MediaConstraints {
   }
 
   public boolean canResize(PduPart part) {
-    return part != null && MediaUtil.isImage(part);
+    return part != null && MediaUtil.isImage(part) && !MediaUtil.isGif(part);
   }
 
   public byte[] getResizedMedia(Context context, MasterSecret masterSecret, PduPart part)

--- a/src/org/thoughtcrime/securesms/mms/MmsMediaConstraints.java
+++ b/src/org/thoughtcrime/securesms/mms/MmsMediaConstraints.java
@@ -25,6 +25,11 @@ public class MmsMediaConstraints extends MediaConstraints {
   }
 
   @Override
+  public int getGifMaxSize() {
+    return MAX_MESSAGE_SIZE;
+  }
+
+  @Override
   public int getVideoMaxSize() {
     return MAX_MESSAGE_SIZE;
   }

--- a/src/org/thoughtcrime/securesms/mms/PushMediaConstraints.java
+++ b/src/org/thoughtcrime/securesms/mms/PushMediaConstraints.java
@@ -26,6 +26,11 @@ public class PushMediaConstraints extends MediaConstraints {
   }
 
   @Override
+  public int getGifMaxSize() {
+    return 1 * MB;
+  }
+
+  @Override
   public int getVideoMaxSize() {
     return MmsMediaConstraints.MAX_MESSAGE_SIZE;
   }

--- a/src/org/thoughtcrime/securesms/mms/RoundedCorners.java
+++ b/src/org/thoughtcrime/securesms/mms/RoundedCorners.java
@@ -1,0 +1,78 @@
+package org.thoughtcrime.securesms.mms;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.BitmapShader;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.graphics.Shader.TileMode;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
+import com.bumptech.glide.load.resource.bitmap.BitmapTransformation;
+
+public class RoundedCorners extends BitmapTransformation {
+  private static final String TAG = RoundedCorners.class.getSimpleName();
+
+  private final int radius;
+  private final int colorHint;
+
+  public RoundedCorners(@NonNull Context context, int radius, int colorHint) {
+    super(context);
+    this.radius = radius;
+    this.colorHint = colorHint;
+  }
+
+  @Override protected Bitmap transform(BitmapPool pool, Bitmap toTransform, int outWidth,
+                                       int outHeight)
+  {
+    final Bitmap toReuse = pool.get(outWidth, outHeight, toTransform.getConfig() != null
+                                                         ? toTransform.getConfig()
+                                                         : Bitmap.Config.ARGB_8888);
+    Bitmap transformed = round(toReuse, toTransform);
+    if (toReuse != null && toReuse != transformed && !pool.put(toReuse)) {
+      toReuse.recycle();
+    }
+    return transformed;
+  }
+
+  private Bitmap round(@Nullable Bitmap recycled, @Nullable Bitmap toRound) {
+    Log.w(TAG, String.format("roundAndCrop(%s, %s)", recycled, toRound));
+    if (toRound == null) {
+      return null;
+    }
+
+    final Bitmap result;
+    if (recycled != null) {
+      result = recycled;
+    } else {
+      result = Bitmap.createBitmap(toRound.getWidth(), toRound.getHeight(), getSafeConfig(toRound));
+    }
+
+    final Canvas canvas      = new Canvas(result);
+    final Paint  cornerPaint = new Paint();
+    final Paint  shaderPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+
+    shaderPaint.setShader(new BitmapShader(toRound, TileMode.CLAMP, TileMode.CLAMP));
+    cornerPaint.setColor(colorHint);
+    if (!result.hasAlpha()) {
+      canvas.drawRect(0, 0, radius, radius, cornerPaint);
+      canvas.drawRect(0, toRound.getHeight() - radius, radius, toRound.getHeight(), cornerPaint);
+      canvas.drawRect(toRound.getWidth() - radius, 0, toRound.getWidth(), radius, cornerPaint);
+      canvas.drawRect(toRound.getWidth() - radius, toRound.getHeight() - radius, toRound.getWidth(), toRound.getHeight(), cornerPaint);
+    }
+    canvas.drawRoundRect(new RectF(0, 0, toRound.getWidth(), toRound.getHeight()), radius, radius, shaderPaint);
+    return result;
+  }
+
+  private static Bitmap.Config getSafeConfig(Bitmap bitmap) {
+    return bitmap.getConfig() != null ? bitmap.getConfig() : Bitmap.Config.ARGB_8888;
+  }
+
+  @Override public String getId() {
+    return RoundedCorners.class.getCanonicalName();
+  }
+}

--- a/src/org/thoughtcrime/securesms/util/MediaUtil.java
+++ b/src/org/thoughtcrime/securesms/util/MediaUtil.java
@@ -3,11 +3,14 @@ package org.thoughtcrime.securesms.util;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.net.Uri;
+import android.text.TextUtils;
 import android.util.Log;
+import android.webkit.MimeTypeMap;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.mms.AudioSlide;
+import org.thoughtcrime.securesms.mms.GifSlide;
 import org.thoughtcrime.securesms.mms.ImageSlide;
 import org.thoughtcrime.securesms.mms.PartAuthority;
 import org.thoughtcrime.securesms.mms.Slide;
@@ -59,7 +62,9 @@ public class MediaUtil {
 
   public static Slide getSlideForPart(Context context, MasterSecret masterSecret, PduPart part, String contentType) {
     Slide slide = null;
-    if (ContentType.isImageType(contentType)) {
+    if (isGif(contentType)) {
+      slide = new GifSlide(context, masterSecret, part);
+    } else if (ContentType.isImageType(contentType)) {
       slide = new ImageSlide(context, masterSecret, part);
     } else if (ContentType.isVideoType(contentType)) {
       slide = new VideoSlide(context, masterSecret, part);
@@ -68,6 +73,23 @@ public class MediaUtil {
     }
 
     return slide;
+  }
+
+  public static String getMimeType(Context context, Uri uri) {
+    String type = context.getContentResolver().getType(uri);
+    if (type == null) {
+      final String extension = MimeTypeMap.getFileExtensionFromUrl(uri.toString());
+      type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
+    }
+    return type;
+  }
+
+  private static boolean isGif(String contentType) {
+    return !TextUtils.isEmpty(contentType) && contentType.trim().equals("image/gif");
+  }
+
+  public static boolean isGif(PduPart part) {
+    return isGif(Util.toIsoString(part.getContentType()));
   }
 
   public static boolean isImage(PduPart part) {


### PR DESCRIPTION
* Use Glide for rounding and cropping images *and* gifs off the main thread, finally cutting out our use of RoundedImageView. This was traditionally less memory efficient, but Glide's pooling and reuse of bitmaps make that not the case any more. If anything this should make scrolling faster since there's no shader activity in the ImageView's onDraw().
  * Our new RoundedCorners transformation "cheats" transparency with a hint for what the background it's being drawn on is. This way we don't need an alpha channel for our drawables so can continue using RGB_565 to save memory.
* Add support for animated gifs and a new media constraint allowing them to be up to 1MB.