### PR TITLE
filter duplicate numbers

### DIFF
--- a/src/org/thoughtcrime/securesms/contacts/ContactsDatabase.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactsDatabase.java
@@ -197,7 +197,29 @@ public class ContactsDatabase {
                                                        new String[] {"__TS"},
                                                        sort);
 
-    return new ProjectionMappingCursor(cursor, projectionMap,
+
+      MatrixCursor finalCursor = new MatrixCursor(new String[] {ContactsContract.CommonDataKinds.Phone._ID,
+              ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME,
+              ContactsContract.CommonDataKinds.Phone.NUMBER,
+              ContactsContract.CommonDataKinds.Phone.TYPE,
+              ContactsContract.CommonDataKinds.Phone.LABEL}, 0);
+
+      List<String> numberList = new ArrayList<>();
+      while (cursor.moveToNext()) {
+          String number =  cursor.getString(cursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone.NUMBER));
+
+          if (!numberList.contains(number)) {
+              numberList.add(number);
+              finalCursor.addRow(new Object[]{
+              cursor.getInt(cursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone._ID)),
+              cursor.getString(cursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME)),
+              number,
+              cursor.getInt(cursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone.TYPE)),
+              cursor.getString(cursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone.LABEL))});
+          }
+      }
+
+    return new ProjectionMappingCursor(finalCursor, projectionMap,
                                        new Pair<String, Object>(CONTACT_TYPE_COLUMN, NORMAL_TYPE));
   }
 


### PR DESCRIPTION
this fixes #4029 

ContactsContract does not allow to select distinct numbers or grouping functions. Therefore, the query is done as it was, and the duplicate-filtering is done afterwards creating a new cursor with only unique numbers.

