### PR TITLE
prevent a thread race in CameraView

### DIFF
--- a/src/org/thoughtcrime/securesms/components/camera/CameraView.java
+++ b/src/org/thoughtcrime/securesms/components/camera/CameraView.java
@@ -137,9 +137,7 @@ public class CameraView extends FrameLayout {
       }
 
       @Override protected Void onRunBackground() {
-        if (camera != null) {
-          previewDestroyed();
-        }
+        previewDestroyed();
         return null;
       }
 

--- a/src/org/thoughtcrime/securesms/components/camera/SurfacePreviewStrategy.java
+++ b/src/org/thoughtcrime/securesms/components/camera/SurfacePreviewStrategy.java
@@ -56,7 +56,7 @@ class SurfacePreviewStrategy implements PreviewStrategy,
   @Override
   public void surfaceDestroyed(SurfaceHolder holder) {
     Log.w(TAG, "surfaceDestroyed()");
-    cameraView.previewDestroyed();
+    cameraView.onPause();
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/components/camera/TexturePreviewStrategy.java
+++ b/src/org/thoughtcrime/securesms/components/camera/TexturePreviewStrategy.java
@@ -55,7 +55,7 @@ class TexturePreviewStrategy implements PreviewStrategy,
   @Override
   public boolean onSurfaceTextureDestroyed(SurfaceTexture surface) {
     Log.w(TAG, "onSurfaceTextureDestroyed()");
-    cameraView.previewDestroyed();
+    cameraView.onPause();
 
     return(true);
   }


### PR DESCRIPTION
when a camera preview surface is destroyed, send it down the same pipelien
to make sure a race condition isn't hit

i couldn't reproduce, but should fix #3864
// FREEBIE