### PR TITLE
glide all day every day

### DIFF
--- a/src/org/thoughtcrime/securesms/database/PartDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/PartDatabase.java
@@ -32,7 +32,6 @@ import org.thoughtcrime.securesms.crypto.EncryptingPartOutputStream;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.crypto.MasterSecretUnion;
 import org.thoughtcrime.securesms.mms.PartAuthority;
-import org.thoughtcrime.securesms.util.BitmapDecodingException;
 import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.MediaUtil.ThumbnailData;
 import org.thoughtcrime.securesms.util.Util;
@@ -608,16 +607,12 @@ public class PartDatabase extends Database {
         return stream;
       }
 
-      try {
-        PduPart part = getPart(partId);
-        ThumbnailData data = MediaUtil.generateThumbnail(context, masterSecret, part.getDataUri(), Util.toIsoString(part.getContentType()));
-        if (data == null) {
-          return null;
-        }
-        updatePartThumbnail(masterSecret, partId, part, data.toDataStream(), data.getAspectRatio());
-      } catch (BitmapDecodingException bde) {
-        throw new IOException(bde);
+      PduPart part = getPart(partId);
+      ThumbnailData data = MediaUtil.generateThumbnail(context, masterSecret, part.getDataUri(), Util.toIsoString(part.getContentType()));
+      if (data == null) {
+        return null;
       }
+      updatePartThumbnail(masterSecret, partId, part, data.toDataStream(), data.getAspectRatio());
 
       return getDataStream(masterSecret, partId, THUMBNAIL);
     }
@@ -661,7 +656,6 @@ public class PartDatabase extends Database {
 
       if (rowId != partId.rowId) return false;
       return uniqueId == partId.uniqueId;
-
     }
 
     @Override public int hashCode() {

--- a/src/org/thoughtcrime/securesms/mms/AttachmentStreamLocalUriFetcher.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentStreamLocalUriFetcher.java
@@ -1,0 +1,52 @@
+package org.thoughtcrime.securesms.mms;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.net.Uri;
+import android.util.Log;
+
+import com.bumptech.glide.Priority;
+import com.bumptech.glide.load.data.DataFetcher;
+import com.bumptech.glide.load.data.StreamLocalUriFetcher;
+
+import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.whispersystems.textsecure.api.crypto.AttachmentCipherInputStream;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class AttachmentStreamLocalUriFetcher implements DataFetcher<InputStream> {
+  private static final String TAG = AttachmentStreamLocalUriFetcher.class.getSimpleName();
+  private File        attachment;
+  private byte[]      key;
+  private InputStream is;
+
+  public AttachmentStreamLocalUriFetcher(File attachment, byte[] key) {
+    this.attachment = attachment;
+    this.key        = key;
+  }
+
+  @Override public InputStream loadData(Priority priority) throws Exception {
+    is = new AttachmentCipherInputStream(attachment, key);
+    return is;
+  }
+
+  @Override public void cleanup() {
+    try {
+      if (is != null) is.close();
+      is = null;
+    } catch (IOException ioe) {
+      Log.w(TAG, "ioe");
+    }
+  }
+
+  @Override public String getId() {
+    return AttachmentStreamLocalUriFetcher.class.getCanonicalName() + "::" + attachment.getAbsolutePath();
+  }
+
+  @Override public void cancel() {
+
+  }
+}

--- a/src/org/thoughtcrime/securesms/mms/AttachmentStreamUriLoader.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentStreamUriLoader.java
@@ -1,0 +1,63 @@
+package org.thoughtcrime.securesms.mms;
+
+import android.content.Context;
+import android.net.Uri;
+
+import com.bumptech.glide.load.data.DataFetcher;
+import com.bumptech.glide.load.model.GenericLoaderFactory;
+import com.bumptech.glide.load.model.ModelLoader;
+import com.bumptech.glide.load.model.ModelLoaderFactory;
+import com.bumptech.glide.load.model.stream.StreamModelLoader;
+
+import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.mms.AttachmentStreamUriLoader.AttachmentModel;
+import org.thoughtcrime.securesms.mms.DecryptableStreamUriLoader.DecryptableUri;
+import org.thoughtcrime.securesms.util.SaveAttachmentTask.Attachment;
+
+import java.io.File;
+import java.io.InputStream;
+
+/**
+ * A {@link ModelLoader} for translating uri models into {@link InputStream} data. Capable of handling 'http',
+ * 'https', 'android.resource', 'content', and 'file' schemes. Unsupported schemes will throw an exception in
+ * {@link #getResourceFetcher(Uri, int, int)}.
+ */
+public class AttachmentStreamUriLoader implements StreamModelLoader<AttachmentModel> {
+  private final Context context;
+
+  /**
+   * THe default factory for {@link com.bumptech.glide.load.model.stream.StreamUriLoader}s.
+   */
+  public static class Factory implements ModelLoaderFactory<AttachmentModel, InputStream> {
+
+    @Override
+    public StreamModelLoader<AttachmentModel> build(Context context, GenericLoaderFactory factories) {
+      return new AttachmentStreamUriLoader(context);
+    }
+
+    @Override
+    public void teardown() {
+      // Do nothing.
+    }
+  }
+
+  public AttachmentStreamUriLoader(Context context) {
+    this.context = context;
+  }
+
+  @Override
+  public DataFetcher<InputStream> getResourceFetcher(AttachmentModel model, int width, int height) {
+    return new AttachmentStreamLocalUriFetcher(model.attachment, model.key);
+  }
+
+  public static class AttachmentModel {
+    public File   attachment;
+    public byte[] key;
+
+    public AttachmentModel(File attachment, byte[] key) {
+      this.attachment = attachment;
+      this.key        = key;
+    }
+  }
+}
+

--- a/src/org/thoughtcrime/securesms/mms/ContactPhotoLocalUriFetcher.java
+++ b/src/org/thoughtcrime/securesms/mms/ContactPhotoLocalUriFetcher.java
@@ -1,0 +1,32 @@
+package org.thoughtcrime.securesms.mms;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.net.Uri;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
+import android.provider.ContactsContract;
+
+import com.bumptech.glide.load.data.StreamLocalUriFetcher;
+
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+
+public class ContactPhotoLocalUriFetcher extends StreamLocalUriFetcher {
+  private static final String TAG = ContactPhotoLocalUriFetcher.class.getSimpleName();
+
+  public ContactPhotoLocalUriFetcher(Context context, Uri uri) {
+    super(context, uri);
+  }
+
+  @Override
+  protected InputStream loadResource(Uri uri, ContentResolver contentResolver)
+      throws FileNotFoundException
+  {
+    if (VERSION.SDK_INT >= VERSION_CODES.ICE_CREAM_SANDWICH) {
+      return ContactsContract.Contacts.openContactPhotoInputStream(contentResolver, uri, true);
+    } else {
+      return ContactsContract.Contacts.openContactPhotoInputStream(contentResolver, uri);
+    }
+  }
+}

--- a/src/org/thoughtcrime/securesms/mms/ContactPhotoUriLoader.java
+++ b/src/org/thoughtcrime/securesms/mms/ContactPhotoUriLoader.java
@@ -1,0 +1,51 @@
+package org.thoughtcrime.securesms.mms;
+
+import android.content.Context;
+import android.net.Uri;
+
+import com.bumptech.glide.load.data.DataFetcher;
+import com.bumptech.glide.load.model.GenericLoaderFactory;
+import com.bumptech.glide.load.model.ModelLoaderFactory;
+import com.bumptech.glide.load.model.stream.StreamModelLoader;
+
+import org.thoughtcrime.securesms.mms.ContactPhotoUriLoader.ContactPhotoUri;
+
+import java.io.InputStream;
+
+public class ContactPhotoUriLoader implements StreamModelLoader<ContactPhotoUri> {
+  private final Context context;
+
+  /**
+   * THe default factory for {@link com.bumptech.glide.load.model.stream.StreamUriLoader}s.
+   */
+  public static class Factory implements ModelLoaderFactory<ContactPhotoUri, InputStream> {
+
+    @Override
+    public StreamModelLoader<ContactPhotoUri> build(Context context, GenericLoaderFactory factories) {
+      return new ContactPhotoUriLoader(context);
+    }
+
+    @Override
+    public void teardown() {
+      // Do nothing.
+    }
+  }
+
+  public ContactPhotoUriLoader(Context context) {
+    this.context = context;
+  }
+
+  @Override
+  public DataFetcher<InputStream> getResourceFetcher(ContactPhotoUri model, int width, int height) {
+    return new ContactPhotoLocalUriFetcher(context, model.uri);
+  }
+
+  public static class ContactPhotoUri {
+    public Uri uri;
+
+    public ContactPhotoUri(Uri uri) {
+      this.uri = uri;
+    }
+  }
+}
+

--- a/src/org/thoughtcrime/securesms/mms/MediaConstraints.java
+++ b/src/org/thoughtcrime/securesms/mms/MediaConstraints.java
@@ -1,20 +1,22 @@
 package org.thoughtcrime.securesms.mms;
 
 import android.content.Context;
+import android.graphics.Bitmap.CompressFormat;
 import android.net.Uri;
 import android.util.Log;
 import android.util.Pair;
 
 import com.bumptech.glide.Glide;
-import com.bumptech.glide.gifdecoder.GifDecoder;
 
 import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.mms.DecryptableStreamUriLoader.DecryptableUri;
 import org.thoughtcrime.securesms.util.BitmapDecodingException;
 import org.thoughtcrime.securesms.util.BitmapUtil;
 import org.thoughtcrime.securesms.util.MediaUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.ExecutionException;
 
 import ws.com.google.android.mms.pdu.PduPart;
 
@@ -64,15 +66,10 @@ public abstract class MediaConstraints {
     if (!canResize(part) || part.getDataUri() == null) {
       throw new UnsupportedOperationException("Cannot resize this content type");
     }
-
     try {
-      return BitmapUtil.createScaledBytes(context, masterSecret, part.getDataUri(),
-                                          getImageMaxWidth(context),
-                                          getImageMaxHeight(context),
-                                          getImageMaxSize());
-    } catch (BitmapDecodingException bde) {
-      throw new IOException(bde);
+      return BitmapUtil.createScaledBytes(context, new DecryptableUri(masterSecret, part.getDataUri()), this);
+    } catch (ExecutionException ee) {
+      throw new IOException(ee);
     }
   }
-
 }

--- a/src/org/thoughtcrime/securesms/mms/RoundedCorners.java
+++ b/src/org/thoughtcrime/securesms/mms/RoundedCorners.java
@@ -10,11 +10,12 @@ import android.graphics.RectF;
 import android.graphics.Shader.TileMode;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.util.Log;
 
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
 import com.bumptech.glide.load.resource.bitmap.BitmapTransformation;
 import com.bumptech.glide.load.resource.bitmap.TransformationUtils;
+
+import org.thoughtcrime.securesms.util.ResUtil;
 
 public class RoundedCorners extends BitmapTransformation {
   private final boolean crop;
@@ -26,6 +27,10 @@ public class RoundedCorners extends BitmapTransformation {
     this.crop      = crop;
     this.radius    = radius;
     this.colorHint = colorHint;
+  }
+
+  public RoundedCorners(@NonNull Context context, int radius) {
+    this(context, true, radius, ResUtil.getColor(context, android.R.attr.windowBackground));
   }
 
   @Override protected Bitmap transform(BitmapPool pool, Bitmap toTransform, int outWidth,

--- a/src/org/thoughtcrime/securesms/mms/TextSecureGlideModule.java
+++ b/src/org/thoughtcrime/securesms/mms/TextSecureGlideModule.java
@@ -8,6 +8,8 @@ import com.bumptech.glide.load.engine.cache.DiskCache;
 import com.bumptech.glide.load.engine.cache.DiskCacheAdapter;
 import com.bumptech.glide.module.GlideModule;
 
+import org.thoughtcrime.securesms.mms.AttachmentStreamUriLoader.AttachmentModel;
+import org.thoughtcrime.securesms.mms.ContactPhotoUriLoader.ContactPhotoUri;
 import org.thoughtcrime.securesms.mms.DecryptableStreamUriLoader.DecryptableUri;
 
 import java.io.InputStream;
@@ -21,6 +23,8 @@ public class TextSecureGlideModule implements GlideModule {
   @Override
   public void registerComponents(Context context, Glide glide) {
     glide.register(DecryptableUri.class, InputStream.class, new DecryptableStreamUriLoader.Factory());
+    glide.register(ContactPhotoUri.class, InputStream.class, new ContactPhotoUriLoader.Factory());
+    glide.register(AttachmentModel.class, InputStream.class, new AttachmentStreamUriLoader.Factory());
   }
 
   public static class NoopDiskCacheFactory implements DiskCache.Factory {

--- a/src/org/thoughtcrime/securesms/util/BitmapUtil.java
+++ b/src/org/thoughtcrime/securesms/util/BitmapUtil.java
@@ -3,222 +3,110 @@ package org.thoughtcrime.securesms.util;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.CompressFormat;
-import android.graphics.Bitmap.Config;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
-import android.graphics.Color;
 import android.graphics.ImageFormat;
-import android.graphics.Matrix;
-import android.graphics.Paint;
-import android.graphics.PorterDuff;
-import android.graphics.PorterDuffXfermode;
 import android.graphics.Rect;
-import android.graphics.RectF;
 import android.graphics.YuvImage;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
-import android.net.Uri;
-import android.os.Handler;
-import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.util.Log;
 import android.util.Pair;
 
-import com.android.gallery3d.data.Exif;
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.Priority;
 
-import org.thoughtcrime.securesms.crypto.MasterSecret;
-import org.thoughtcrime.securesms.mms.PartAuthority;
+import org.thoughtcrime.securesms.mms.MediaConstraints;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class BitmapUtil {
   private static final String TAG = BitmapUtil.class.getSimpleName();
 
-  private static final int MAX_COMPRESSION_QUALITY  = 95;
-  private static final int MIN_COMPRESSION_QUALITY  = 50;
+  private static final int MAX_COMPRESSION_QUALITY  = 80;
+  private static final int MIN_COMPRESSION_QUALITY  = 45;
   private static final int MAX_COMPRESSION_ATTEMPTS = 4;
 
-  public static byte[] createScaledBytes(Context context, MasterSecret masterSecret, Uri uri, int maxWidth, int maxHeight, int maxSize)
-      throws IOException, BitmapDecodingException
+  public static <T> byte[] createScaledBytes(Context context, T model, MediaConstraints constraints)
+      throws ExecutionException, IOException
   {
-    Bitmap bitmap;
+    int    quality  = MAX_COMPRESSION_QUALITY;
+    int    attempts = 0;
+    byte[] bytes;
+    Bitmap scaledBitmap = createScaledBitmap(context,
+                                             model,
+                                             constraints.getImageMaxWidth(context),
+                                             constraints.getImageMaxHeight(context));
     try {
-      bitmap = createScaledBitmap(context, masterSecret, uri, maxWidth, maxHeight, false);
-    } catch(OutOfMemoryError oome) {
-      Log.w(TAG, "OutOfMemoryError when scaling precisely, doing rough scale to save memory instead");
-      bitmap = createScaledBitmap(context, masterSecret, uri, maxWidth, maxHeight, true);
-    }
-    int quality         = MAX_COMPRESSION_QUALITY;
-    int attempts        = 0;
+      do {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        scaledBitmap.compress(CompressFormat.JPEG, quality, baos);
+        bytes = baos.toByteArray();
 
-    ByteArrayOutputStream baos;
-
-    do {
-      baos = new ByteArrayOutputStream();
-      bitmap.compress(Bitmap.CompressFormat.JPEG, quality, baos);
-
-      quality = Math.max((quality * maxSize) / baos.size(), MIN_COMPRESSION_QUALITY);
-    } while (baos.size() > maxSize && attempts++ < MAX_COMPRESSION_ATTEMPTS);
-
-    Log.w(TAG, "createScaledBytes(" + uri + ") -> quality " + Math.min(quality, MAX_COMPRESSION_QUALITY) + ", " + attempts + " attempt(s)");
-
-    bitmap.recycle();
-
-    if (baos.size() <= maxSize) return baos.toByteArray();
-    else                        throw new IOException("Unable to scale image below: " + baos.size());
-  }
-
-  public static Bitmap createScaledBitmap(Context context, MasterSecret masterSecret, Uri uri, int maxWidth, int maxHeight)
-      throws BitmapDecodingException, IOException
-  {
-    Bitmap bitmap;
-    try {
-      bitmap = createScaledBitmap(context, masterSecret, uri, maxWidth, maxHeight, false);
-    } catch(OutOfMemoryError oome) {
-      Log.w(TAG, "OutOfMemoryError when scaling precisely, doing rough scale to save memory instead");
-      bitmap = createScaledBitmap(context, masterSecret, uri, maxWidth, maxHeight, true);
-    }
-
-    return bitmap;
-  }
-
-  private static Bitmap createScaledBitmap(Context context, MasterSecret masterSecret, Uri uri, int maxWidth, int maxHeight, boolean constrainedMemory)
-      throws IOException, BitmapDecodingException
-  {
-    InputStream is = PartAuthority.getPartStream(context, masterSecret, uri);
-    if (is == null) throw new IOException("Couldn't obtain InputStream");
-    return createScaledBitmap(is,
-                              PartAuthority.getPartStream(context, masterSecret, uri),
-                              PartAuthority.getPartStream(context, masterSecret, uri),
-                              maxWidth, maxHeight, constrainedMemory);
-  }
-
-  private static Bitmap createScaledBitmap(InputStream measure, InputStream orientationStream, InputStream data,
-                                           int maxWidth, int maxHeight, boolean constrainedMemory)
-      throws IOException, BitmapDecodingException
-  {
-    Bitmap bitmap = createScaledBitmap(measure, data, maxWidth, maxHeight, constrainedMemory);
-    return fixOrientation(bitmap, orientationStream);
-  }
-
-  private static Bitmap createScaledBitmap(InputStream measure, InputStream data, int maxWidth, int maxHeight,
-                                           boolean constrainedMemory)
-      throws BitmapDecodingException
-  {
-    final BitmapFactory.Options options = getImageDimensions(measure);
-    return createScaledBitmap(data, maxWidth, maxHeight, options, constrainedMemory);
-  }
-
-  public static Bitmap createScaledBitmap(InputStream measure, InputStream data, float scale)
-      throws BitmapDecodingException
-  {
-    final BitmapFactory.Options options = getImageDimensions(measure);
-    final int outWidth = (int)(options.outWidth * scale);
-    final int outHeight = (int)(options.outHeight * scale);
-    Log.w(TAG, "creating scaled bitmap with scale " + scale + " => " + outWidth + "x" + outHeight);
-    return createScaledBitmap(data, outWidth, outHeight, options, false);
-  }
-
-  public static Bitmap createScaledBitmap(InputStream measure, InputStream data, int maxWidth, int maxHeight)
-      throws BitmapDecodingException
-  {
-    return createScaledBitmap(measure, data, maxWidth, maxHeight, false);
-  }
-
-  private static Bitmap createScaledBitmap(InputStream data, int maxWidth, int maxHeight,
-                                           BitmapFactory.Options options, boolean constrainedMemory)
-      throws BitmapDecodingException
-  {
-    final int imageWidth  = options.outWidth;
-    final int imageHeight = options.outHeight;
-
-    options.inSampleSize       = getScaleFactor(imageWidth, imageHeight, maxWidth, maxHeight, constrainedMemory);
-    options.inJustDecodeBounds = false;
-    options.inPreferredConfig  = constrainedMemory ? Config.RGB_565 : Config.ARGB_8888;
-
-    InputStream is             = new BufferedInputStream(data);
-    Bitmap      roughThumbnail = BitmapFactory.decodeStream(is, null, options);
-    try {
-      is.close();
-    } catch (IOException ioe) {
-      Log.w(TAG, "IOException thrown when closing an images InputStream", ioe);
-    }
-    Log.w(TAG, "rough scale " + (imageWidth) + "x" + (imageHeight) +
-               " => " + (options.outWidth) + "x" + (options.outHeight));
-    if (roughThumbnail == null) {
-      throw new BitmapDecodingException("Decoded stream was null.");
-    }
-    if (constrainedMemory) {
-      return roughThumbnail;
-    }
-
-    if (options.outWidth > maxWidth || options.outHeight > maxHeight) {
-      final float aspectWidth, aspectHeight;
-
-      if (imageWidth == 0 || imageHeight == 0) {
-        aspectWidth = maxWidth;
-        aspectHeight = maxHeight;
-      } else if (options.outWidth >= options.outHeight) {
-        aspectWidth = maxWidth;
-        aspectHeight = (aspectWidth / options.outWidth) * options.outHeight;
-      } else {
-        aspectHeight = maxHeight;
-        aspectWidth = (aspectHeight / options.outHeight) * options.outWidth;
+        Log.w(TAG, "iteration with quality " + quality + " size " + (bytes.length / 1024) + "kb");
+        if (quality == MIN_COMPRESSION_QUALITY) break;
+        quality = Math.max((quality * constraints.getImageMaxSize()) / bytes.length, MIN_COMPRESSION_QUALITY);
       }
-
-      final int fineWidth  = Math.round(aspectWidth);
-      final int fineHeight = Math.round(aspectHeight);
-
-      Log.w(TAG, "fine scale " + options.outWidth + "x" + options.outHeight +
-                 " => " + fineWidth + "x" + fineHeight);
-      Bitmap scaledThumbnail = null;
-      try {
-        scaledThumbnail = Bitmap.createScaledBitmap(roughThumbnail, fineWidth, fineHeight, true);
-      } finally {
-        if (roughThumbnail != scaledThumbnail) roughThumbnail.recycle();
+      while (bytes.length > constraints.getImageMaxSize() && attempts++ < MAX_COMPRESSION_ATTEMPTS);
+      if (bytes.length > constraints.getImageMaxSize()) {
+        throw new IOException("Unable to scale image below: " + bytes.length);
       }
-      return scaledThumbnail;
-    } else {
-      return roughThumbnail;
+      Log.w(TAG, "createScaledBytes(" + model.toString() + ") -> quality " + Math.min(quality, MAX_COMPRESSION_QUALITY) + ", " + attempts + " attempt(s)");
+      return bytes;
+    } finally {
+      if (scaledBitmap != null) scaledBitmap.recycle();
     }
   }
 
-  @VisibleForTesting static int getScaleFactor(int inWidth, int inHeight,
-                                               int maxWidth, int maxHeight,
-                                               boolean constrained)
+  public static <T> Bitmap createScaledBitmap(Context context, T model, int maxWidth, int maxHeight)
+      throws ExecutionException
   {
-    int scaler = 1;
-    while (!constrained && ((inWidth / scaler / 2 >= maxWidth) && (inHeight / scaler / 2 >= maxHeight))) {
-      scaler *= 2;
-    }
-    while (constrained && ((inWidth / scaler > maxWidth) || (inHeight / scaler > maxHeight))) {
-      scaler *= 2;
-    }
-    return scaler;
+    final Pair<Integer, Integer> dimensions = getDimensions(getInputStreamForModel(context, model));
+    final Pair<Integer, Integer> clamped = clampDimensions(dimensions.first, dimensions.second,
+                                                           maxWidth, maxHeight);
+    return createScaledBitmapInto(context, model, clamped.first, clamped.second);
   }
 
-  private static Bitmap fixOrientation(Bitmap bitmap, InputStream orientationStream) throws IOException {
-    final int orientation = Exif.getOrientation(orientationStream);
-    orientationStream.close();
-    if (orientation != 0) {
-      return rotateBitmap(bitmap, orientation);
-    } else {
-      return bitmap;
+  private static <T> InputStream getInputStreamForModel(Context context, T model)
+      throws ExecutionException
+  {
+    try {
+      return Glide.buildStreamModelLoader(model, context)
+                  .getResourceFetcher(model, -1, -1)
+                  .loadData(Priority.NORMAL);
+    } catch (Exception e) {
+      throw new ExecutionException(e);
     }
   }
 
-  public static Bitmap rotateBitmap(Bitmap bitmap, int angle) {
-    if (angle == 0) return bitmap;
-    Matrix matrix = new Matrix();
-    matrix.postRotate(angle);
-    Bitmap rotated = Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), matrix, true);
-    if (rotated != bitmap) bitmap.recycle();
-    return rotated;
+  private static <T> Bitmap createScaledBitmapInto(Context context, T model, int width, int height)
+      throws ExecutionException
+  {
+    try {
+      return Glide.with(context)
+                  .load(model)
+                  .asBitmap()
+                  .skipMemoryCache(true)
+                  .into(width, height)
+                  .get();
+    } catch (InterruptedException ie) {
+      throw new AssertionError(ie);
+    }
+  }
+
+  public static <T> Bitmap createScaledBitmap(Context context, T model, float scale)
+      throws ExecutionException
+  {
+    Pair<Integer, Integer> dimens = getDimensions(getInputStreamForModel(context, model));
+    return createScaledBitmapInto(context, model,
+                                  (int)(dimens.first * scale), (int)(dimens.second * scale));
   }
 
   private static BitmapFactory.Options getImageDimensions(InputStream inputStream) {
@@ -249,27 +137,6 @@ public class BitmapUtil {
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
     bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
     return stream.toByteArray();
-  }
-
-  public static Bitmap getCircleBitmap(Bitmap bitmap) {
-    final Bitmap output = Bitmap.createBitmap(bitmap.getWidth(),
-                                              bitmap.getHeight(), Bitmap.Config.ARGB_8888);
-    final Canvas canvas = new Canvas(output);
-
-    final int   color = Color.RED;
-    final Paint paint = new Paint();
-    final Rect  rect  = new Rect(0, 0, bitmap.getWidth(), bitmap.getHeight());
-    final RectF rectF = new RectF(rect);
-
-    paint.setAntiAlias(true);
-    canvas.drawARGB(0, 0, 0, 0);
-    paint.setColor(color);
-    canvas.drawOval(rectF, paint);
-
-    paint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_IN));
-    canvas.drawBitmap(bitmap, rect, rect, paint);
-
-    return output;
   }
 
   public static byte[] createFromNV21(@NonNull final byte[] data,
@@ -331,6 +198,27 @@ public class BitmapUtil {
       }
     }
     return output;
+  }
+
+  private static Pair<Integer, Integer> clampDimensions(int inWidth, int inHeight, int maxWidth, int maxHeight) {
+    if (inWidth > maxWidth || inHeight > maxHeight) {
+      final float aspectWidth, aspectHeight;
+
+      if (inWidth == 0 || inHeight == 0) {
+        aspectWidth  = maxWidth;
+        aspectHeight = maxHeight;
+      } else if (inWidth >= inHeight) {
+        aspectWidth  = maxWidth;
+        aspectHeight = (aspectWidth / inWidth) * inHeight;
+      } else {
+        aspectHeight = maxHeight;
+        aspectWidth  = (aspectHeight / inHeight) * inWidth;
+      }
+
+      return new Pair<>(Math.round(aspectWidth), Math.round(aspectHeight));
+    } else {
+      return new Pair<>(inWidth, inHeight);
+    }
   }
 
   public static Bitmap createFromDrawable(final Drawable drawable, final int width, final int height) {

--- a/src/org/thoughtcrime/securesms/util/MediaUtil.java
+++ b/src/org/thoughtcrime/securesms/util/MediaUtil.java
@@ -7,9 +7,12 @@ import android.text.TextUtils;
 import android.util.Log;
 import android.webkit.MimeTypeMap;
 
+import com.bumptech.glide.Glide;
+
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.mms.AudioSlide;
+import org.thoughtcrime.securesms.mms.DecryptableStreamUriLoader.DecryptableUri;
 import org.thoughtcrime.securesms.mms.GifSlide;
 import org.thoughtcrime.securesms.mms.ImageSlide;
 import org.thoughtcrime.securesms.mms.PartAuthority;
@@ -19,6 +22,7 @@ import org.thoughtcrime.securesms.mms.VideoSlide;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.ExecutionException;
 
 import ws.com.google.android.mms.ContentType;
 import ws.com.google.android.mms.pdu.PduPart;
@@ -27,7 +31,7 @@ public class MediaUtil {
   private static final String TAG = MediaUtil.class.getSimpleName();
 
   public static ThumbnailData generateThumbnail(Context context, MasterSecret masterSecret, Uri uri, String type)
-      throws IOException, BitmapDecodingException, OutOfMemoryError
+      throws ExecutionException
   {
     long   startMillis = System.currentTimeMillis();
     ThumbnailData data;
@@ -54,10 +58,10 @@ public class MediaUtil {
   }
 
   private static Bitmap generateImageThumbnail(Context context, MasterSecret masterSecret, Uri uri)
-      throws IOException, BitmapDecodingException, OutOfMemoryError
+      throws ExecutionException
   {
-    int maxSize = context.getResources().getDimensionPixelSize(R.dimen.thumbnail_max_size);
-    return BitmapUtil.createScaledBitmap(context, masterSecret, uri, maxSize, maxSize);
+    int maxSize = context.getResources().getDimensionPixelSize(R.dimen.media_bubble_height);
+    return BitmapUtil.createScaledBitmap(context, new DecryptableUri(masterSecret, uri), maxSize, maxSize);
   }
 
   public static Slide getSlideForPart(Context context, MasterSecret masterSecret, PduPart part, String contentType) {


### PR DESCRIPTION
Pretty much finish the transition to Glide by having it take care of all our bitmap-related tasks both in and out of the UI. Their code is both less likely to be buggy and allows our BitmapUtil to handle very nice abstract input models.

While this is actual a positive diff, the code ends up being much cleaner IMO. Most if it is having new InputStream loaders for Android contact photos (Glide doesn't currently include one) and TextSecure attachments.

fixes #3908