### PR TITLE
smooth transition for custom keyboards and softkey

### DIFF
--- a/res/layout/conversation_activity.xml
+++ b/res/layout/conversation_activity.xml
@@ -145,11 +145,11 @@
 
         </LinearLayout>
 
-        <ViewStub android:id="@+id/emoji_drawer_stub"
-                  android:layout_width="match_parent"
-                  android:layout_height="wrap_content"
-                  android:inflatedId="@+id/emoji_drawer"
-                  android:layout="@layout/emoji_drawer_stub" />
+        <org.thoughtcrime.securesms.components.emoji.EmojiDrawer
+                android:id="@+id/emoji_drawer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
     </LinearLayout>
 </org.thoughtcrime.securesms.components.camera.QuickAttachmentDrawer>
 </org.thoughtcrime.securesms.components.KeyboardAwareLinearLayout>

--- a/res/layout/conversation_activity.xml
+++ b/res/layout/conversation_activity.xml
@@ -1,72 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<org.thoughtcrime.securesms.components.camera.QuickAttachmentDrawer
+<org.thoughtcrime.securesms.components.KeyboardAwareLinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/quick_attachment_drawer"
+    android:id="@+id/layout_container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/black">
+    android:layout_height="match_parent">
 
-<org.thoughtcrime.securesms.components.KeyboardAwareLinearLayout
-        android:id="@+id/layout_container"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
-        android:orientation="vertical">
+<org.thoughtcrime.securesms.components.camera.QuickAttachmentDrawer
+        android:id="@+id/quick_attachment_drawer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:background="@color/black">
 
-    <RelativeLayout android:layout_width="fill_parent"
-                    android:layout_height="fill_parent"
-                    android:layout_weight="1"
-                    android:orientation="vertical"
-                    android:background="?conversation_background"
-                    android:paddingTop="?attr/actionBarSize"
-                    android:gravity="bottom">
+    <LinearLayout android:layout_width="match_parent"
+                  android:layout_height="match_parent"
+                  android:orientation="vertical"
+                  android:background="?conversation_background"
+                  android:paddingTop="?attr/actionBarSize"
+                  android:gravity="bottom">
 
         <FrameLayout android:id="@+id/fragment_content"
                      android:layout_width="match_parent"
-                     android:layout_height="match_parent"
-                     android:layout_above="@+id/bottom_container" />
+                     android:layout_height="0dp"
+                     android:layout_weight="1" />
 
-        <LinearLayout
-                android:layout_alignParentBottom="true"
-                android:id="@id/bottom_container"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
+        <LinearLayout android:id="@+id/bottom_container"
+                      android:layout_width="fill_parent"
+                      android:layout_height="wrap_content"
+                      android:orientation="vertical">
 
-            <ScrollView android:layout_width="fill_parent"
-                        android:layout_height="0dp"
-                        android:layout_weight="1">
-                <FrameLayout
-                        android:id="@+id/attachment_editor"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_horizontal"
-                        android:visibility="gone">
+            <FrameLayout
+                    android:id="@+id/attachment_editor"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    android:paddingTop="10dp"
+                    android:visibility="gone">
 
-                    <FrameLayout
-                            android:paddingLeft="10dp"
-                            android:paddingTop="10dp"
-                            android:layout_width="fill_parent"
-                            android:layout_height="fill_parent">
+                <org.thoughtcrime.securesms.components.ThumbnailView
+                        android:id="@+id/attachment_thumbnail"
+                        android:layout_width="230dp"
+                        android:layout_height="150dp"
+                        android:contentDescription="@string/conversation_activity__attachment_thumbnail"
+                        app:backgroundColorHint="?conversation_background" />
 
-                        <org.thoughtcrime.securesms.components.ThumbnailView
-                                android:id="@+id/attachment_thumbnail"
-                                android:layout_width="230dp"
-                                android:layout_height="150dp"
-                                android:contentDescription="@string/conversation_activity__attachment_thumbnail"
-                                app:backgroundColorHint="?conversation_background" />
-                    </FrameLayout>
+                <ImageView android:id="@+id/remove_image_button"
+                           android:layout_width="wrap_content"
+                           android:layout_height="wrap_content"
+                           android:src="@drawable/conversation_attachment_close_circle"
+                           android:layout_gravity="top|left"/>
 
-                    <ImageView android:id="@+id/remove_image_button"
-                               android:layout_width="wrap_content"
-                               android:layout_height="wrap_content"
-                               android:src="@drawable/conversation_attachment_close_circle"
-                               android:layout_gravity="top|left"/>
-
-               </FrameLayout>
-            </ScrollView>
+           </FrameLayout>
 
             <LinearLayout android:id="@+id/bottom_panel"
                           android:layout_width="fill_parent"
@@ -157,12 +144,12 @@
                      android:text="160/160 (1)" />
 
         </LinearLayout>
-    </RelativeLayout>
-    
-    <ViewStub android:id="@+id/emoji_drawer_stub"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:inflatedId="@+id/emoji_drawer"
-              android:layout="@layout/emoji_drawer_stub" />
-</org.thoughtcrime.securesms.components.KeyboardAwareLinearLayout>
+
+        <ViewStub android:id="@+id/emoji_drawer_stub"
+                  android:layout_width="match_parent"
+                  android:layout_height="wrap_content"
+                  android:inflatedId="@+id/emoji_drawer"
+                  android:layout="@layout/emoji_drawer_stub" />
+    </LinearLayout>
 </org.thoughtcrime.securesms.components.camera.QuickAttachmentDrawer>
+</org.thoughtcrime.securesms.components.KeyboardAwareLinearLayout>

--- a/res/layout/conversation_activity.xml
+++ b/res/layout/conversation_activity.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<org.thoughtcrime.securesms.components.KeyboardAwareLinearLayout
+<org.thoughtcrime.securesms.components.InputAwareLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -152,4 +152,4 @@
 
     </LinearLayout>
 </org.thoughtcrime.securesms.components.camera.QuickAttachmentDrawer>
-</org.thoughtcrime.securesms.components.KeyboardAwareLinearLayout>
+</org.thoughtcrime.securesms.components.InputAwareLayout>

--- a/res/layout/emoji_drawer_stub.xml
+++ b/res/layout/emoji_drawer_stub.xml
@@ -2,5 +2,4 @@
 <org.thoughtcrime.securesms.components.emoji.EmojiDrawer
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:layout_weight="1.1" />
+    android:layout_height="match_parent" />

--- a/res/layout/emoji_drawer_stub.xml
+++ b/res/layout/emoji_drawer_stub.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<org.thoughtcrime.securesms.components.emoji.EmojiDrawer
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent" />

--- a/src/org/thoughtcrime/securesms/ConversationPopupActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationPopupActivity.java
@@ -114,11 +114,6 @@ public class ConversationPopupActivity extends ConversationActivity {
   }
 
   @Override
-  protected void hideEmojiDrawer(boolean expectingKeyboard) {
-    super.hideEmojiDrawer(false);
-  }
-
-  @Override
   protected void sendComplete(long threadId) {
     super.sendComplete(threadId);
     finish();

--- a/src/org/thoughtcrime/securesms/components/InputManager.java
+++ b/src/org/thoughtcrime/securesms/components/InputManager.java
@@ -1,0 +1,93 @@
+package org.thoughtcrime.securesms.components;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.widget.TextView;
+
+import org.thoughtcrime.securesms.components.KeyboardAwareLinearLayout.OnKeyboardShownListener;
+import org.thoughtcrime.securesms.util.ServiceUtil;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class InputManager implements OnKeyboardShownListener {
+  private final KeyboardAwareLinearLayout container;
+  private final TextView                  inputTarget;
+
+  private InputView current;
+
+  public InputManager(@NonNull KeyboardAwareLinearLayout container,
+                      @NonNull TextView inputTarget)
+  {
+    this.container   = container;
+    this.inputTarget = inputTarget;
+    container.addOnKeyboardShownListener(this);
+  }
+
+  @Override public void onKeyboardShown() {
+    hideAttachedInput();
+  }
+
+  public void show(@NonNull final InputView input) {
+    if (container.isKeyboardOpen()) {
+      hideSoftkey(new Runnable() {
+        @Override public void run() {
+          input.show(container.getKeyboardHeight(), true);
+        }
+      });
+    } else if (current != null && current.isShowing()) {
+      current.hide(true);
+      input.show(container.getKeyboardHeight(), true);
+    } else {
+      input.show(container.getKeyboardHeight(), false);
+    }
+
+    current = input;
+  }
+
+  public InputView getCurrentInput() {
+    return current;
+  }
+
+  public void hideCurrentInput() {
+    if (container.isKeyboardOpen()) hideSoftkey(null);
+    else                            hideAttachedInput();
+  }
+
+  public void hideAttachedInput() {
+    if (current != null) current.hide(true);
+    current = null;
+  }
+
+  public boolean isInputOpen() {
+    return (container.isKeyboardOpen() || (current != null && current.isShowing()));
+  }
+
+  public void showSoftkey() {
+    container.postOnKeyboardOpen(new Runnable() {
+      @Override public void run() {
+        hideAttachedInput();
+      }
+    });
+    inputTarget.post(new Runnable() {
+      @Override public void run() {
+        inputTarget.requestFocus();
+        ServiceUtil.getInputMethodManager(inputTarget.getContext()).showSoftInput(inputTarget, 0);
+      }
+    });
+  }
+
+  private void hideSoftkey(@Nullable Runnable runAfterClose) {
+    if (runAfterClose != null) container.postOnKeyboardClose(runAfterClose);
+
+    ServiceUtil.getInputMethodManager(inputTarget.getContext())
+               .hideSoftInputFromWindow(inputTarget.getWindowToken(), 0);
+  }
+
+  public interface InputView {
+    void show(int height, boolean immediate);
+    void hide(boolean immediate);
+    boolean isShowing();
+  }
+}
+

--- a/src/org/thoughtcrime/securesms/components/camera/QuickAttachmentDrawer.java
+++ b/src/org/thoughtcrime/securesms/components/camera/QuickAttachmentDrawer.java
@@ -21,12 +21,13 @@ import android.view.ViewGroup;
 import android.widget.ImageButton;
 
 import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.components.InputManager.InputView;
 import org.thoughtcrime.securesms.components.KeyboardAwareLinearLayout;
 import org.thoughtcrime.securesms.components.camera.QuickCamera.QuickCameraListener;
 import org.thoughtcrime.securesms.util.ServiceUtil;
 import org.thoughtcrime.securesms.util.Util;
 
-public class QuickAttachmentDrawer extends ViewGroup {
+public class QuickAttachmentDrawer extends ViewGroup implements InputView {
   private static final String TAG = QuickAttachmentDrawer.class.getSimpleName();
 
   private final ViewDragHelper dragHelper;
@@ -80,24 +81,19 @@ public class QuickAttachmentDrawer extends ViewGroup {
            Camera.getNumberOfCameras() > 0;
   }
 
-  public boolean isOpen() {
+  @Override
+  public boolean isShowing() {
     return drawerState.isVisible();
   }
 
-  public void close() {
-    setDrawerStateAndUpdate(DrawerState.COLLAPSED);
+  @Override
+  public void hide(boolean immediate) {
+    setDrawerStateAndUpdate(DrawerState.COLLAPSED, immediate);
   }
 
-  public void open() {
-    setDrawerStateAndUpdate(DrawerState.HALF_EXPANDED);
-  }
-
-  public void openInstant() {
-    setDrawerStateAndUpdate(DrawerState.HALF_EXPANDED, true);
-  }
-
-  public void closeInstant() {
-    setDrawerStateAndUpdate(DrawerState.COLLAPSED, true);
+  @Override
+  public void show(int height, boolean immediate) {
+    setDrawerStateAndUpdate(DrawerState.HALF_EXPANDED, immediate);
   }
 
   public void onConfigurationChanged() {
@@ -105,7 +101,7 @@ public class QuickAttachmentDrawer extends ViewGroup {
     final boolean rotationChanged = this.rotation != rotation;
     this.rotation = rotation;
     if (rotationChanged) {
-      if (isOpen()) {
+      if (isShowing()) {
         quickCamera.onPause();
       }
       updateControlsView();

--- a/src/org/thoughtcrime/securesms/components/emoji/EmojiDrawer.java
+++ b/src/org/thoughtcrime/securesms/components/emoji/EmojiDrawer.java
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms.components.emoji;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.view.PagerAdapter;
@@ -18,7 +19,7 @@ import android.widget.LinearLayout;
 import com.astuetz.PagerSlidingTabStrip;
 
 import org.thoughtcrime.securesms.R;
-import org.thoughtcrime.securesms.components.KeyboardAwareLinearLayout;
+import org.thoughtcrime.securesms.components.InputManager.InputView;
 import org.thoughtcrime.securesms.components.RepeatableImageKey;
 import org.thoughtcrime.securesms.components.RepeatableImageKey.KeyEventListener;
 import org.thoughtcrime.securesms.components.emoji.EmojiPageView.EmojiSelectionListener;
@@ -27,7 +28,7 @@ import org.thoughtcrime.securesms.util.ResUtil;
 import java.util.LinkedList;
 import java.util.List;
 
-public class EmojiDrawer extends LinearLayout {
+public class EmojiDrawer extends LinearLayout implements InputView {
   private static final KeyEvent DELETE_KEY_EVENT = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL);
 
   private ViewPager            pager;
@@ -35,6 +36,7 @@ public class EmojiDrawer extends LinearLayout {
   private PagerSlidingTabStrip strip;
   private RecentEmojiPageModel recentModel;
   private EmojiEventListener   listener;
+  private EmojiDrawerListener  drawerListener;
 
   public EmojiDrawer(Context context) {
     this(context, null);
@@ -43,6 +45,9 @@ public class EmojiDrawer extends LinearLayout {
   public EmojiDrawer(Context context, AttributeSet attrs) {
     super(context, attrs);
     setOrientation(VERTICAL);
+  }
+
+  private void initView() {
     final View v = LayoutInflater.from(getContext()).inflate(R.layout.emoji_drawer, this, true);
     initializeResources(v);
     initializePageModels();
@@ -51,6 +56,10 @@ public class EmojiDrawer extends LinearLayout {
 
   public void setEmojiEventListener(EmojiEventListener listener) {
     this.listener = listener;
+  }
+
+  public void setDrawerListener(EmojiDrawerListener listener) {
+    this.drawerListener = listener;
   }
 
   private void initializeResources(View v) {
@@ -66,20 +75,27 @@ public class EmojiDrawer extends LinearLayout {
     });
   }
 
+  @Override
   public boolean isShowing() {
     return getVisibility() == VISIBLE;
   }
 
-  public void show(KeyboardAwareLinearLayout container) {
+  @Override
+  public void show(int height, boolean immediate) {
+    if (this.pager == null) initView();
     ViewGroup.LayoutParams params = getLayoutParams();
-    params.height = container.getKeyboardHeight();
+    params.height = height;
     Log.w("EmojiDrawer", "showing emoji drawer with height " + params.height);
     setLayoutParams(params);
     setVisibility(VISIBLE);
+    if (drawerListener != null) drawerListener.onShown();
   }
 
-  public void dismiss() {
+  @Override
+  public void hide(boolean immediate) {
     setVisibility(GONE);
+    if (drawerListener != null) drawerListener.onHidden();
+    Log.w("EmojiDrawer", "hide()");
   }
 
   private void initializeEmojiGrid() {
@@ -160,5 +176,10 @@ public class EmojiDrawer extends LinearLayout {
 
   public interface EmojiEventListener extends EmojiSelectionListener {
     void onKeyEvent(KeyEvent keyEvent);
+  }
+
+  public interface EmojiDrawerListener {
+    void onShown();
+    void onHidden();
   }
 }

--- a/src/org/thoughtcrime/securesms/components/emoji/EmojiToggle.java
+++ b/src/org/thoughtcrime/securesms/components/emoji/EmojiToggle.java
@@ -5,21 +5,15 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
-import android.util.Log;
-import android.view.View;
-import android.view.View.OnClickListener;
 import android.widget.ImageButton;
 
 import org.thoughtcrime.securesms.R;
-import org.thoughtcrime.securesms.components.InputManager;
 import org.thoughtcrime.securesms.components.emoji.EmojiDrawer.EmojiDrawerListener;
 
-public class EmojiToggle extends ImageButton implements OnClickListener, EmojiDrawerListener {
+public class EmojiToggle extends ImageButton implements EmojiDrawerListener {
 
-  private Drawable     emojiToggle;
-  private Drawable     imeToggle;
-  private EmojiDrawer  drawer;
-  private InputManager inputManager;
+  private Drawable emojiToggle;
+  private Drawable imeToggle;
 
   public EmojiToggle(Context context) {
     super(context);
@@ -54,23 +48,10 @@ public class EmojiToggle extends ImageButton implements OnClickListener, EmojiDr
 
     drawables.recycle();
     setToEmoji();
-    setOnClickListener(this);
   }
 
-  public void attach(InputManager manager, EmojiDrawer drawer) {
-    this.inputManager = manager;
-    this.drawer       = drawer;
+  public void attach(EmojiDrawer drawer) {
     drawer.setDrawerListener(this);
-  }
-
-  @Override public void onClick(View v) {
-    if (inputManager == null || drawer == null) return;
-
-    if (inputManager.getCurrentInput() == drawer) {
-      inputManager.showSoftkey();
-    } else {
-      inputManager.show(drawer);
-    }
   }
 
   @Override public void onShown() {

--- a/src/org/thoughtcrime/securesms/components/emoji/EmojiToggle.java
+++ b/src/org/thoughtcrime/securesms/components/emoji/EmojiToggle.java
@@ -5,14 +5,21 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
+import android.util.Log;
+import android.view.View;
+import android.view.View.OnClickListener;
 import android.widget.ImageButton;
 
 import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.components.InputManager;
+import org.thoughtcrime.securesms.components.emoji.EmojiDrawer.EmojiDrawerListener;
 
-public class EmojiToggle extends ImageButton {
+public class EmojiToggle extends ImageButton implements OnClickListener, EmojiDrawerListener {
 
-  private Drawable emojiToggle;
-  private Drawable imeToggle;
+  private Drawable     emojiToggle;
+  private Drawable     imeToggle;
+  private EmojiDrawer  drawer;
+  private InputManager inputManager;
 
   public EmojiToggle(Context context) {
     super(context);
@@ -46,6 +53,31 @@ public class EmojiToggle extends ImageButton {
     this.imeToggle       = drawables.getDrawable(1);
 
     drawables.recycle();
+    setToEmoji();
+    setOnClickListener(this);
+  }
+
+  public void attach(InputManager manager, EmojiDrawer drawer) {
+    this.inputManager = manager;
+    this.drawer       = drawer;
+    drawer.setDrawerListener(this);
+  }
+
+  @Override public void onClick(View v) {
+    if (inputManager == null || drawer == null) return;
+
+    if (inputManager.getCurrentInput() == drawer) {
+      inputManager.showSoftkey();
+    } else {
+      inputManager.show(drawer);
+    }
+  }
+
+  @Override public void onShown() {
+    setToIme();
+  }
+
+  @Override public void onHidden() {
     setToEmoji();
   }
 }

--- a/src/org/thoughtcrime/securesms/util/Util.java
+++ b/src/org/thoughtcrime/securesms/util/Util.java
@@ -348,4 +348,8 @@ public class Util {
   public static int clamp(int value, int min, int max) {
     return Math.min(Math.max(value, min), max);
   }
+
+  public static float clamp(float value, float min, float max) {
+    return Math.min(Math.max(value, min), max);
+  }
 }


### PR DESCRIPTION
no more twitching out when hitting the direct capture button when soft keyboard or emoji keyboard is open.

in the process, I also simplified the view hierarchy for the attachment section of ConversationActivity and made KeyboardAwareLinearLayout a bit more efficient by not doing resource reflection every onMeasure.

Made an effort to simplify some of the QuickAttachmentDrawer math a bit too.

strangely, this refactor seems to fix #3780. could reproduce on 2.24.0, cannot on this branch.