### PR TITLE
stop conversation list from hogging db

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -155,7 +155,6 @@
     <activity android:name=".ConversationActivity"
               android:windowSoftInputMode="stateUnchanged"
               android:launchMode="singleTask"
-              android:theme="@style/TextSecure.LightTheme.Popup"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize" />
 
     <activity android:name=".ConversationPopupActivity"


### PR DESCRIPTION
is there a reason ConversationActivity was popup themed?

It looks like because the theme makes the activity transparent, onStop is never called so the conversation list is continuing to reload itself even while in the conversation activity. seems to work fine with the default theming.