### PR TITLE
make the migration and media situation suck a bit less

### DIFF
--- a/src/org/thoughtcrime/securesms/DatabaseUpgradeActivity.java
+++ b/src/org/thoughtcrime/securesms/DatabaseUpgradeActivity.java
@@ -66,7 +66,7 @@ public class DatabaseUpgradeActivity extends BaseActivity {
   public static final int PUSH_DECRYPT_SERIAL_ID_VERSION       = 131;
   public static final int MIGRATE_SESSION_PLAINTEXT            = 136;
   public static final int CONTACTS_ACCOUNT_VERSION             = 136;
-  public static final int MEDIA_DOWNLOAD_CONTROLS_VERSION      = 149;
+  public static final int MEDIA_DOWNLOAD_CONTROLS_VERSION      = 151;
 
   private static final SortedSet<Integer> UPGRADE_VERSIONS = new TreeSet<Integer>() {{
     add(NO_MORE_KEY_EXCHANGE_PREFIX_VERSION);
@@ -233,8 +233,8 @@ public class DatabaseUpgradeActivity extends BaseActivity {
         final Reader        reader = mmsDb.readerFor(masterSecret, mmsDb.getMessage(part.getMmsId()));
         final MessageRecord record = reader.getNext();
 
-        if (part.getContentLocation() == null) {
-          Log.w(TAG, "corrected a pending self-sent media part " + part.getPartId() + ".");
+        if (part.getDataUri() != null) {
+          Log.w(TAG, "corrected a pending media part " + part.getPartId() + "that already had data.");
           partDb.setTransferState(part.getMmsId(), part.getPartId(), PartDatabase.TRANSFER_PROGRESS_DONE);
         } else if (record != null && !record.isOutgoing() && record.isPush()) {
           Log.w(TAG, "queuing new attachment download job for incoming push part " + part.getPartId() + ".");

--- a/src/org/thoughtcrime/securesms/components/ThumbnailView.java
+++ b/src/org/thoughtcrime/securesms/components/ThumbnailView.java
@@ -226,7 +226,7 @@ public class ThumbnailView extends FrameLayout {
       builder = buildPlaceholderGlideRequest(slide);
     }
 
-    if (slide.isInProgress() && !hideControls) {
+    if (slide.getTransferProgress() != PartDatabase.TRANSFER_PROGRESS_DONE && !hideControls) {
       return builder;
     } else {
       return builder.error(R.drawable.ic_missing_thumbnail_picture);
@@ -331,9 +331,9 @@ public class ThumbnailView extends FrameLayout {
   private class ThumbnailClickDispatcher implements View.OnClickListener {
     @Override
     public void onClick(View view) {
-      if (thumbnailClickListener != null &&
-          slide                  != null &&
-          slide.getTransferProgress() == PartDatabase.TRANSFER_PROGRESS_DONE)
+      if (thumbnailClickListener       != null &&
+          slide                        != null &&
+          slide.getPart().getDataUri() != null)
       {
         thumbnailClickListener.onClick(view, slide);
       }

--- a/src/org/thoughtcrime/securesms/database/PartDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/PartDatabase.java
@@ -298,6 +298,11 @@ public class PartDatabase extends Database {
 
     if (!cursor.isNull(sizeColumn))
       part.setDataSize(cursor.getLong(cursor.getColumnIndexOrThrow(SIZE)));
+
+    int dataColumn = cursor.getColumnIndexOrThrow(DATA);
+
+    if (!cursor.isNull(dataColumn))
+      part.setDataUri(PartAuthority.getPartUri(part.getPartId()));
   }
 
   private ContentValues getContentValuesForPart(PduPart part) throws MmsException {
@@ -439,8 +444,6 @@ public class PartDatabase extends Database {
     PduPart part = new PduPart();
 
     getPartValues(part, cursor);
-
-    part.setDataUri(PartAuthority.getPartUri(part.getPartId()));
 
     return part;
   }

--- a/src/org/thoughtcrime/securesms/jobs/AttachmentDownloadJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/AttachmentDownloadJob.java
@@ -71,6 +71,10 @@ public class AttachmentDownloadJob extends MasterSecretJob implements Injectable
       Log.w(TAG, "part no longer exists.");
       return;
     }
+    if (part.getDataUri() != null) {
+      Log.w(TAG, "part was already downloaded.");
+      return;
+    }
 
     Log.w(TAG, "Downloading push part " + partId);
 

--- a/src/org/thoughtcrime/securesms/jobs/PushGroupSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushGroupSendJob.java
@@ -87,6 +87,7 @@ public class PushGroupSendJob extends PushSendJob implements InjectableType {
       database.markAsPush(messageId);
       database.markAsSecure(messageId);
       database.markAsSent(messageId, "push".getBytes(), 0);
+      markPartsUploaded(messageId, message.getBody());
     } catch (InvalidNumberException | RecipientFormattingException | UndeliverableMessageException e) {
       Log.w(TAG, e);
       database.markAsSentFailed(messageId);

--- a/src/org/thoughtcrime/securesms/mms/ImageSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/ImageSlide.java
@@ -55,7 +55,7 @@ public class ImageSlide extends Slide {
 
   @Override
   public @DrawableRes int getPlaceholderRes(Theme theme) {
-    return R.drawable.ic_missing_thumbnail_picture;
+    return 0;
   }
 
   @Override


### PR DESCRIPTION
As it turns out, outgoing group media was never marked as non-pending after it was sent, which was the assumption that caused the most recent thumbnail click regression.

After thinking about it, I decided parts should only have a data uri set if there's a corresponding data file to read from, and that should be the authoritative indicator on if we can preview the media. So that's what this change does.

As for the migration: we will not try to download any part that already has a non-null data column (has media available already). I wasn't able to reproduce @McLoo's failure case and there haven't been any other crash reports besides that one, but this seems like a more fail-safe way to do this check than looking for a content location.

Tested the migration with pending parts that actually need downloading, along with outgoing group media and the previously borked self-send media messages.

Assuming 2.26.5 will be version code 151