### PR TITLE
Fix Incorrect String: Message Notifications Description (Preferences)

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -789,7 +789,7 @@
     <string name="preferences__pref_timeout_interval_title">Timeout interval</string>
     <string name="preferences__the_amount_of_time_to_wait_before_forgetting_passphrase">The amount of time to wait before forgetting passphrase from memory</string>
     <string name="preferences__notifications">Notifications</string>
-    <string name="preferences__display_message_notifications_in_status_bar">Display message notifications in status bar</string>
+    <string name="preferences__enable_message_notifications">Enable message notifications</string>
     <string name="preferences__led_color">LED color</string>
     <string name="preferences__led_color_unknown">Unknown</string>
     <string name="preferences__pref_led_blink_title">LED blink pattern</string>

--- a/res/xml/preferences_notifications.xml
+++ b/res/xml/preferences_notifications.xml
@@ -4,7 +4,7 @@
     <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
                         android:key="pref_key_enable_notifications"
                         android:title="@string/preferences__notifications"
-                        android:summary="@string/preferences__display_message_notifications_in_status_bar"
+                        android:summary="@string/preferences__enable_message_notifications"
                         android:defaultValue="true" />
 
     <RingtonePreference android:dependency="pref_key_enable_notifications"


### PR DESCRIPTION
The original string is incorrect as the underlying option affects not only the status bar but TextSecure's message notifications as a whole (status bar, message sound, vibration, LED).

Old string: "Display message notifications in status bar"
New string: "Enable message notifications"

// FREEBIE