### PR TITLE
let ThumbnailView handle remove button placement

### DIFF
--- a/res/drawable/conversation_attachment_close_circle.xml
+++ b/res/drawable/conversation_attachment_close_circle.xml
@@ -9,7 +9,7 @@
     <item>
         <shape android:shape="oval">
             <size android:height="21dp" android:width="21dp"/>
-            <solid android:color="@color/textsecure_primary_dark"/>
+            <solid android:color="@color/red_600"/>
             <stroke android:color="@android:color/transparent"
                     android:width="3dp"/>
         </shape>

--- a/res/layout/conversation_activity.xml
+++ b/res/layout/conversation_activity.xml
@@ -29,7 +29,6 @@
                      android:layout_width="match_parent"
                      android:layout_height="wrap_content"
                      android:gravity="center_horizontal"
-                     android:paddingTop="10dp"
                      android:background="?android:windowBackground"
                      android:visibility="gone">
 
@@ -40,13 +39,6 @@
                 android:layout_gravity="center_horizontal"
                 android:contentDescription="@string/conversation_activity__attachment_thumbnail"
                 app:backgroundColorHint="?conversation_background" />
-
-            <ImageView android:id="@+id/remove_image_button"
-                       android:layout_width="wrap_content"
-                       android:layout_height="wrap_content"
-                       android:src="@drawable/conversation_attachment_close_circle"
-                       android:layout_marginRight="115dp"
-                       android:layout_gravity="top|center_horizontal"/>
 
         </FrameLayout>
 

--- a/res/layout/thumbnail_view.xml
+++ b/res/layout/thumbnail_view.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android"
-       xmlns:app="http://schemas.android.com/apk/res-auto">
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
 
     <ImageView android:id="@+id/thumbnail_image"
                android:layout_width="match_parent"
@@ -10,15 +9,15 @@
                android:contentDescription="@string/conversation_item__mms_image_description"
                android:layout_margin="@dimen/media_bubble_border_width" />
 
-    <com.pnikosis.materialishprogress.ProgressWheel
-            android:id="@+id/progress_wheel"
-            android:layout_width="70dp"
-            android:layout_height="70dp"
-            android:layout_gravity="center"
-            android:background="@drawable/progress_background"
-            android:visibility="gone"
-            app:matProg_barColor="@color/white"
-            app:matProg_linearProgress="true"
-            app:matProg_spinSpeed="0.333" />
+    <ViewStub android:id="@+id/progress_wheel_stub"
+              android:layout_width="70dp"
+              android:layout_height="70dp"
+              android:layout_gravity="center"
+              android:layout="@layout/thumbnail_view_progress_wheel" />
 
+    <ViewStub android:id="@+id/remove_button_stub"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_gravity="top|right"
+              android:layout="@layout/thumbnail_view_remove_button" />
 </merge>

--- a/res/layout/thumbnail_view_progress_wheel.xml
+++ b/res/layout/thumbnail_view_progress_wheel.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.pnikosis.materialishprogress.ProgressWheel
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/progress_wheel"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@drawable/progress_background"
+        android:visibility="gone"
+        app:matProg_barColor="@color/white"
+        app:matProg_linearProgress="true"
+        app:matProg_spinSpeed="0.333" />

--- a/res/layout/thumbnail_view_remove_button.xml
+++ b/res/layout/thumbnail_view_remove_button.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+           android:id="@+id/remove_image_button"
+           android:layout_width="wrap_content"
+           android:layout_height="wrap_content"
+           android:src="@drawable/conversation_attachment_close_circle" />

--- a/src/org/thoughtcrime/securesms/components/ThumbnailView.java
+++ b/src/org/thoughtcrime/securesms/components/ThumbnailView.java
@@ -5,6 +5,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Color;
+import android.os.Build;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.support.annotation.NonNull;
@@ -16,12 +17,12 @@ import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
 import android.view.animation.Animation.AnimationListener;
 import android.widget.FrameLayout;
+import android.widget.ImageButton;
 import android.widget.ImageView;
 
 import com.bumptech.glide.DrawableTypeRequest;
 import com.bumptech.glide.GenericRequestBuilder;
 import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.resource.bitmap.CenterCrop;
 import com.bumptech.glide.load.resource.bitmap.GlideBitmapDrawable;
 import com.bumptech.glide.load.resource.drawable.GlideDrawable;
 import com.bumptech.glide.request.RequestListener;
@@ -38,6 +39,7 @@ import org.thoughtcrime.securesms.util.FutureTaskListener;
 import org.thoughtcrime.securesms.util.ListenableFutureTask;
 import org.thoughtcrime.securesms.mms.RoundedCorners;
 import org.thoughtcrime.securesms.util.Util;
+import org.thoughtcrime.securesms.util.ViewUtil;
 
 import de.greenrobot.event.EventBus;
 import ws.com.google.android.mms.pdu.PduPart;
@@ -48,6 +50,7 @@ public class ThumbnailView extends FrameLayout {
   private boolean       showProgress = true;
   private ImageView     image;
   private ProgressWheel progress;
+  private ImageView     removeButton;
   private int           backgroundColorHint;
   private int           radius;
 
@@ -69,13 +72,21 @@ public class ThumbnailView extends FrameLayout {
     super(context, attrs, defStyle);
     inflate(context, R.layout.thumbnail_view, this);
     radius   = getResources().getDimensionPixelSize(R.dimen.message_bubble_corner_radius);
-    image    = (ImageView)     findViewById(R.id.thumbnail_image);
-    progress = (ProgressWheel) findViewById(R.id.progress_wheel);
+    image    = (ImageView) findViewById(R.id.thumbnail_image);
 
     if (attrs != null) {
       TypedArray typedArray = context.getTheme().obtainStyledAttributes(attrs, R.styleable.ThumbnailView, 0, 0);
       backgroundColorHint = typedArray.getColor(0, Color.BLACK);
       typedArray.recycle();
+    }
+  }
+
+  @Override protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+    super.onLayout(changed, left, top, right, bottom);
+    if (removeButton != null) {
+      final int paddingHorizontal = removeButton.getWidth()  / 2;
+      final int paddingVertical   = removeButton.getHeight() / 2;
+      image.setPadding(paddingHorizontal, paddingVertical, paddingHorizontal, 0);
     }
   }
 
@@ -89,12 +100,26 @@ public class ThumbnailView extends FrameLayout {
     EventBus.getDefault().unregister(this);
   }
 
+  private ProgressWheel getProgressWheel() {
+    if (progress == null) progress = ViewUtil.inflateStub(this, R.id.progress_wheel_stub);
+    return progress;
+  }
+
+  private void hideProgressWheel() {
+    if (progress != null) progress.setVisibility(GONE);
+  }
+
+  private ImageView getRemoveButton() {
+    if (removeButton == null) removeButton = ViewUtil.inflateStub(this, R.id.remove_button_stub);
+    return removeButton;
+  }
+
   @SuppressWarnings("unused")
   public void onEventAsync(final PartProgressEvent event) {
     if (this.slide != null && event.partId.equals(this.slide.getPart().getPartId())) {
       Util.runOnMain(new Runnable() {
         @Override public void run() {
-          progress.setInstantProgress(((float)event.progress) / event.total);
+          getProgressWheel().setInstantProgress(((float)event.progress) / event.total);
           if (event.progress >= event.total) animateOutProgress();
         }
       });
@@ -116,7 +141,7 @@ public class ThumbnailView extends FrameLayout {
     String slideId = id + "::" + timestamp;
 
     if (!slideId.equals(this.slideId)) {
-      progress.setVisibility(GONE);
+      hideProgressWheel();
       image.setImageDrawable(null);
       this.slide   = null;
       this.slideId = slideId;
@@ -139,10 +164,10 @@ public class ThumbnailView extends FrameLayout {
 
     this.slide = slide;
     if (slide.isInProgress() && showProgress) {
-      progress.spin();
-      progress.setVisibility(VISIBLE);
+      getProgressWheel().spin();
+      getProgressWheel().setVisibility(VISIBLE);
     } else {
-      progress.setVisibility(GONE);
+      hideProgressWheel();
     }
     buildGlideRequest(slide, masterSecret).into(image);
     setOnClickListener(new ThumbnailClickDispatcher(thumbnailClickListener, slide));
@@ -152,13 +177,17 @@ public class ThumbnailView extends FrameLayout {
     this.thumbnailClickListener = listener;
   }
 
+  public void setRemoveClickListener(OnClickListener listener) {
+    getRemoveButton().setOnClickListener(listener);
+  }
+
   public void clear() {
     if (isContextValid()) Glide.clear(this);
   }
 
   public void setShowProgress(boolean showProgress) {
     this.showProgress = showProgress;
-    if (progress.getVisibility() == View.VISIBLE && !showProgress) {
+    if (progress != null && progress.getVisibility() == View.VISIBLE && !showProgress) {
       animateOutProgress();
     }
   }
@@ -222,16 +251,17 @@ public class ThumbnailView extends FrameLayout {
   }
 
   private void animateOutProgress() {
+    if (progress == null) return;
     AlphaAnimation animation = new AlphaAnimation(1f, 0f);
     animation.setDuration(200);
     animation.setAnimationListener(new AnimationListener() {
       @Override public void onAnimationStart(Animation animation) { }
       @Override public void onAnimationRepeat(Animation animation) { }
       @Override public void onAnimationEnd(Animation animation) {
-        progress.setVisibility(View.GONE);
+        getProgressWheel().setVisibility(View.GONE);
       }
     });
-    progress.startAnimation(animation);
+    getProgressWheel().startAnimation(animation);
   }
 
   private class SlideDeckListener implements FutureTaskListener<SlideDeck> {
@@ -300,7 +330,7 @@ public class ThumbnailView extends FrameLayout {
     }
   }
 
-  private static class PduThumbnailSetListener implements RequestListener<Object, GlideDrawable> {
+  private class PduThumbnailSetListener implements RequestListener<Object, GlideDrawable> {
     private PduPart part;
 
     public PduThumbnailSetListener(@NonNull PduPart part) {
@@ -317,6 +347,11 @@ public class ThumbnailView extends FrameLayout {
       if (resource instanceof GlideBitmapDrawable) {
         Log.w(TAG, "onResourceReady() for a Bitmap. Saving.");
         part.setThumbnail(((GlideBitmapDrawable)resource).getBitmap());
+      }
+      if (resource.getIntrinsicWidth() < resource.getIntrinsicHeight()) {
+        getRemoveButton().setPadding(0, 0, (getWidth() - resource.getIntrinsicWidth()) / 2, 0);
+      } else {
+        getRemoveButton().setPadding(0, (getHeight() - resource.getIntrinsicHeight()) / 2, 0, 0);
       }
       return false;
     }

--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -29,7 +29,6 @@ import android.util.Log;
 import android.view.View;
 import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
-import android.widget.ImageView;
 import android.widget.Toast;
 
 import org.thoughtcrime.securesms.R;
@@ -48,7 +47,6 @@ public class AttachmentManager {
   private final Context            context;
   private final View               attachmentView;
   private final ThumbnailView      thumbnail;
-  private final ImageView          removeButton;
   private final SlideDeck          slideDeck;
   private final AttachmentListener attachmentListener;
 
@@ -57,12 +55,11 @@ public class AttachmentManager {
   public AttachmentManager(Activity view, AttachmentListener listener) {
     this.attachmentView     = view.findViewById(R.id.attachment_editor);
     this.thumbnail          = (ThumbnailView)view.findViewById(R.id.attachment_thumbnail);
-    this.removeButton       = (ImageView)view.findViewById(R.id.remove_image_button);
     this.slideDeck          = new SlideDeck();
     this.context            = view;
     this.attachmentListener = listener;
 
-    this.removeButton.setOnClickListener(new RemoveButtonListener());
+    thumbnail.setRemoveClickListener(new RemoveButtonListener());
   }
 
   public void clear() {
@@ -76,7 +73,6 @@ public class AttachmentManager {
         attachmentView.setVisibility(View.GONE);
         attachmentListener.onAttachmentChanged();
       }
-
     });
 
     attachmentView.startAnimation(animation);

--- a/src/org/thoughtcrime/securesms/util/ViewUtil.java
+++ b/src/org/thoughtcrime/securesms/util/ViewUtil.java
@@ -18,12 +18,14 @@ package org.thoughtcrime.securesms.util;
 
 import android.graphics.drawable.Drawable;
 import android.support.annotation.DrawableRes;
+import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.text.TextUtils.TruncateAt;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewStub;
 import android.widget.TextView;
 
 public class ViewUtil {
@@ -60,5 +62,10 @@ public class ViewUtil {
                                  view.getWidth() - view.getPaddingRight() - view.getPaddingLeft(),
                                  TruncateAt.END);
     }
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T extends View> T inflateStub(@NonNull View parent, @IdRes int stubId) {
+    return (T)((ViewStub)parent.findViewById(stubId)).inflate();
   }
 }


### PR DESCRIPTION
Let ThumbnailView figure out when and where to put the "remove" button in the case of drafts.

Since we use ThumbnailView in many places, and most of the time neither the remove button or progress indicators will be shown, I switched those to be lazily inflated since neither ImageViews nor ProgressWheel instances are very cheap to inflate when scrolling quickly.