### PR TITLE
correct lollipop bug leaving new conversations unhighlighted

### DIFF
--- a/res/drawable-v21/conversation_list_item_unread_background.xml
+++ b/res/drawable-v21/conversation_list_item_unread_background.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+        android:color="@color/textsecure_primary">
+    <item android:drawable="@color/conversation_list_item_background_unread_dark" />
+    <item android:id="@android:id/mask" android:drawable="@android:color/black" />
+    <item>
+        <selector>
+            <item android:drawable="@color/textsecure_primary_alpha33" android:state_selected="true" />
+        </selector>
+    </item>
+</ripple>

--- a/src/org/thoughtcrime/securesms/ConversationListItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationListItem.java
@@ -48,11 +48,10 @@ import static org.thoughtcrime.securesms.util.SpanUtil.color;
  */
 
 public class ConversationListItem extends RelativeLayout
-                                  implements Recipients.RecipientsModifiedListener
-{
+        implements Recipients.RecipientsModifiedListener {
   private final static String TAG = ConversationListItem.class.getSimpleName();
 
-  private final static Typeface BOLD_TYPEFACE  = Typeface.create("sans-serif", Typeface.BOLD);
+    private final static Typeface BOLD_TYPEFACE = Typeface.create("sans-serif", Typeface.BOLD_ITALIC);
   private final static Typeface LIGHT_TYPEFACE = Typeface.create("sans-serif-light", Typeface.NORMAL);
 
   private Context         context;
@@ -135,6 +134,10 @@ public class ConversationListItem extends RelativeLayout
   @TargetApi(VERSION_CODES.LOLLIPOP)
   public void setRippleColor(Recipients recipients) {
     if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
+            if (!read)
+                setBackgroundResource(R.drawable.conversation_list_item_unread_background);
+            else
+                setBackgroundResource(R.drawable.conversation_list_item_background);
       ((RippleDrawable)(getBackground()).mutate())
           .setColor(ColorStateList.valueOf(recipients.getColor().toConversationColor(context)));
     }

--- a/src/org/thoughtcrime/securesms/components/FromTextView.java
+++ b/src/org/thoughtcrime/securesms/components/FromTextView.java
@@ -56,7 +56,7 @@ public class FromTextView extends EmojiTextView {
       if (!read) typeface = Typeface.BOLD_ITALIC;
       else       typeface = Typeface.ITALIC;
     } else if (!read) {
-      typeface = Typeface.BOLD;
+      typeface = Typeface.BOLD_ITALIC;
     } else {
       typeface = Typeface.NORMAL;
     }


### PR DESCRIPTION
pre-lollipop, textsecure highlighted conversations containing unread messages in a slightly lighter color. when the background was switched to a ripple drawable, this behavior disappeared, making it very difficult to tell which conversations had new messages waiting. this fix returns this behavior to the dark themed textsecure. further work will be required to fix the light theme.