### PR TITLE
DB performance optimizations

### DIFF
--- a/src/org/thoughtcrime/securesms/database/DatabaseFactory.java
+++ b/src/org/thoughtcrime/securesms/database/DatabaseFactory.java
@@ -65,7 +65,8 @@ public class DatabaseFactory {
   private static final int INTRODUCED_RECIPIENT_PREFS_DB       = 18;
   private static final int INTRODUCED_ENVELOPE_CONTENT_VERSION = 19;
   private static final int INTRODUCED_COLOR_PREFERENCE_VERSION = 20;
-  private static final int DATABASE_VERSION                    = 20;
+  private static final int INTRODUCED_DB_OPTIMIZATIONS_VERSION = 21;
+  private static final int DATABASE_VERSION                    = 21;
 
   private static final String DATABASE_NAME    = "messages.db";
   private static final Object lock             = new Object();
@@ -752,6 +753,12 @@ public class DatabaseFactory {
 
       if (oldVersion < INTRODUCED_COLOR_PREFERENCE_VERSION) {
         db.execSQL("ALTER TABLE recipient_preferences ADD COLUMN color TEXT DEFAULT NULL");
+      }
+
+      if (oldVersion < INTRODUCED_DB_OPTIMIZATIONS_VERSION) {
+        db.execSQL("UPDATE mms SET date_received = (date_received * 1000), date = (date * 1000);");
+        db.execSQL("CREATE INDEX IF NOT EXISTS sms_thread_date_index ON sms (thread_id, date);");
+        db.execSQL("CREATE INDEX IF NOT EXISTS mms_thread_date_index ON mms (thread_id, date_received);");
       }
 
       db.setTransactionSuccessful();

--- a/src/org/thoughtcrime/securesms/database/MmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MmsDatabase.java
@@ -182,21 +182,18 @@ public class MmsDatabase extends MessagingDatabase {
     return TABLE_NAME;
   }
 
-  public int getMessageCountForThread(long threadId) {
+  public boolean hasMessagesForThread(long threadId) {
     SQLiteDatabase db = databaseHelper.getReadableDatabase();
     Cursor cursor     = null;
 
     try {
-      cursor = db.query(TABLE_NAME, new String[] {"COUNT(*)"}, THREAD_ID + " = ?", new String[] {threadId+""}, null, null, null);
+      cursor = db.rawQuery("SELECT EXISTS(SELECT 1 FROM " + TABLE_NAME + " WHERE " + THREAD_ID + " = ?);",
+                           new String[] {String.valueOf(threadId)});
 
-      if (cursor != null && cursor.moveToFirst())
-        return cursor.getInt(0);
+      return cursor != null && cursor.moveToFirst() && cursor.getInt(0) == 1;
     } finally {
-      if (cursor != null)
-        cursor.close();
+      if (cursor != null) cursor.close();
     }
-
-    return 0;
   }
 
   public void addFailures(long messageId, List<NetworkFailure> failure) {

--- a/src/org/thoughtcrime/securesms/database/MmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MmsDatabase.java
@@ -152,12 +152,13 @@ public class MmsDatabase extends MessagingDatabase {
     "CREATE INDEX IF NOT EXISTS mms_read_index ON " + TABLE_NAME + " (" + READ + ");",
     "CREATE INDEX IF NOT EXISTS mms_read_and_thread_id_index ON " + TABLE_NAME + "(" + READ + "," + THREAD_ID + ");",
     "CREATE INDEX IF NOT EXISTS mms_message_box_index ON " + TABLE_NAME + " (" + MESSAGE_BOX + ");",
-    "CREATE INDEX IF NOT EXISTS mms_date_sent_index ON " + TABLE_NAME + " (" + DATE_SENT + ");"
+    "CREATE INDEX IF NOT EXISTS mms_date_sent_index ON " + TABLE_NAME + " (" + DATE_SENT + ");",
+    "CREATE INDEX IF NOT EXISTS mms_thread_date_index ON " + TABLE_NAME + " (" + THREAD_ID + ", " + DATE_RECEIVED + ");"
   };
 
   private static final String[] MMS_PROJECTION = new String[] {
-      ID, THREAD_ID, DATE_SENT + " * 1000 AS " + NORMALIZED_DATE_SENT,
-      DATE_RECEIVED + " * 1000 AS " + NORMALIZED_DATE_RECEIVED,
+      ID, THREAD_ID, DATE_SENT + " AS " + NORMALIZED_DATE_SENT,
+      DATE_RECEIVED + " AS " + NORMALIZED_DATE_RECEIVED,
       MESSAGE_BOX, READ, MESSAGE_ID, SUBJECT, SUBJECT_CHARSET, CONTENT_TYPE,
       CONTENT_LOCATION, EXPIRY, MESSAGE_CLASS, MESSAGE_TYPE, MMS_VERSION,
       MESSAGE_SIZE, PRIORITY, REPORT_ALLOWED, STATUS, TRANSACTION_ID, RETRIEVE_STATUS,
@@ -218,7 +219,7 @@ public class MmsDatabase extends MessagingDatabase {
     Cursor             cursor          = null;
 
     try {
-      cursor = database.query(TABLE_NAME, new String[] {ID, THREAD_ID, MESSAGE_BOX}, DATE_SENT + " = ?", new String[] {String.valueOf(timestamp / 1000)}, null, null, null, null);
+      cursor = database.query(TABLE_NAME, new String[] {ID, THREAD_ID, MESSAGE_BOX}, DATE_SENT + " = ?", new String[] {String.valueOf(timestamp)}, null, null, null, null);
 
       while (cursor.moveToNext()) {
         if (Types.isOutgoingMessageType(cursor.getLong(cursor.getColumnIndexOrThrow(MESSAGE_BOX)))) {
@@ -605,7 +606,7 @@ public class MmsDatabase extends MessagingDatabase {
     contentValues.put(THREAD_ID, threadId);
     contentValues.put(CONTENT_LOCATION, contentLocation);
     contentValues.put(STATUS, Status.DOWNLOAD_INITIALIZED);
-    contentValues.put(DATE_RECEIVED, System.currentTimeMillis() / 1000);
+    contentValues.put(DATE_RECEIVED, System.currentTimeMillis());
     contentValues.put(READ, unread ? 0 : 1);
 
     if (!contentValues.containsKey(DATE_SENT)) {
@@ -678,7 +679,7 @@ public class MmsDatabase extends MessagingDatabase {
     contentValues.put(MESSAGE_BOX, Types.BASE_INBOX_TYPE);
     contentValues.put(THREAD_ID, threadId);
     contentValues.put(STATUS, Status.DOWNLOAD_INITIALIZED);
-    contentValues.put(DATE_RECEIVED, System.currentTimeMillis() / 1000);
+    contentValues.put(DATE_RECEIVED, System.currentTimeMillis());
     contentValues.put(READ, Util.isDefaultSmsProvider(context) ? 0 : 1);
 
     if (!contentValues.containsKey(DATE_SENT))
@@ -720,7 +721,7 @@ public class MmsDatabase extends MessagingDatabase {
     }
 
     SendReq sendRequest = new SendReq();
-    sendRequest.setDate(timestamp / 1000L);
+    sendRequest.setDate(timestamp);
     sendRequest.setBody(message.getPduBody());
     sendRequest.setContentType(ContentType.MULTIPART_MIXED.getBytes());
 
@@ -853,7 +854,6 @@ public class MmsDatabase extends MessagingDatabase {
   }
 
   /*package*/void deleteMessagesInThreadBeforeDate(long threadId, long date) {
-    date          = date / 1000;
     Cursor cursor = null;
 
     try {
@@ -930,7 +930,7 @@ public class MmsDatabase extends MessagingDatabase {
     phb.addLong(EXPIRY, PduHeaders.EXPIRY);
     phb.addLong(MESSAGE_SIZE, PduHeaders.MESSAGE_SIZE);
 
-    headers.setLongInteger(headers.getLongInteger(PduHeaders.DATE) / 1000L, PduHeaders.DATE);
+    headers.setLongInteger(headers.getLongInteger(PduHeaders.DATE), PduHeaders.DATE);
 
     return headers;
   }

--- a/src/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
@@ -21,12 +21,13 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.database.sqlite.SQLiteQueryBuilder;
-import android.util.Log;
 
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.model.MessageRecord;
+import org.thoughtcrime.securesms.util.LRUCache;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 public class MmsSmsDatabase extends Database {
@@ -35,29 +36,90 @@ public class MmsSmsDatabase extends Database {
   public static final String MMS_TRANSPORT = "mms";
   public static final String SMS_TRANSPORT = "sms";
 
+  private final Map<Long, String> queryCache = new LRUCache<>(100);
+
+  private static final String[] CONVERSATION_PROJECTION = {MmsSmsColumns.ID, SmsDatabase.BODY, SmsDatabase.TYPE,
+                                                           MmsSmsColumns.THREAD_ID,
+                                                           SmsDatabase.ADDRESS, SmsDatabase.ADDRESS_DEVICE_ID, SmsDatabase.SUBJECT,
+                                                           MmsSmsColumns.NORMALIZED_DATE_SENT,
+                                                           MmsSmsColumns.NORMALIZED_DATE_RECEIVED,
+                                                           MmsDatabase.MESSAGE_TYPE, MmsDatabase.MESSAGE_BOX,
+                                                           SmsDatabase.STATUS, MmsDatabase.PART_COUNT,
+                                                           MmsDatabase.CONTENT_LOCATION, MmsDatabase.TRANSACTION_ID,
+                                                           MmsDatabase.MESSAGE_SIZE, MmsDatabase.EXPIRY,
+                                                           MmsDatabase.STATUS, MmsSmsColumns.RECEIPT_COUNT,
+                                                           MmsSmsColumns.MISMATCHED_IDENTITIES,
+                                                           MmsDatabase.NETWORK_FAILURE, TRANSPORT};
+  private static final String[] MMS_PROJECTION = {MmsDatabase.DATE_SENT + " * 1000 AS " + MmsSmsColumns.NORMALIZED_DATE_SENT,
+                                                  MmsDatabase.DATE_RECEIVED + " * 1000 AS " + MmsSmsColumns.NORMALIZED_DATE_RECEIVED,
+                                                  MmsSmsColumns.ID, SmsDatabase.BODY, MmsSmsColumns.READ, MmsSmsColumns.THREAD_ID,
+                                                  SmsDatabase.TYPE, SmsDatabase.ADDRESS, SmsDatabase.ADDRESS_DEVICE_ID, SmsDatabase.SUBJECT, MmsDatabase.MESSAGE_TYPE,
+                                                  MmsDatabase.MESSAGE_BOX, SmsDatabase.STATUS, MmsDatabase.PART_COUNT,
+                                                  MmsDatabase.CONTENT_LOCATION, MmsDatabase.TRANSACTION_ID,
+                                                  MmsDatabase.MESSAGE_SIZE, MmsDatabase.EXPIRY, MmsDatabase.STATUS,
+                                                  MmsSmsColumns.RECEIPT_COUNT, MmsSmsColumns.MISMATCHED_IDENTITIES,
+                                                  MmsDatabase.NETWORK_FAILURE, TRANSPORT};
+  private static final String[] SMS_PROJECTION = {SmsDatabase.DATE_SENT + " * 1 AS " + MmsSmsColumns.NORMALIZED_DATE_SENT,
+                                                  SmsDatabase.DATE_RECEIVED + " * 1 AS " + MmsSmsColumns.NORMALIZED_DATE_RECEIVED,
+                                                  MmsSmsColumns.ID, SmsDatabase.BODY, MmsSmsColumns.READ, MmsSmsColumns.THREAD_ID,
+                                                  SmsDatabase.TYPE, SmsDatabase.ADDRESS, SmsDatabase.ADDRESS_DEVICE_ID, SmsDatabase.SUBJECT, MmsDatabase.MESSAGE_TYPE,
+                                                  MmsDatabase.MESSAGE_BOX, SmsDatabase.STATUS, MmsDatabase.PART_COUNT,
+                                                  MmsDatabase.CONTENT_LOCATION, MmsDatabase.TRANSACTION_ID,
+                                                  MmsDatabase.MESSAGE_SIZE, MmsDatabase.EXPIRY, MmsDatabase.STATUS,
+                                                  MmsSmsColumns.RECEIPT_COUNT, MmsSmsColumns.MISMATCHED_IDENTITIES,
+                                                  MmsDatabase.NETWORK_FAILURE, TRANSPORT};
+  private static final String CONVERSATION_ORDER = MmsSmsColumns.NORMALIZED_DATE_RECEIVED + " ASC";
+  private static final Set<String> MMS_COLUMNS_PRESENT = new HashSet<String>() {{
+    add(MmsSmsColumns.ID);
+    add(MmsSmsColumns.READ);
+    add(MmsSmsColumns.THREAD_ID);
+    add(MmsSmsColumns.BODY);
+    add(MmsSmsColumns.ADDRESS);
+    add(MmsSmsColumns.ADDRESS_DEVICE_ID);
+    add(MmsSmsColumns.RECEIPT_COUNT);
+    add(MmsSmsColumns.MISMATCHED_IDENTITIES);
+    add(MmsDatabase.MESSAGE_TYPE);
+    add(MmsDatabase.MESSAGE_BOX);
+    add(MmsDatabase.DATE_SENT);
+    add(MmsDatabase.DATE_RECEIVED);
+    add(MmsDatabase.PART_COUNT);
+    add(MmsDatabase.CONTENT_LOCATION);
+    add(MmsDatabase.TRANSACTION_ID);
+    add(MmsDatabase.MESSAGE_SIZE);
+    add(MmsDatabase.EXPIRY);
+    add(MmsDatabase.STATUS);
+    add(MmsDatabase.NETWORK_FAILURE);
+  }};
+  private static final Set<String> SMS_COLUMNS_PRESENT = new HashSet<String>() {{
+    add(MmsSmsColumns.ID);
+    add(MmsSmsColumns.BODY);
+    add(MmsSmsColumns.ADDRESS);
+    add(MmsSmsColumns.ADDRESS_DEVICE_ID);
+    add(MmsSmsColumns.READ);
+    add(MmsSmsColumns.THREAD_ID);
+    add(MmsSmsColumns.RECEIPT_COUNT);
+    add(MmsSmsColumns.MISMATCHED_IDENTITIES);
+    add(SmsDatabase.TYPE);
+    add(SmsDatabase.SUBJECT);
+    add(SmsDatabase.DATE_SENT);
+    add(SmsDatabase.DATE_RECEIVED);
+    add(SmsDatabase.STATUS);
+  }};
+
   public MmsSmsDatabase(Context context, SQLiteOpenHelper databaseHelper) {
     super(context, databaseHelper);
   }
 
   public Cursor getConversation(long threadId) {
-    String[] projection    = {MmsSmsColumns.ID, SmsDatabase.BODY, SmsDatabase.TYPE,
-                              MmsSmsColumns.THREAD_ID,
-                              SmsDatabase.ADDRESS, SmsDatabase.ADDRESS_DEVICE_ID, SmsDatabase.SUBJECT,
-                              MmsSmsColumns.NORMALIZED_DATE_SENT,
-                              MmsSmsColumns.NORMALIZED_DATE_RECEIVED,
-                              MmsDatabase.MESSAGE_TYPE, MmsDatabase.MESSAGE_BOX,
-                              SmsDatabase.STATUS, MmsDatabase.PART_COUNT,
-                              MmsDatabase.CONTENT_LOCATION, MmsDatabase.TRANSACTION_ID,
-                              MmsDatabase.MESSAGE_SIZE, MmsDatabase.EXPIRY,
-                              MmsDatabase.STATUS, MmsSmsColumns.RECEIPT_COUNT,
-                              MmsSmsColumns.MISMATCHED_IDENTITIES,
-                              MmsDatabase.NETWORK_FAILURE, TRANSPORT};
-
-    String order           = MmsSmsColumns.NORMALIZED_DATE_RECEIVED + " ASC";
-
-    String selection       = MmsSmsColumns.THREAD_ID + " = " + threadId;
-
-    Cursor cursor = queryTables(projection, selection, selection, order, null, null);
+    final String selection = MmsSmsColumns.THREAD_ID + " = " + threadId;
+    final String query;
+    if (queryCache.containsKey(threadId)) {
+      query = queryCache.get(threadId);
+    } else {
+      query = getQuery(CONVERSATION_PROJECTION, selection, selection, CONVERSATION_ORDER, null, null);
+      queryCache.put(threadId, query);
+    }
+    final Cursor cursor = rawQuery(query);
     setNotifyConverationListeners(cursor, threadId);
 
     return cursor;
@@ -139,28 +201,16 @@ public class MmsSmsDatabase extends Database {
     DatabaseFactory.getMmsDatabase(context).incrementDeliveryReceiptCount(address, timestamp);
   }
 
+  private Cursor rawQuery(final String query) {
+    SQLiteDatabase db = databaseHelper.getReadableDatabase();
+    return db.rawQuery(query, null);
+  }
+
   private Cursor queryTables(String[] projection, String smsSelection, String mmsSelection, String order, String groupBy, String limit) {
-    String[] mmsProjection = {MmsDatabase.DATE_SENT + " * 1000 AS " + MmsSmsColumns.NORMALIZED_DATE_SENT,
-                              MmsDatabase.DATE_RECEIVED + " * 1000 AS " + MmsSmsColumns.NORMALIZED_DATE_RECEIVED,
-                              MmsSmsColumns.ID, SmsDatabase.BODY, MmsSmsColumns.READ, MmsSmsColumns.THREAD_ID,
-                              SmsDatabase.TYPE, SmsDatabase.ADDRESS, SmsDatabase.ADDRESS_DEVICE_ID, SmsDatabase.SUBJECT, MmsDatabase.MESSAGE_TYPE,
-                              MmsDatabase.MESSAGE_BOX, SmsDatabase.STATUS, MmsDatabase.PART_COUNT,
-                              MmsDatabase.CONTENT_LOCATION, MmsDatabase.TRANSACTION_ID,
-                              MmsDatabase.MESSAGE_SIZE, MmsDatabase.EXPIRY, MmsDatabase.STATUS,
-                              MmsSmsColumns.RECEIPT_COUNT, MmsSmsColumns.MISMATCHED_IDENTITIES,
-                              MmsDatabase.NETWORK_FAILURE, TRANSPORT};
+    return rawQuery(getQuery(projection, smsSelection, mmsSelection, order, groupBy, limit));
+  }
 
-    String[] smsProjection = {SmsDatabase.DATE_SENT + " * 1 AS " + MmsSmsColumns.NORMALIZED_DATE_SENT,
-                              SmsDatabase.DATE_RECEIVED + " * 1 AS " + MmsSmsColumns.NORMALIZED_DATE_RECEIVED,
-                              MmsSmsColumns.ID, SmsDatabase.BODY, MmsSmsColumns.READ, MmsSmsColumns.THREAD_ID,
-                              SmsDatabase.TYPE, SmsDatabase.ADDRESS, SmsDatabase.ADDRESS_DEVICE_ID, SmsDatabase.SUBJECT, MmsDatabase.MESSAGE_TYPE,
-                              MmsDatabase.MESSAGE_BOX, SmsDatabase.STATUS, MmsDatabase.PART_COUNT,
-                              MmsDatabase.CONTENT_LOCATION, MmsDatabase.TRANSACTION_ID,
-                              MmsDatabase.MESSAGE_SIZE, MmsDatabase.EXPIRY, MmsDatabase.STATUS,
-                              MmsSmsColumns.RECEIPT_COUNT, MmsSmsColumns.MISMATCHED_IDENTITIES,
-                              MmsDatabase.NETWORK_FAILURE, TRANSPORT};
-
-
+  private String getQuery(String[] projection, String smsSelection, String mmsSelection, String order, String groupBy, String limit) {
     SQLiteQueryBuilder mmsQueryBuilder = new SQLiteQueryBuilder();
     SQLiteQueryBuilder smsQueryBuilder = new SQLiteQueryBuilder();
 
@@ -170,44 +220,8 @@ public class MmsSmsDatabase extends Database {
     mmsQueryBuilder.setTables(MmsDatabase.TABLE_NAME);
     smsQueryBuilder.setTables(SmsDatabase.TABLE_NAME);
 
-    Set<String> mmsColumnsPresent = new HashSet<String>();
-    mmsColumnsPresent.add(MmsSmsColumns.ID);
-    mmsColumnsPresent.add(MmsSmsColumns.READ);
-    mmsColumnsPresent.add(MmsSmsColumns.THREAD_ID);
-    mmsColumnsPresent.add(MmsSmsColumns.BODY);
-    mmsColumnsPresent.add(MmsSmsColumns.ADDRESS);
-    mmsColumnsPresent.add(MmsSmsColumns.ADDRESS_DEVICE_ID);
-    mmsColumnsPresent.add(MmsSmsColumns.RECEIPT_COUNT);
-    mmsColumnsPresent.add(MmsSmsColumns.MISMATCHED_IDENTITIES);
-    mmsColumnsPresent.add(MmsDatabase.MESSAGE_TYPE);
-    mmsColumnsPresent.add(MmsDatabase.MESSAGE_BOX);
-    mmsColumnsPresent.add(MmsDatabase.DATE_SENT);
-    mmsColumnsPresent.add(MmsDatabase.DATE_RECEIVED);
-    mmsColumnsPresent.add(MmsDatabase.PART_COUNT);
-    mmsColumnsPresent.add(MmsDatabase.CONTENT_LOCATION);
-    mmsColumnsPresent.add(MmsDatabase.TRANSACTION_ID);
-    mmsColumnsPresent.add(MmsDatabase.MESSAGE_SIZE);
-    mmsColumnsPresent.add(MmsDatabase.EXPIRY);
-    mmsColumnsPresent.add(MmsDatabase.STATUS);
-    mmsColumnsPresent.add(MmsDatabase.NETWORK_FAILURE);
-
-    Set<String> smsColumnsPresent = new HashSet<String>();
-    smsColumnsPresent.add(MmsSmsColumns.ID);
-    smsColumnsPresent.add(MmsSmsColumns.BODY);
-    smsColumnsPresent.add(MmsSmsColumns.ADDRESS);
-    smsColumnsPresent.add(MmsSmsColumns.ADDRESS_DEVICE_ID);
-    smsColumnsPresent.add(MmsSmsColumns.READ);
-    smsColumnsPresent.add(MmsSmsColumns.THREAD_ID);
-    smsColumnsPresent.add(MmsSmsColumns.RECEIPT_COUNT);
-    smsColumnsPresent.add(MmsSmsColumns.MISMATCHED_IDENTITIES);
-    smsColumnsPresent.add(SmsDatabase.TYPE);
-    smsColumnsPresent.add(SmsDatabase.SUBJECT);
-    smsColumnsPresent.add(SmsDatabase.DATE_SENT);
-    smsColumnsPresent.add(SmsDatabase.DATE_RECEIVED);
-    smsColumnsPresent.add(SmsDatabase.STATUS);
-
-    String mmsSubQuery = mmsQueryBuilder.buildUnionSubQuery(TRANSPORT, mmsProjection, mmsColumnsPresent, 2, MMS_TRANSPORT, mmsSelection, null, null, null);
-    String smsSubQuery = smsQueryBuilder.buildUnionSubQuery(TRANSPORT, smsProjection, smsColumnsPresent, 2, SMS_TRANSPORT, smsSelection, null, null, null);
+    String mmsSubQuery = mmsQueryBuilder.buildUnionSubQuery(TRANSPORT, MMS_PROJECTION, MMS_COLUMNS_PRESENT, 2, MMS_TRANSPORT, mmsSelection, null, null, null);
+    String smsSubQuery = smsQueryBuilder.buildUnionSubQuery(TRANSPORT, SMS_PROJECTION, SMS_COLUMNS_PRESENT, 2, SMS_TRANSPORT, smsSelection, null, null, null);
 
     SQLiteQueryBuilder unionQueryBuilder = new SQLiteQueryBuilder();
     String unionQuery = unionQueryBuilder.buildUnionQuery(new String[] {smsSubQuery, mmsSubQuery}, order, null);
@@ -215,11 +229,7 @@ public class MmsSmsDatabase extends Database {
     SQLiteQueryBuilder outerQueryBuilder = new SQLiteQueryBuilder();
     outerQueryBuilder.setTables("(" + unionQuery + ")");
 
-    String query      = outerQueryBuilder.buildQuery(projection, null, null, groupBy, null, null, limit);
-
-    Log.w("MmsSmsDatabase", "Executing query: " + query);
-    SQLiteDatabase db = databaseHelper.getReadableDatabase();
-    return db.rawQuery(query, null);
+    return outerQueryBuilder.buildQuery(projection, null, null, groupBy, null, null, limit);
   }
 
   public Reader readerFor(Cursor cursor, MasterSecret masterSecret) {

--- a/src/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
@@ -189,11 +189,9 @@ public class MmsSmsDatabase extends Database {
     return queryTables(projection, selection, selection, order, null, null);
   }
 
-  public int getConversationCount(long threadId) {
-    int count = DatabaseFactory.getSmsDatabase(context).getMessageCountForThread(threadId);
-    count    += DatabaseFactory.getMmsDatabase(context).getMessageCountForThread(threadId);
-
-    return count;
+  public boolean isConversationEmpty(long threadId) {
+    return !DatabaseFactory.getSmsDatabase(context).hasMessagesForThread(threadId) &&
+           !DatabaseFactory.getMmsDatabase(context).hasMessagesForThread(threadId);
   }
 
   public void incrementDeliveryReceiptCount(String address, long timestamp) {

--- a/src/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
@@ -50,8 +50,8 @@ public class MmsSmsDatabase extends Database {
                                                            MmsDatabase.STATUS, MmsSmsColumns.RECEIPT_COUNT,
                                                            MmsSmsColumns.MISMATCHED_IDENTITIES,
                                                            MmsDatabase.NETWORK_FAILURE, TRANSPORT};
-  private static final String[] MMS_PROJECTION = {MmsDatabase.DATE_SENT + " * 1000 AS " + MmsSmsColumns.NORMALIZED_DATE_SENT,
-                                                  MmsDatabase.DATE_RECEIVED + " * 1000 AS " + MmsSmsColumns.NORMALIZED_DATE_RECEIVED,
+  private static final String[] MMS_PROJECTION = {MmsDatabase.DATE_SENT + " AS " + MmsSmsColumns.NORMALIZED_DATE_SENT,
+                                                  MmsDatabase.DATE_RECEIVED + " AS " + MmsSmsColumns.NORMALIZED_DATE_RECEIVED,
                                                   MmsSmsColumns.ID, SmsDatabase.BODY, MmsSmsColumns.READ, MmsSmsColumns.THREAD_ID,
                                                   SmsDatabase.TYPE, SmsDatabase.ADDRESS, SmsDatabase.ADDRESS_DEVICE_ID, SmsDatabase.SUBJECT, MmsDatabase.MESSAGE_TYPE,
                                                   MmsDatabase.MESSAGE_BOX, SmsDatabase.STATUS, MmsDatabase.PART_COUNT,
@@ -59,8 +59,8 @@ public class MmsSmsDatabase extends Database {
                                                   MmsDatabase.MESSAGE_SIZE, MmsDatabase.EXPIRY, MmsDatabase.STATUS,
                                                   MmsSmsColumns.RECEIPT_COUNT, MmsSmsColumns.MISMATCHED_IDENTITIES,
                                                   MmsDatabase.NETWORK_FAILURE, TRANSPORT};
-  private static final String[] SMS_PROJECTION = {SmsDatabase.DATE_SENT + " * 1 AS " + MmsSmsColumns.NORMALIZED_DATE_SENT,
-                                                  SmsDatabase.DATE_RECEIVED + " * 1 AS " + MmsSmsColumns.NORMALIZED_DATE_RECEIVED,
+  private static final String[] SMS_PROJECTION = {SmsDatabase.DATE_SENT + " AS " + MmsSmsColumns.NORMALIZED_DATE_SENT,
+                                                  SmsDatabase.DATE_RECEIVED + " AS " + MmsSmsColumns.NORMALIZED_DATE_RECEIVED,
                                                   MmsSmsColumns.ID, SmsDatabase.BODY, MmsSmsColumns.READ, MmsSmsColumns.THREAD_ID,
                                                   SmsDatabase.TYPE, SmsDatabase.ADDRESS, SmsDatabase.ADDRESS_DEVICE_ID, SmsDatabase.SUBJECT, MmsDatabase.MESSAGE_TYPE,
                                                   MmsDatabase.MESSAGE_BOX, SmsDatabase.STATUS, MmsDatabase.PART_COUNT,
@@ -212,8 +212,8 @@ public class MmsSmsDatabase extends Database {
     SQLiteQueryBuilder mmsQueryBuilder = new SQLiteQueryBuilder();
     SQLiteQueryBuilder smsQueryBuilder = new SQLiteQueryBuilder();
 
-    mmsQueryBuilder.setDistinct(true);
-    smsQueryBuilder.setDistinct(true);
+    mmsQueryBuilder.setDistinct(false);
+    smsQueryBuilder.setDistinct(false);
 
     mmsQueryBuilder.setTables(MmsDatabase.TABLE_NAME);
     smsQueryBuilder.setTables(SmsDatabase.TABLE_NAME);

--- a/src/org/thoughtcrime/securesms/database/PartDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/PartDatabase.java
@@ -568,7 +568,7 @@ public class PartDatabase extends Database {
       return new ImageRecord(partId,
                              cursor.getString(cursor.getColumnIndexOrThrow(CONTENT_TYPE)),
                              cursor.getString(cursor.getColumnIndexOrThrow(MmsDatabase.ADDRESS)),
-                             cursor.getLong(cursor.getColumnIndexOrThrow(MmsDatabase.NORMALIZED_DATE_RECEIVED)) * 1000);
+                             cursor.getLong(cursor.getColumnIndexOrThrow(MmsDatabase.NORMALIZED_DATE_RECEIVED)));
     }
 
     public PartId getPartId() {

--- a/src/org/thoughtcrime/securesms/database/SmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/SmsDatabase.java
@@ -83,7 +83,8 @@ public class SmsDatabase extends MessagingDatabase {
     "CREATE INDEX IF NOT EXISTS sms_read_index ON " + TABLE_NAME + " (" + READ + ");",
     "CREATE INDEX IF NOT EXISTS sms_read_and_thread_id_index ON " + TABLE_NAME + "(" + READ + "," + THREAD_ID + ");",
     "CREATE INDEX IF NOT EXISTS sms_type_index ON " + TABLE_NAME + " (" + TYPE + ");",
-    "CREATE INDEX IF NOT EXISTS sms_date_sent_index ON " + TABLE_NAME + " (" + DATE_SENT + ");"
+    "CREATE INDEX IF NOT EXISTS sms_date_sent_index ON " + TABLE_NAME + " (" + DATE_SENT + ");",
+    "CREATE INDEX IF NOT EXISTS sms_thread_date_index ON " + TABLE_NAME + " (" + THREAD_ID + ", " + DATE_RECEIVED + ");"
   };
 
   private static final String[] MESSAGE_PROJECTION = new String[] {

--- a/src/org/thoughtcrime/securesms/database/SmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/SmsDatabase.java
@@ -155,22 +155,18 @@ public class SmsDatabase extends MessagingDatabase {
     }
   }
 
-  public int getMessageCountForThread(long threadId) {
+  public boolean hasMessagesForThread(long threadId) {
     SQLiteDatabase db = databaseHelper.getReadableDatabase();
     Cursor cursor     = null;
 
     try {
-      cursor = db.query(TABLE_NAME, new String[] {"COUNT(*)"}, THREAD_ID + " = ?",
-                        new String[] {threadId+""}, null, null, null);
+      cursor = db.rawQuery("SELECT EXISTS(SELECT 1 FROM " + TABLE_NAME + " WHERE " + THREAD_ID + " = ?);",
+                           new String[] {String.valueOf(threadId)});
 
-      if (cursor != null && cursor.moveToFirst())
-        return cursor.getInt(0);
+      return cursor != null && cursor.moveToFirst() && cursor.getInt(0) == 1;
     } finally {
-      if (cursor != null)
-        cursor.close();
+      if (cursor != null) cursor.close();
     }
-
-    return 0;
   }
 
   public void markAsEndSession(long id) {

--- a/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
@@ -37,17 +37,15 @@ import org.thoughtcrime.securesms.util.GroupUtil;
 public class ThreadRecord extends DisplayRecord {
 
   private final Context context;
-  private final long count;
   private final boolean read;
-  private final int distributionType;
+  private final int     distributionType;
 
   public ThreadRecord(Context context, Body body, Recipients recipients, long date,
-                      long count, boolean read, long threadId, long snippetType,
+                      boolean read, long threadId, long snippetType,
                       int distributionType)
   {
     super(context, body, recipients, date, date, threadId, snippetType);
     this.context          = context.getApplicationContext();
-    this.count            = count;
     this.read             = read;
     this.distributionType = distributionType;
   }
@@ -93,10 +91,6 @@ public class ThreadRecord extends DisplayRecord {
     spannable.setSpan(new StyleSpan(android.graphics.Typeface.ITALIC),
                       start, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
     return spannable;
-  }
-
-  public long getCount() {
-    return count;
   }
 
   public boolean isRead() {


### PR DESCRIPTION
First round of database-related performance optimizations - it should cut load times for long conversations roughly in half. It's still kind of slow even given that, but more changes on the way to fix that.

* Add multi-column index that allows quick sorting against thread id and received time, which is how we sort our conversations. Without them, SQLite has been having to sort with temporary B-Trees which is not so efficient. Part of this requires using (column AS name) instead of (expr AS name), so I had to migrate the MMS database to use normal timestamps.
* Use the SQLite EXISTS method for checking if a conversation is empty instead of having to do a full sweep of the table.
* Move unnecessary HashMap and array allocations to static variables for the most-used getConversation() method.
* Stop keeping track of message count in ThreadDatabase since we don't use it and it's slow.