### PR TITLE
Fix notification repeat

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -542,7 +542,7 @@ public class MessageNotifier {
     public void onReceive(Context context, Intent intent) {
       MasterSecret masterSecret  = KeyCachingService.getMasterSecret(context);
       int          reminderCount = intent.getIntExtra("reminder_count", 0);
-      MessageNotifier.updateNotification(context, masterSecret, true, reminderCount + 1);
+      MessageNotifier.updateNotification(context, masterSecret, true, true, reminderCount + 1);
     }
   }
 


### PR DESCRIPTION
by adding an undeniable truth
Until now we use the reminderCount as threadId and afterwards we updateNotification with a repeat count of always 0
