### PR TITLE
fix system emoji transparency

### DIFF
--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -125,8 +125,8 @@
 
 
         <item name="conversation_item_bubble_background">@color/white</item>
-        <item name="conversation_item_sent_text_primary_color">#99000000</item>
-        <item name="conversation_item_sent_text_secondary_color">#bb000000</item>
+        <item name="conversation_item_sent_text_primary_color">@color/grey_800</item>
+        <item name="conversation_item_sent_text_secondary_color">@color/grey_900</item>
         <item name="conversation_item_sent_text_indicator_tab_color">#99000000</item>
         <item name="conversation_item_received_text_primary_color">@color/white</item>
         <item name="conversation_item_received_text_secondary_color">#BFffffff</item>


### PR DESCRIPTION
when system emoji pref is set, the fact that we were using outgoing text colors that had non-100% alpha made the emoji appear faded.