### PR TITLE
Add branded launch screen

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -135,6 +135,7 @@
 
     <activity android:name=".ConversationListActivity"
           android:label="@string/app_name"
+          android:theme="@style/TextSecure.BrandedLaunch"
           android:launchMode="singleTask"
           android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"
           android:exported="true" />

--- a/res/drawable/launch_screen.xml
+++ b/res/drawable/launch_screen.xml
@@ -1,0 +1,11 @@
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <color android:color="@color/black"/>
+    </item>
+    <item>
+        <bitmap
+            android:src="@drawable/lockscreen_watermark_dark"
+            android:tileMode="disabled"
+            android:gravity="center"/>
+    </item>
+</layer-list>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -2,6 +2,10 @@
 
 <resources xmlns:tools="http://schemas.android.com/tools">
 
+    <style name="TextSecure.BrandedLaunch" parent="@style/Theme.AppCompat">
+        <item name="android:windowBackground">@drawable/launch_screen</item>
+    </style>
+
     <style name="TextSecure.LightNoActionBar" parent="@style/Theme.AppCompat.Light.NoActionBar">
         <item name="theme_type">light</item>
         <item name="actionBarStyle">@style/TextSecure.LightActionBar</item>


### PR DESCRIPTION
When the app starts cold there is currently a blank white screen that shows for about 1/2 a second (longer on slower devices) while the app loads.

This introduces a simple branded launch screen [as defined by the Google design docs](https://www.google.com/design/spec/patterns/launch-screens.html#launch-screens-branded-launch) that shows the TextSecure icon on a black background while the app is initializing.