### PR TITLE
Modified Usage of Light / Dark Colors in Conversation Activity

### DIFF
--- a/src/org/thoughtcrime/securesms/color/MaterialColor.java
+++ b/src/org/thoughtcrime/securesms/color/MaterialColor.java
@@ -54,8 +54,8 @@ public enum MaterialColor {
     this.serialized             = serialized;
   }
 
-  MaterialColor(int lightColor, int darkColor, int statusBarColor, String serialized) {
-    this(lightColor, lightColor, statusBarColor, darkColor, darkColor, statusBarColor, serialized);
+  MaterialColor(int lightColor, int darkColor, int middleColor, String serialized) {
+    this(middleColor, lightColor, middleColor, darkColor, middleColor, darkColor, serialized);
   }
 
   public int toConversationColor(@NonNull Context context) {


### PR DESCRIPTION
I have only recently started using a version of TextSecure with the custom per-conversation colors, but there were a couple of things that struck me straight away.

* The fact that the action bar and text bubbles appear the same color makes the layout of the objects on screen seem less clear. It suggests that they are at the same point in the hierarchy, and the only thing that suggests otherwise is the slight drop-shadow that you can sometimes see over a text bubble if it is in the right place.
* In the dark theme, the status bar color is lighter than the action bar, this looks particularly odd (and goes against design recommendations I believe).

This pull request makes two changes:

* In the light theme, makes the text bubbles match the color of the status bar.
* In the dark theme, swap the status bar and action bar colors.

Here are a few screenshots of the change (original on left, new on right)

[View Full Album](http://imgur.com/a/eLx7s)

![](http://i.imgur.com/Y7tIp4Q.png)
![](http://i.imgur.com/6YASHot.png)
![](http://i.imgur.com/gwxrKcw.png)
![](http://i.imgur.com/DMgqghZ.png)

Potential Improvements:

* We may want to make the action bar colour on the dark theme slightly darker (maybe 800)