### PR TITLE
LargeSQLiteCursor

### DIFF
--- a/src/org/thoughtcrime/securesms/database/LargeSQLiteCursor.java
+++ b/src/org/thoughtcrime/securesms/database/LargeSQLiteCursor.java
@@ -1,0 +1,212 @@
+package org.thoughtcrime.securesms.database;
+
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
+import android.content.ContentResolver;
+import android.database.AbstractCursor;
+import android.database.ContentObserver;
+import android.database.Cursor;
+import android.database.DataSetObserver;
+import android.database.sqlite.SQLiteDatabase;
+import android.net.Uri;
+import android.os.Build.VERSION_CODES;
+import android.support.annotation.NonNull;
+import android.support.v4.util.LruCache;
+import android.util.Log;
+
+public class LargeSQLiteCursor extends AbstractCursor {
+  private static final String TAG = LargeSQLiteCursor.class.getSimpleName();
+
+  private final SQLiteDatabase db;
+  private final String         query;
+  private final int            windowSize;
+
+  private int                       count;
+  private ContentObserver           contentObserver;
+  private ContentResolver           contentResolver;
+  private DataSetObserver           dataSetObserver;
+  private Uri                       notificationUri;
+  private LruCache<Integer, Cursor> loadedCursors;
+  private Cursor                    current;
+
+  public LargeSQLiteCursor(SQLiteDatabase db, String query, int windowSize) {
+    this.db            = db;
+    this.query         = query;
+    this.windowSize    = windowSize;
+    this.count         = getCount(db, query);
+    this.loadedCursors = new CursorLruCache(4);
+    updateCursor(0);
+  }
+
+  private int getCount(SQLiteDatabase db, String query) {
+    Cursor countCursor = null;
+    try {
+      long start = System.currentTimeMillis();
+      countCursor = db.rawQuery("SELECT COUNT(1) FROM (" + query + ");", null);
+      if (!countCursor.moveToFirst()) {
+        throw new IllegalStateException("couldn't get count of results in query");
+      }
+      final int count = countCursor.getInt(0);
+      Log.w(TAG, "got count " + count + " -> " + (System.currentTimeMillis() - start) + "ms");
+      return count;
+    } finally {
+      if (countCursor != null) countCursor.close();
+    }
+  }
+
+  private String buildWindowedQuery(final int limit, final int offset) {
+    return query + " LIMIT " + limit + " OFFSET " + offset;
+  }
+
+  private void updateCursor(int position) {
+    if (position < 0 || (count > 0 && position >= count)) return;
+
+    final int    offset       = position - (position % windowSize);
+    final Cursor loadedCursor = loadedCursors.get(offset);
+    if (loadedCursor != null) {
+      current = loadedCursor;
+      loadedCursors.remove(offset);
+      loadedCursors.put(offset, loadedCursor);
+    } else {
+      @SuppressLint("Recycle")
+      Cursor cursor = db.rawQuery(buildWindowedQuery(windowSize, offset), null);
+      if (notificationUri != null) cursor.setNotificationUri(contentResolver, notificationUri);
+      if (dataSetObserver != null) cursor.registerDataSetObserver(dataSetObserver);
+      if (contentObserver != null) cursor.registerContentObserver(contentObserver);
+      loadedCursors.put(offset, cursor);
+      current = cursor;
+      Log.w(TAG, "loaded new cursor for offset " + offset + ", holding " + loadedCursors.size() + " open cursors.");
+    }
+  }
+
+  private boolean setPosition(int position) {
+    updateCursor(position);
+    return current.moveToPosition(position % windowSize);
+  }
+
+  @Override public int getCount() {
+    return count;
+  }
+
+  @Override public int getColumnIndex(@NonNull String columnName) {
+    return current.getColumnIndex(columnName);
+  }
+
+  @Override public int getColumnIndexOrThrow(@NonNull String columnName) throws IllegalArgumentException {
+    return current.getColumnIndexOrThrow(columnName);
+  }
+
+  @Override public String getColumnName(int columnIndex) {
+    return current.getColumnName(columnIndex);
+  }
+
+  @Override public String[] getColumnNames() {
+    return current.getColumnNames();
+  }
+
+  @Override public int getColumnCount() {
+    return current.getColumnCount();
+  }
+
+  @Override public byte[] getBlob(int columnIndex) {
+    return current.getBlob(columnIndex);
+  }
+
+  @Override public String getString(int columnIndex) {
+    return current.getString(columnIndex);
+  }
+
+  @Override public short getShort(int columnIndex) {
+    return current.getShort(columnIndex);
+  }
+
+  @Override public int getInt(int columnIndex) {
+    return current.getInt(columnIndex);
+  }
+
+  @Override public long getLong(int columnIndex) {
+    return current.getLong(columnIndex);
+  }
+
+  @Override public float getFloat(int columnIndex) {
+    return current.getFloat(columnIndex);
+  }
+
+  @Override public double getDouble(int columnIndex) {
+    return current.getDouble(columnIndex);
+  }
+
+  @TargetApi(VERSION_CODES.HONEYCOMB)
+  @Override public int getType(int columnIndex) {
+    return current.getType(columnIndex);
+  }
+
+  @Override public boolean isNull(int columnIndex) {
+    return current.isNull(columnIndex);
+  }
+
+  @Override public void close() {
+    current = null;
+    loadedCursors.evictAll();
+  }
+
+  @Override public boolean onMove(int oldPosition, int newPosition) {
+    updateCursor(newPosition);
+    return setPosition(newPosition);
+  }
+
+  @Override public void registerContentObserver(ContentObserver observer) {
+    this.contentObserver = observer;
+    for (Cursor cursor : loadedCursors.snapshot().values()) {
+      cursor.registerContentObserver(observer);
+    }
+  }
+
+  @Override public void unregisterContentObserver(ContentObserver observer) {
+    this.contentObserver = null;
+    for (Cursor cursor : loadedCursors.snapshot().values()) {
+      cursor.unregisterContentObserver(observer);
+    }
+  }
+
+  @Override public void registerDataSetObserver(DataSetObserver observer) {
+    this.dataSetObserver = observer;
+    for (Cursor cursor : loadedCursors.snapshot().values()) {
+      cursor.registerDataSetObserver(observer);
+    }
+  }
+
+  @Override public void unregisterDataSetObserver(DataSetObserver observer) {
+    this.dataSetObserver = null;
+    for (Cursor cursor : loadedCursors.snapshot().values()) {
+      cursor.unregisterDataSetObserver(observer);
+    }
+  }
+
+  @Override public void setNotificationUri(ContentResolver cr, Uri uri) {
+    this.contentResolver = cr;
+    this.notificationUri = uri;
+    for (Cursor cursor : loadedCursors.snapshot().values()) {
+      cursor.setNotificationUri(cr, uri);
+    }
+  }
+
+  @TargetApi(VERSION_CODES.KITKAT)
+  @Override public Uri getNotificationUri() {
+    return notificationUri;
+  }
+
+  private class CursorLruCache extends LruCache<Integer, Cursor> {
+
+    public CursorLruCache(int maxSize) {
+      super(maxSize);
+    }
+
+    @Override protected void entryRemoved(boolean evicted, Integer key, Cursor oldc, Cursor newc) {
+      if (oldc != current && evicted) {
+        Log.w(TAG, "evicting cursor with offset " + key);
+        oldc.close();
+      }
+    }
+  }
+}

--- a/src/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
@@ -28,8 +28,10 @@ import android.util.Log;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.model.MessageRecord;
 import org.whispersystems.libaxolotl.util.guava.Optional;
+import org.thoughtcrime.securesms.util.LRUCache;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 public class MmsSmsDatabase extends Database {
@@ -38,29 +40,90 @@ public class MmsSmsDatabase extends Database {
   public static final String MMS_TRANSPORT = "mms";
   public static final String SMS_TRANSPORT = "sms";
 
+  private final Map<Long, String> queryCache = new LRUCache<>(100);
+
+  private static final String[] CONVERSATION_PROJECTION = {MmsSmsColumns.ID, SmsDatabase.BODY, SmsDatabase.TYPE,
+                                                           MmsSmsColumns.THREAD_ID,
+                                                           SmsDatabase.ADDRESS, SmsDatabase.ADDRESS_DEVICE_ID, SmsDatabase.SUBJECT,
+                                                           MmsSmsColumns.NORMALIZED_DATE_SENT,
+                                                           MmsSmsColumns.NORMALIZED_DATE_RECEIVED,
+                                                           MmsDatabase.MESSAGE_TYPE, MmsDatabase.MESSAGE_BOX,
+                                                           SmsDatabase.STATUS, MmsDatabase.PART_COUNT,
+                                                           MmsDatabase.CONTENT_LOCATION, MmsDatabase.TRANSACTION_ID,
+                                                           MmsDatabase.MESSAGE_SIZE, MmsDatabase.EXPIRY,
+                                                           MmsDatabase.STATUS, MmsSmsColumns.RECEIPT_COUNT,
+                                                           MmsSmsColumns.MISMATCHED_IDENTITIES,
+                                                           MmsDatabase.NETWORK_FAILURE, TRANSPORT};
+  private static final String[] MMS_PROJECTION = {MmsDatabase.DATE_SENT + " * 1000 AS " + MmsSmsColumns.NORMALIZED_DATE_SENT,
+                                                  MmsDatabase.DATE_RECEIVED + " * 1000 AS " + MmsSmsColumns.NORMALIZED_DATE_RECEIVED,
+                                                  MmsSmsColumns.ID, SmsDatabase.BODY, MmsSmsColumns.READ, MmsSmsColumns.THREAD_ID,
+                                                  SmsDatabase.TYPE, SmsDatabase.ADDRESS, SmsDatabase.ADDRESS_DEVICE_ID, SmsDatabase.SUBJECT, MmsDatabase.MESSAGE_TYPE,
+                                                  MmsDatabase.MESSAGE_BOX, SmsDatabase.STATUS, MmsDatabase.PART_COUNT,
+                                                  MmsDatabase.CONTENT_LOCATION, MmsDatabase.TRANSACTION_ID,
+                                                  MmsDatabase.MESSAGE_SIZE, MmsDatabase.EXPIRY, MmsDatabase.STATUS,
+                                                  MmsSmsColumns.RECEIPT_COUNT, MmsSmsColumns.MISMATCHED_IDENTITIES,
+                                                  MmsDatabase.NETWORK_FAILURE, TRANSPORT};
+  private static final String[] SMS_PROJECTION = {SmsDatabase.DATE_SENT + " * 1 AS " + MmsSmsColumns.NORMALIZED_DATE_SENT,
+                                                  SmsDatabase.DATE_RECEIVED + " * 1 AS " + MmsSmsColumns.NORMALIZED_DATE_RECEIVED,
+                                                  MmsSmsColumns.ID, SmsDatabase.BODY, MmsSmsColumns.READ, MmsSmsColumns.THREAD_ID,
+                                                  SmsDatabase.TYPE, SmsDatabase.ADDRESS, SmsDatabase.ADDRESS_DEVICE_ID, SmsDatabase.SUBJECT, MmsDatabase.MESSAGE_TYPE,
+                                                  MmsDatabase.MESSAGE_BOX, SmsDatabase.STATUS, MmsDatabase.PART_COUNT,
+                                                  MmsDatabase.CONTENT_LOCATION, MmsDatabase.TRANSACTION_ID,
+                                                  MmsDatabase.MESSAGE_SIZE, MmsDatabase.EXPIRY, MmsDatabase.STATUS,
+                                                  MmsSmsColumns.RECEIPT_COUNT, MmsSmsColumns.MISMATCHED_IDENTITIES,
+                                                  MmsDatabase.NETWORK_FAILURE, TRANSPORT};
+  private static final String CONVERSATION_ORDER = MmsSmsColumns.NORMALIZED_DATE_RECEIVED + " ASC";
+  private static final Set<String> MMS_COLUMNS_PRESENT = new HashSet<String>() {{
+    add(MmsSmsColumns.ID);
+    add(MmsSmsColumns.READ);
+    add(MmsSmsColumns.THREAD_ID);
+    add(MmsSmsColumns.BODY);
+    add(MmsSmsColumns.ADDRESS);
+    add(MmsSmsColumns.ADDRESS_DEVICE_ID);
+    add(MmsSmsColumns.RECEIPT_COUNT);
+    add(MmsSmsColumns.MISMATCHED_IDENTITIES);
+    add(MmsDatabase.MESSAGE_TYPE);
+    add(MmsDatabase.MESSAGE_BOX);
+    add(MmsDatabase.DATE_SENT);
+    add(MmsDatabase.DATE_RECEIVED);
+    add(MmsDatabase.PART_COUNT);
+    add(MmsDatabase.CONTENT_LOCATION);
+    add(MmsDatabase.TRANSACTION_ID);
+    add(MmsDatabase.MESSAGE_SIZE);
+    add(MmsDatabase.EXPIRY);
+    add(MmsDatabase.STATUS);
+    add(MmsDatabase.NETWORK_FAILURE);
+  }};
+  private static final Set<String> SMS_COLUMNS_PRESENT = new HashSet<String>() {{
+    add(MmsSmsColumns.ID);
+    add(MmsSmsColumns.BODY);
+    add(MmsSmsColumns.ADDRESS);
+    add(MmsSmsColumns.ADDRESS_DEVICE_ID);
+    add(MmsSmsColumns.READ);
+    add(MmsSmsColumns.THREAD_ID);
+    add(MmsSmsColumns.RECEIPT_COUNT);
+    add(MmsSmsColumns.MISMATCHED_IDENTITIES);
+    add(SmsDatabase.TYPE);
+    add(SmsDatabase.SUBJECT);
+    add(SmsDatabase.DATE_SENT);
+    add(SmsDatabase.DATE_RECEIVED);
+    add(SmsDatabase.STATUS);
+  }};
+
   public MmsSmsDatabase(Context context, SQLiteOpenHelper databaseHelper) {
     super(context, databaseHelper);
   }
 
   public Cursor getConversation(long threadId) {
-    String[] projection    = {MmsSmsColumns.ID, SmsDatabase.BODY, SmsDatabase.TYPE,
-                              MmsSmsColumns.THREAD_ID,
-                              SmsDatabase.ADDRESS, SmsDatabase.ADDRESS_DEVICE_ID, SmsDatabase.SUBJECT,
-                              MmsSmsColumns.NORMALIZED_DATE_SENT,
-                              MmsSmsColumns.NORMALIZED_DATE_RECEIVED,
-                              MmsDatabase.MESSAGE_TYPE, MmsDatabase.MESSAGE_BOX,
-                              SmsDatabase.STATUS, MmsDatabase.PART_COUNT,
-                              MmsDatabase.CONTENT_LOCATION, MmsDatabase.TRANSACTION_ID,
-                              MmsDatabase.MESSAGE_SIZE, MmsDatabase.EXPIRY,
-                              MmsDatabase.STATUS, MmsSmsColumns.RECEIPT_COUNT,
-                              MmsSmsColumns.MISMATCHED_IDENTITIES,
-                              MmsDatabase.NETWORK_FAILURE, TRANSPORT};
-
-    String order           = MmsSmsColumns.NORMALIZED_DATE_RECEIVED + " ASC";
-
-    String selection       = MmsSmsColumns.THREAD_ID + " = " + threadId;
-
-    Cursor cursor = queryTables(projection, selection, selection, order, null, null);
+    final String selection = MmsSmsColumns.THREAD_ID + " = " + threadId;
+    final String query;
+    if (queryCache.containsKey(threadId)) {
+      query = queryCache.get(threadId);
+    } else {
+      query = getQuery(CONVERSATION_PROJECTION, selection, selection, CONVERSATION_ORDER, null, null);
+      queryCache.put(threadId, query);
+    }
+    final Cursor cursor = largeQuery(query);
     setNotifyConverationListeners(cursor, threadId);
 
     return cursor;
@@ -142,75 +205,34 @@ public class MmsSmsDatabase extends Database {
     DatabaseFactory.getMmsDatabase(context).incrementDeliveryReceiptCount(address, timestamp);
   }
 
+  private Cursor largeQuery(final String query) {
+    SQLiteDatabase db = databaseHelper.getReadableDatabase();
+    Log.w("MmsSmsDatabase", query);
+    return new LargeSQLiteCursor(db, query, 500);
+  }
+
+  private Cursor rawQuery(final String query) {
+    SQLiteDatabase db = databaseHelper.getReadableDatabase();
+    Log.w("MmsSmsDatabase", query);
+    return db.rawQuery(query, null);
+  }
+
   private Cursor queryTables(String[] projection, String smsSelection, String mmsSelection, String order, String groupBy, String limit) {
-    String[] mmsProjection = {MmsDatabase.DATE_SENT + " AS " + MmsSmsColumns.NORMALIZED_DATE_SENT,
-                              MmsDatabase.DATE_RECEIVED + " AS " + MmsSmsColumns.NORMALIZED_DATE_RECEIVED,
-                              MmsSmsColumns.ID, SmsDatabase.BODY, MmsSmsColumns.READ, MmsSmsColumns.THREAD_ID,
-                              SmsDatabase.TYPE, SmsDatabase.ADDRESS, SmsDatabase.ADDRESS_DEVICE_ID, SmsDatabase.SUBJECT, MmsDatabase.MESSAGE_TYPE,
-                              MmsDatabase.MESSAGE_BOX, SmsDatabase.STATUS, MmsDatabase.PART_COUNT,
-                              MmsDatabase.CONTENT_LOCATION, MmsDatabase.TRANSACTION_ID,
-                              MmsDatabase.MESSAGE_SIZE, MmsDatabase.EXPIRY, MmsDatabase.STATUS,
-                              MmsSmsColumns.RECEIPT_COUNT, MmsSmsColumns.MISMATCHED_IDENTITIES,
-                              MmsDatabase.NETWORK_FAILURE, TRANSPORT};
+    return rawQuery(getQuery(projection, smsSelection, mmsSelection, order, groupBy, limit));
+  }
 
-    String[] smsProjection = {SmsDatabase.DATE_SENT + " AS " + MmsSmsColumns.NORMALIZED_DATE_SENT,
-                              SmsDatabase.DATE_RECEIVED + " AS " + MmsSmsColumns.NORMALIZED_DATE_RECEIVED,
-                              MmsSmsColumns.ID, SmsDatabase.BODY, MmsSmsColumns.READ, MmsSmsColumns.THREAD_ID,
-                              SmsDatabase.TYPE, SmsDatabase.ADDRESS, SmsDatabase.ADDRESS_DEVICE_ID, SmsDatabase.SUBJECT, MmsDatabase.MESSAGE_TYPE,
-                              MmsDatabase.MESSAGE_BOX, SmsDatabase.STATUS, MmsDatabase.PART_COUNT,
-                              MmsDatabase.CONTENT_LOCATION, MmsDatabase.TRANSACTION_ID,
-                              MmsDatabase.MESSAGE_SIZE, MmsDatabase.EXPIRY, MmsDatabase.STATUS,
-                              MmsSmsColumns.RECEIPT_COUNT, MmsSmsColumns.MISMATCHED_IDENTITIES,
-                              MmsDatabase.NETWORK_FAILURE, TRANSPORT};
-
-
+  private String getQuery(String[] projection, String smsSelection, String mmsSelection, String order, String groupBy, String limit) {
     SQLiteQueryBuilder mmsQueryBuilder = new SQLiteQueryBuilder();
     SQLiteQueryBuilder smsQueryBuilder = new SQLiteQueryBuilder();
 
-    mmsQueryBuilder.setDistinct(true);
-    smsQueryBuilder.setDistinct(true);
+    mmsQueryBuilder.setDistinct(false);
+    smsQueryBuilder.setDistinct(false);
 
     mmsQueryBuilder.setTables(MmsDatabase.TABLE_NAME);
     smsQueryBuilder.setTables(SmsDatabase.TABLE_NAME);
 
-    Set<String> mmsColumnsPresent = new HashSet<String>();
-    mmsColumnsPresent.add(MmsSmsColumns.ID);
-    mmsColumnsPresent.add(MmsSmsColumns.READ);
-    mmsColumnsPresent.add(MmsSmsColumns.THREAD_ID);
-    mmsColumnsPresent.add(MmsSmsColumns.BODY);
-    mmsColumnsPresent.add(MmsSmsColumns.ADDRESS);
-    mmsColumnsPresent.add(MmsSmsColumns.ADDRESS_DEVICE_ID);
-    mmsColumnsPresent.add(MmsSmsColumns.RECEIPT_COUNT);
-    mmsColumnsPresent.add(MmsSmsColumns.MISMATCHED_IDENTITIES);
-    mmsColumnsPresent.add(MmsDatabase.MESSAGE_TYPE);
-    mmsColumnsPresent.add(MmsDatabase.MESSAGE_BOX);
-    mmsColumnsPresent.add(MmsDatabase.DATE_SENT);
-    mmsColumnsPresent.add(MmsDatabase.DATE_RECEIVED);
-    mmsColumnsPresent.add(MmsDatabase.PART_COUNT);
-    mmsColumnsPresent.add(MmsDatabase.CONTENT_LOCATION);
-    mmsColumnsPresent.add(MmsDatabase.TRANSACTION_ID);
-    mmsColumnsPresent.add(MmsDatabase.MESSAGE_SIZE);
-    mmsColumnsPresent.add(MmsDatabase.EXPIRY);
-    mmsColumnsPresent.add(MmsDatabase.STATUS);
-    mmsColumnsPresent.add(MmsDatabase.NETWORK_FAILURE);
-
-    Set<String> smsColumnsPresent = new HashSet<String>();
-    smsColumnsPresent.add(MmsSmsColumns.ID);
-    smsColumnsPresent.add(MmsSmsColumns.BODY);
-    smsColumnsPresent.add(MmsSmsColumns.ADDRESS);
-    smsColumnsPresent.add(MmsSmsColumns.ADDRESS_DEVICE_ID);
-    smsColumnsPresent.add(MmsSmsColumns.READ);
-    smsColumnsPresent.add(MmsSmsColumns.THREAD_ID);
-    smsColumnsPresent.add(MmsSmsColumns.RECEIPT_COUNT);
-    smsColumnsPresent.add(MmsSmsColumns.MISMATCHED_IDENTITIES);
-    smsColumnsPresent.add(SmsDatabase.TYPE);
-    smsColumnsPresent.add(SmsDatabase.SUBJECT);
-    smsColumnsPresent.add(SmsDatabase.DATE_SENT);
-    smsColumnsPresent.add(SmsDatabase.DATE_RECEIVED);
-    smsColumnsPresent.add(SmsDatabase.STATUS);
-
-    String mmsSubQuery = mmsQueryBuilder.buildUnionSubQuery(TRANSPORT, mmsProjection, mmsColumnsPresent, 2, MMS_TRANSPORT, mmsSelection, null, null, null);
-    String smsSubQuery = smsQueryBuilder.buildUnionSubQuery(TRANSPORT, smsProjection, smsColumnsPresent, 2, SMS_TRANSPORT, smsSelection, null, null, null);
+    String mmsSubQuery = mmsQueryBuilder.buildUnionSubQuery(TRANSPORT, MMS_PROJECTION, MMS_COLUMNS_PRESENT, 2, MMS_TRANSPORT, mmsSelection, null, null, null);
+    String smsSubQuery = smsQueryBuilder.buildUnionSubQuery(TRANSPORT, SMS_PROJECTION, SMS_COLUMNS_PRESENT, 2, SMS_TRANSPORT, smsSelection, null, null, null);
 
     SQLiteQueryBuilder unionQueryBuilder = new SQLiteQueryBuilder();
     String unionQuery = unionQueryBuilder.buildUnionQuery(new String[] {smsSubQuery, mmsSubQuery}, order, null);
@@ -218,11 +240,7 @@ public class MmsSmsDatabase extends Database {
     SQLiteQueryBuilder outerQueryBuilder = new SQLiteQueryBuilder();
     outerQueryBuilder.setTables("(" + unionQuery + ")");
 
-    String query      = outerQueryBuilder.buildQuery(projection, null, null, groupBy, null, null, limit);
-
-    Log.w("MmsSmsDatabase", "Executing query: " + query);
-    SQLiteDatabase db = databaseHelper.getReadableDatabase();
-    return db.rawQuery(query, null);
+    return outerQueryBuilder.buildQuery(projection, null, null, groupBy, null, null, limit);
   }
 
   public Reader readerFor(@NonNull Cursor cursor, @Nullable MasterSecret masterSecret) {

--- a/src/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
@@ -54,8 +54,8 @@ public class MmsSmsDatabase extends Database {
                                                            MmsDatabase.STATUS, MmsSmsColumns.RECEIPT_COUNT,
                                                            MmsSmsColumns.MISMATCHED_IDENTITIES,
                                                            MmsDatabase.NETWORK_FAILURE, TRANSPORT};
-  private static final String[] MMS_PROJECTION = {MmsDatabase.DATE_SENT + " * 1000 AS " + MmsSmsColumns.NORMALIZED_DATE_SENT,
-                                                  MmsDatabase.DATE_RECEIVED + " * 1000 AS " + MmsSmsColumns.NORMALIZED_DATE_RECEIVED,
+  private static final String[] MMS_PROJECTION = {MmsDatabase.DATE_SENT + " AS " + MmsSmsColumns.NORMALIZED_DATE_SENT,
+                                                  MmsDatabase.DATE_RECEIVED + " AS " + MmsSmsColumns.NORMALIZED_DATE_RECEIVED,
                                                   MmsSmsColumns.ID, SmsDatabase.BODY, MmsSmsColumns.READ, MmsSmsColumns.THREAD_ID,
                                                   SmsDatabase.TYPE, SmsDatabase.ADDRESS, SmsDatabase.ADDRESS_DEVICE_ID, SmsDatabase.SUBJECT, MmsDatabase.MESSAGE_TYPE,
                                                   MmsDatabase.MESSAGE_BOX, SmsDatabase.STATUS, MmsDatabase.PART_COUNT,
@@ -63,8 +63,8 @@ public class MmsSmsDatabase extends Database {
                                                   MmsDatabase.MESSAGE_SIZE, MmsDatabase.EXPIRY, MmsDatabase.STATUS,
                                                   MmsSmsColumns.RECEIPT_COUNT, MmsSmsColumns.MISMATCHED_IDENTITIES,
                                                   MmsDatabase.NETWORK_FAILURE, TRANSPORT};
-  private static final String[] SMS_PROJECTION = {SmsDatabase.DATE_SENT + " * 1 AS " + MmsSmsColumns.NORMALIZED_DATE_SENT,
-                                                  SmsDatabase.DATE_RECEIVED + " * 1 AS " + MmsSmsColumns.NORMALIZED_DATE_RECEIVED,
+  private static final String[] SMS_PROJECTION = {SmsDatabase.DATE_SENT + " AS " + MmsSmsColumns.NORMALIZED_DATE_SENT,
+                                                  SmsDatabase.DATE_RECEIVED + " AS " + MmsSmsColumns.NORMALIZED_DATE_RECEIVED,
                                                   MmsSmsColumns.ID, SmsDatabase.BODY, MmsSmsColumns.READ, MmsSmsColumns.THREAD_ID,
                                                   SmsDatabase.TYPE, SmsDatabase.ADDRESS, SmsDatabase.ADDRESS_DEVICE_ID, SmsDatabase.SUBJECT, MmsDatabase.MESSAGE_TYPE,
                                                   MmsDatabase.MESSAGE_BOX, SmsDatabase.STATUS, MmsDatabase.PART_COUNT,

--- a/test/unitTest/java/org/thoughtcrime/securesms/BaseUnitTest.java
+++ b/test/unitTest/java/org/thoughtcrime/securesms/BaseUnitTest.java
@@ -1,0 +1,44 @@
+package org.thoughtcrime.securesms;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.mockito.Matchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest( { Log.class, Handler.class, Looper.class })
+public abstract class BaseUnitTest {
+  @Before
+  public void setUp() throws Exception {
+    mockStatic(Looper.class);
+    mockStatic(Log.class);
+    mockStatic(Handler.class);
+
+    PowerMockito.when(Looper.getMainLooper()).thenReturn(null);
+    PowerMockito.whenNew(Handler.class).withAnyArguments().thenReturn(null);
+
+    Answer<?> logAnswer = new Answer<Void>() {
+      @Override public Void answer(InvocationOnMock invocation) throws Throwable {
+        final String tag = (String)invocation.getArguments()[0];
+        final String msg = (String)invocation.getArguments()[1];
+        System.out.println(invocation.getMethod().getName().toUpperCase() + "/[" + tag + "] " + msg);
+        return null;
+      }
+    };
+    PowerMockito.doAnswer(logAnswer).when(Log.class, "d", anyString(), anyString());
+    PowerMockito.doAnswer(logAnswer).when(Log.class, "i", anyString(), anyString());
+    PowerMockito.doAnswer(logAnswer).when(Log.class, "w", anyString(), anyString());
+    PowerMockito.doAnswer(logAnswer).when(Log.class, "e", anyString(), anyString());
+    PowerMockito.doAnswer(logAnswer).when(Log.class, "wtf", anyString(), anyString());
+  }
+}

--- a/test/unitTest/java/org/thoughtcrime/securesms/database/LargeSQLiteCursorTest.java
+++ b/test/unitTest/java/org/thoughtcrime/securesms/database/LargeSQLiteCursorTest.java
@@ -1,0 +1,94 @@
+package org.thoughtcrime.securesms.database;
+
+import android.database.AbstractCursor;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.thoughtcrime.securesms.BaseUnitTest;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+public class LargeSQLiteCursorTest extends BaseUnitTest {
+  @Test public void testSingleCursor() throws Exception {
+    LargeSQLiteCursor cursor = new LargeSQLiteCursor(getMockDatabase(1), "select whatever from wherever where something is something else", 1);
+    assertThat(cursor.onMove(-1, 0)).isTrue();
+    assertThat(cursor.getString(0)).isEqualTo("0");
+  }
+
+  @Test public void testMultipleCursors() throws Exception {
+    LargeSQLiteCursor cursor = new LargeSQLiteCursor(getMockDatabase(50), "select whatever from wherever where something is something else", 10);
+    assertThat(cursor.onMove(-1, 0)).isTrue();
+    assertThat(cursor.getString(0)).isEqualTo("0");
+
+    assertThat(cursor.onMove(0, 14)).isTrue();
+    assertThat(cursor.getString(0)).isEqualTo("10");
+
+    assertThat(cursor.onMove(14, 5)).isTrue();
+    assertThat(cursor.getString(0)).isEqualTo("0");
+
+    assertThat(cursor.onMove(5, 49)).isTrue();
+    assertThat(cursor.getString(0)).isEqualTo("40");
+
+    assertThat(cursor.onMove(49, 50)).isFalse();
+  }
+
+  @Test public void testCursorEviction() throws Exception {
+    LargeSQLiteCursor cursor = new LargeSQLiteCursor(getMockDatabase(100), "select whatever from wherever where something is something else", 10);
+    assertThat(cursor.onMove(-1, 0)).isTrue();
+    assertThat(cursor.getLoadedCursors().evictionCount()).isEqualTo(0);
+    assertThat(cursor.onMove(0, 10)).isTrue();
+    assertThat(cursor.onMove(10, 20)).isTrue();
+    assertThat(cursor.onMove(20, 30)).isTrue();
+    assertThat(cursor.onMove(30, 40)).isTrue();
+    assertThat(cursor.getLoadedCursors().evictionCount()).isEqualTo(1);
+    assertThat(cursor.onMove(40, 50)).isTrue();
+    assertThat(cursor.getLoadedCursors().evictionCount()).isEqualTo(2);
+    assertThat(cursor.onMove(50, 30)).isTrue();
+    assertThat(cursor.getLoadedCursors().evictionCount()).isEqualTo(2);
+    assertThat(cursor.onMove(30, 60)).isTrue();
+    assertThat(cursor.getLoadedCursors().evictionCount()).isEqualTo(3);
+    assertThat(cursor.onMove(60, 70)).isTrue();
+    assertThat(cursor.getLoadedCursors().evictionCount()).isEqualTo(4);
+    assertThat(cursor.onMove(70, 1)).isTrue();
+    assertThat(cursor.getLoadedCursors().evictionCount()).isEqualTo(5);
+  }
+
+  private Cursor getMockCountCursor(int count) {
+    Cursor cursor = mock(AbstractCursor.class);
+    when(cursor.moveToFirst()).thenReturn(true);
+    when(cursor.getInt(0)).thenReturn(count);
+    return cursor;
+  }
+
+  private Cursor getMockWindowCursor(String firstColumn) {
+    Cursor cursor = mock(AbstractCursor.class);
+    when(cursor.moveToPosition(anyInt())).thenReturn(true);
+    when(cursor.getString(eq(0))).thenReturn(firstColumn);
+    return cursor;
+  }
+
+  private SQLiteDatabase getMockDatabase(int count) {
+    SQLiteDatabase mockDb = mock(SQLiteDatabase.class);
+    Cursor countCursor = getMockCountCursor(count);
+    when(mockDb.rawQuery(startsWith("SELECT COUNT"), (String[])isNull())).thenReturn(countCursor);
+    when(mockDb.rawQuery(matches(".*LIMIT \\d+ OFFSET \\d+.*"), (String[])isNull())).thenAnswer(new Answer<Cursor>() {
+      @Override public Cursor answer(InvocationOnMock invocation) throws Throwable {
+        String query = (String)invocation.getArguments()[0];
+        Matcher matcher = Pattern.compile("OFFSET (\\d+)").matcher(query);
+        if (matcher.find()) {
+          return getMockWindowCursor(matcher.group(1));
+        }
+        return null;
+      }
+    });
+    return mockDb;
+  }
+}

--- a/test/unitTest/java/org/thoughtcrime/securesms/util/ListPartitionTest.java
+++ b/test/unitTest/java/org/thoughtcrime/securesms/util/ListPartitionTest.java
@@ -1,13 +1,14 @@
 package org.thoughtcrime.securesms.util;
 
 import org.junit.Test;
+import org.thoughtcrime.securesms.BaseUnitTest;
 
 import java.util.LinkedList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
-public class ListPartitionTest {
+public class ListPartitionTest extends BaseUnitTest {
 
   @Test public void testPartitionEven() {
     List<Integer> list = new LinkedList<>();

--- a/test/unitTest/java/org/thoughtcrime/securesms/util/Rfc5724UriTest.java
+++ b/test/unitTest/java/org/thoughtcrime/securesms/util/Rfc5724UriTest.java
@@ -22,12 +22,13 @@ import android.util.Log;
 import junit.framework.AssertionFailedError;
 
 import org.junit.Test;
+import org.thoughtcrime.securesms.BaseUnitTest;
 
 import java.net.URISyntaxException;
 
 import static org.junit.Assert.assertTrue;
 
-public class Rfc5724UriTest {
+public class Rfc5724UriTest extends BaseUnitTest {
 
   private static final String TAG = Rfc5724UriTest.class.getSimpleName();
 

--- a/test/unitTest/java/org/thoughtcrime/securesms/util/Rfc5724UriTest.java
+++ b/test/unitTest/java/org/thoughtcrime/securesms/util/Rfc5724UriTest.java
@@ -17,8 +17,6 @@
 
 package org.thoughtcrime.securesms.util;
 
-import android.util.Log;
-
 import junit.framework.AssertionFailedError;
 
 import org.junit.Test;
@@ -29,8 +27,6 @@ import java.net.URISyntaxException;
 import static org.junit.Assert.assertTrue;
 
 public class Rfc5724UriTest extends BaseUnitTest {
-
-  private static final String TAG = Rfc5724UriTest.class.getSimpleName();
 
   @Test public void testInvalidPath() throws Exception {
     final String[] invalidSchemaUris = {
@@ -102,7 +98,6 @@ public class Rfc5724UriTest extends BaseUnitTest {
       final Rfc5724Uri testUri     = new Rfc5724Uri(uriTestPair[0]);
       final String     paramResult = testUri.getQueryParams().get(uriTestPair[1]);
 
-      Log.d(TAG, paramResult + " ?= " + uriTestPair[2]);
       if (paramResult == null) assertTrue(uriTestPair[2] == null);
       else                     assertTrue(paramResult.equals(uriTestPair[2]));
     }


### PR DESCRIPTION
* getConversation() uses a LargeSQLiteCursor instance, which breaks up queries into chunks of a given window size. This is set to 500 right now, so a cursor load only happens every 500 messages and is pretty quick.
* refactor MmsSmsDatabase a bit to stop excessive object creation when calling getConversation()
* I don't know why we were calling setDistinct on our union subqueries since I'm unaware of any situation where dupe rows would be an issue, but it's slower so I set it to false. If that's a problem, can switch back.