### PR TITLE
stop sync resolution of recipients on ui thread

### DIFF
--- a/src/org/thoughtcrime/securesms/database/MmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MmsDatabase.java
@@ -1099,13 +1099,13 @@ public class MmsDatabase extends MessagingDatabase {
 
     private Recipients getRecipientsFor(String address) {
       if (TextUtils.isEmpty(address) || address.equals("insert-address-token")) {
-        return RecipientFactory.getRecipientsFor(context, Recipient.getUnknownRecipient(), false);
+        return RecipientFactory.getRecipientsFor(context, Recipient.getUnknownRecipient(), true);
       }
 
-      Recipients recipients =  RecipientFactory.getRecipientsFromString(context, address, false);
+      Recipients recipients =  RecipientFactory.getRecipientsFromString(context, address, true);
 
       if (recipients == null || recipients.isEmpty()) {
-        return RecipientFactory.getRecipientsFor(context, Recipient.getUnknownRecipient(), false);
+        return RecipientFactory.getRecipientsFor(context, Recipient.getUnknownRecipient(), true);
       }
 
       return recipients;

--- a/src/org/thoughtcrime/securesms/database/SmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/SmsDatabase.java
@@ -608,16 +608,16 @@ public class SmsDatabase extends MessagingDatabase {
 
     private Recipients getRecipientsFor(String address) {
       if (address != null) {
-        Recipients recipients = RecipientFactory.getRecipientsFromString(context, address, false);
+        Recipients recipients = RecipientFactory.getRecipientsFromString(context, address, true);
 
         if (recipients == null || recipients.isEmpty()) {
-          return RecipientFactory.getRecipientsFor(context, Recipient.getUnknownRecipient(), false);
+          return RecipientFactory.getRecipientsFor(context, Recipient.getUnknownRecipient(), true);
         }
 
         return recipients;
       } else {
         Log.w(TAG, "getRecipientsFor() address is null");
-        return RecipientFactory.getRecipientsFor(context, Recipient.getUnknownRecipient(), false);
+        return RecipientFactory.getRecipientsFor(context, Recipient.getUnknownRecipient(), true);
       }
     }
 


### PR DESCRIPTION
Reader.getNext() is called by the adapters to get a MessageRecord, so we shouldn't be resolving recipients synchronously there. I didn't see any parts that rely on resolved recipient details when retrieving a MessageRecord.

the slowdown became more prominent now that recipients query the preference DB synchronously as well.