### PR TITLE
fix persistent stale attachment jobs

### DIFF
--- a/src/org/thoughtcrime/securesms/jobs/AttachmentDownloadJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/AttachmentDownloadJob.java
@@ -67,6 +67,11 @@ public class AttachmentDownloadJob extends MasterSecretJob implements Injectable
     final PartId  partId = new PartId(partRowId, partUniqueId);
     final PduPart part   = DatabaseFactory.getPartDatabase(context).getPart(partId);
 
+    if (part == null) {
+      Log.w(TAG, "part no longer exists.");
+      return;
+    }
+
     Log.w(TAG, "Downloading push part " + partId);
 
     retrievePart(masterSecret, part, messageId);

--- a/src/org/thoughtcrime/securesms/jobs/requirements/MediaNetworkRequirement.java
+++ b/src/org/thoughtcrime/securesms/jobs/requirements/MediaNetworkRequirement.java
@@ -78,8 +78,8 @@ public class MediaNetworkRequirement implements Requirement, ContextDependent {
     final PartDatabase db     = DatabaseFactory.getPartDatabase(context);
     final PduPart      part   = db.getPart(partId);
     if (part == null) {
-      Log.w(TAG, "part was null");
-      return false;
+      Log.w(TAG, "part was null, returning vacuous true");
+      return true;
     }
 
     Log.w(TAG, "part transfer progress is " + part.getTransferProgress());


### PR DESCRIPTION
if a media message is deleted before the attachment is downloaded, MediaNetworkRequirement would previously never be satisfied and the job would just sit around indefinitely.