### PR TITLE
fix crash on pending self-sent media

### DIFF
--- a/src/org/thoughtcrime/securesms/database/MmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MmsDatabase.java
@@ -577,6 +577,10 @@ public class MmsDatabase extends MessagingDatabase {
       contentValues.put(READ, 1);
       contentValues.put(DATE_RECEIVED, contentValues.getAsLong(DATE_SENT));
 
+      for (int i = 0; i < request.getBody().getPartsNum(); i++) {
+        request.getBody().getPart(i).setTransferProgress(PartDatabase.TRANSFER_PROGRESS_DONE);
+      }
+
       return insertMediaMessage(new MasterSecretUnion(masterSecret), request.getPduHeaders(),
                                 request.getBody(), contentValues);
     } catch (NoSuchMessageException e) {

--- a/src/org/thoughtcrime/securesms/database/PartDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/PartDatabase.java
@@ -444,7 +444,7 @@ public class PartDatabase extends Database {
     return part;
   }
 
-  public List<PduPart> getPendingParts() {
+  public @NonNull List<PduPart> getPendingParts() {
     final SQLiteDatabase database = databaseHelper.getReadableDatabase();
     final List<PduPart>  parts    = new LinkedList<>();
 

--- a/src/org/thoughtcrime/securesms/jobs/AttachmentDownloadJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/AttachmentDownloadJob.java
@@ -88,6 +88,7 @@ public class AttachmentDownloadJob extends MasterSecretJob implements Injectable
   private void retrievePart(MasterSecret masterSecret, PduPart part, long messageId)
       throws IOException
   {
+
     PartDatabase database       = DatabaseFactory.getPartDatabase(context);
     File         attachmentFile = null;
 
@@ -115,6 +116,8 @@ public class AttachmentDownloadJob extends MasterSecretJob implements Injectable
   private TextSecureAttachmentPointer createAttachmentPointer(MasterSecret masterSecret, PduPart part)
       throws InvalidPartException
   {
+    if (part.getContentLocation() == null) throw new InvalidPartException("null content location");
+
     try {
       AsymmetricMasterSecret asymmetricMasterSecret = MasterSecretUtil.getAsymmetricMasterSecret(context, masterSecret);
       long                   id                     = Long.parseLong(Util.toIsoString(part.getContentLocation()));
@@ -153,6 +156,7 @@ public class AttachmentDownloadJob extends MasterSecretJob implements Injectable
   }
 
   private static class InvalidPartException extends Exception {
+    public InvalidPartException(String s) {super(s);}
     public InvalidPartException(Exception e) {super(e);}
   }
 


### PR DESCRIPTION
fixes #4016

this change makes sure parts copied from outbox to inbox are not pending as well since that doesn't make sense.

tested by queuing up pending self-sends as well as pending normal incoming push attachments, both behaved as expected.