### PR TITLE
Grey out "Display in notifications" appropriately 

### DIFF
--- a/res/xml/preferences_notifications.xml
+++ b/res/xml/preferences_notifications.xml
@@ -52,6 +52,7 @@
 
     <ListPreference android:key="pref_notification_privacy"
                     android:title="@string/preferences_notifications__display_in_notifications"
+                    android:dependency="pref_key_enable_notifications"
                     android:defaultValue="all"
                     android:entries="@array/pref_notification_privacy_entries"
                     android:entryValues="@array/pref_notification_privacy_values"/>


### PR DESCRIPTION
Adds dependency for display in notifications on pref_key_enable_notifications.
![adb-screenshot-2015-08-26-13-38-23-181983491](https://cloud.githubusercontent.com/assets/4326714/9502773/cf7ab886-4bf8-11e5-897d-86d812ba17be.png)
