### PR TITLE
Maintenance: changed upcast to use method type parameter.

### DIFF
--- a/src/org/thoughtcrime/securesms/dependencies/TextSecureCommunicationModule.java
+++ b/src/org/thoughtcrime/securesms/dependencies/TextSecureCommunicationModule.java
@@ -66,8 +66,8 @@ public class TextSecureCommunicationModule {
                                            TextSecurePreferences.getLocalNumber(context),
                                            TextSecurePreferences.getPushServerPassword(context),
                                            new TextSecureAxolotlStore(context),
-                                           Optional.of((TextSecureMessageSender.EventListener)
-                                                           new SecurityEventListener(context)));
+                                           Optional.<TextSecureMessageSender.EventListener>of(
+                                               new SecurityEventListener(context)));
       }
     };
   }


### PR DESCRIPTION
It's bad style to use up-casts in this way to trick java's type system into inferring the correct type parameter, instead it should be explicitly given.