### PR TITLE
Bump the max sizes for message limits delivered by push

### DIFF
--- a/src/org/thoughtcrime/securesms/mms/PushMediaConstraints.java
+++ b/src/org/thoughtcrime/securesms/mms/PushMediaConstraints.java
@@ -32,11 +32,11 @@ public class PushMediaConstraints extends MediaConstraints {
 
   @Override
   public int getVideoMaxSize() {
-    return MmsMediaConstraints.MAX_MESSAGE_SIZE;
+    return 512 * MB;
   }
 
   @Override
   public int getAudioMaxSize() {
-    return MmsMediaConstraints.MAX_MESSAGE_SIZE;
+    return 128 * MB;
   }
 }


### PR DESCRIPTION
I picked totally arbitrary numbers that seemed reasonable sounding at
the time.

closes #700

in https://github.com/whispersystems/TextSecure/issues/700#issuecomment-89356438 @mcginty wrote:

> It's just a matter of limiting auto-downloads of large files depending on the network you're on before we increase the size.

However naively, it seems that a malicious implementor of TextSecure's protocol can already bypass this limit, if the only restrictions are client side at present. Thus I propose raising the limit.

I'm totally onboard with picking other numbers, I literally just eyeballed a minute long video.