### PR TITLE
move conversation list to RecyclerView

### DIFF
--- a/res/drawable/conversation_item_background.xml
+++ b/res/drawable/conversation_item_background.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_enabled="true" android:state_selected="true"
-          android:drawable="@drawable/list_selected_holo_light" />
+    <item android:drawable="@color/textsecure_primary_alpha33" android:state_selected="true" />
 </selector>

--- a/res/drawable/conversation_item_background_dark.xml
+++ b/res/drawable/conversation_item_background_dark.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_enabled="true" android:state_selected="true"
-          android:drawable="@drawable/list_selected_holo_dark" />
-</selector>

--- a/res/layout/conversation_fragment.xml
+++ b/res/layout/conversation_fragment.xml
@@ -5,18 +5,12 @@
               android:layout_height="match_parent"
               android:orientation="vertical">
 
-    <ListView android:id="@android:id/list"
-              android:layout_width="fill_parent"
-              android:layout_height="0dp"
-              android:layout_weight="1.0"
-              android:drawSelectorOnTop="false"
-              android:transcriptMode="normal"
-              android:scrollbarAlwaysDrawVerticalTrack="false"
-              android:scrollbarStyle="insideOverlay"
-              android:stackFromBottom="true"
-              android:fadingEdge="none"
-              android:divider="@android:color/transparent"
-              android:dividerHeight="0dp"
-              android:cacheColorHint="?conversation_background" />
+    <android.support.v7.widget.RecyclerView
+            android:id="@android:id/list"
+            android:layout_width="fill_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1.0"
+            android:scrollbars="vertical"
+            android:cacheColorHint="?conversation_background" />
 
 </LinearLayout>

--- a/res/layout/conversation_item_received.xml
+++ b/res/layout/conversation_item_received.xml
@@ -4,11 +4,9 @@
                                              android:layout_height="wrap_content"
                                              android:paddingRight="10dip"
                                              android:orientation="vertical"
-                                             android:background="?conversation_item_background"
+                                             android:background="@drawable/conversation_item_background"
                                              xmlns:android="http://schemas.android.com/apk/res/android"
-                                             xmlns:tools="http://schemas.android.com/tools"
-                                             xmlns:dots="http://schemas.android.com/apk/res-auto"
-                                             xmlns:app="http://schemas.android.com/apk/res-auto">
+                                             xmlns:tools="http://schemas.android.com/tools">
 
     <TextView android:id="@+id/group_message_status"
               android:layout_width="wrap_content"

--- a/res/layout/conversation_item_sent.xml
+++ b/res/layout/conversation_item_sent.xml
@@ -2,12 +2,11 @@
 <org.thoughtcrime.securesms.ConversationItem
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/conversation_item"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal"
-    android:background="?conversation_item_background">
+    android:background="@drawable/conversation_item_background">
 
     <RelativeLayout android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -133,7 +133,6 @@
 
         <item name="quick_camera_icon">@drawable/quick_camera_light</item>
 
-        <item name="conversation_item_background">@drawable/conversation_item_background</item>
         <item name="conversation_item_sent_indicator_text_background">@drawable/conversation_item_sent_indicator_text_shape</item>
 
         <item name="dialog_info_icon">@drawable/ic_info_outline_light</item>
@@ -204,7 +203,6 @@
 
         <item name="conversation_group_member_name">#99ffffff</item>
 
-        <item name="conversation_item_background">@drawable/conversation_item_background_dark</item>
         <item name="conversation_item_bubble_background">#ff333333</item>
         <item name="conversation_item_sent_text_primary_color">#ffffffff</item>
         <item name="conversation_item_sent_text_secondary_color">#aaeeeeee</item>

--- a/src/org/thoughtcrime/securesms/BindableConversationItem.java
+++ b/src/org/thoughtcrime/securesms/BindableConversationItem.java
@@ -1,0 +1,17 @@
+package org.thoughtcrime.securesms;
+
+import android.support.annotation.NonNull;
+
+import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.database.model.MessageRecord;
+
+import java.util.Locale;
+import java.util.Set;
+
+public interface BindableConversationItem extends Unbindable {
+  void bind(@NonNull MasterSecret masterSecret,
+            @NonNull MessageRecord messageRecord,
+            @NonNull Locale locale,
+            @NonNull Set<MessageRecord> batchSelected,
+            boolean groupThread, boolean pushDestination);
+}

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1368,11 +1368,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   @Override
-  public void setComposeText(String text) {
-    this.composeText.setText(text);
-  }
-
-  @Override
   public void setThreadId(long threadId) {
     this.threadId = threadId;
   }

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -23,10 +23,10 @@ import android.content.Intent;
 import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
-import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
+import android.text.util.Linkify;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -40,7 +40,6 @@ import android.widget.Toast;
 
 import com.afollestad.materialdialogs.AlertDialogWrapper;
 
-import org.thoughtcrime.securesms.ConversationFragment.SelectionClickListener;
 import org.thoughtcrime.securesms.components.AvatarImageView;
 import org.thoughtcrime.securesms.components.ThumbnailView;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
@@ -74,7 +73,9 @@ import java.util.Set;
  *
  */
 
-public class ConversationItem extends LinearLayout implements Recipient.RecipientModifiedListener, Unbindable {
+public class ConversationItem extends LinearLayout
+    implements Recipient.RecipientModifiedListener, BindableConversationItem
+{
   private final static String TAG = ConversationItem.class.getSimpleName();
 
   private MessageRecord messageRecord;
@@ -97,16 +98,13 @@ public class ConversationItem extends LinearLayout implements Recipient.Recipien
   private View            pendingIndicator;
   private ImageView       pendingApprovalIndicator;
 
-  private StatusManager          statusManager;
-  private Set<MessageRecord>     batchSelected;
-  private SelectionClickListener selectionClickListener;
-  private ThumbnailView          mediaThumbnail;
-  private Button                 mmsDownloadButton;
-  private TextView               mmsDownloadingLabel;
+  private StatusManager      statusManager;
+  private Set<MessageRecord> batchSelected;
+  private ThumbnailView      mediaThumbnail;
+  private Button             mmsDownloadButton;
+  private TextView           mmsDownloadingLabel;
 
-  private int      defaultBubbleColor;
-  private Drawable selectedBackground;
-  private Drawable normalBackground;
+  private int defaultBubbleColor;
 
   private final MmsDownloadClickListener    mmsDownloadClickListener    = new MmsDownloadClickListener();
   private final MmsPreferencesClickListener mmsPreferencesClickListener = new MmsPreferencesClickListener();
@@ -114,9 +112,8 @@ public class ConversationItem extends LinearLayout implements Recipient.Recipien
   private final Context                     context;
 
   public ConversationItem(Context context) {
-    super(context);
-    this.context = context;
-   }
+    this(context, null);
+  }
 
   public ConversationItem(Context context, AttributeSet attrs) {
     super(context, attrs);
@@ -131,7 +128,7 @@ public class ConversationItem extends LinearLayout implements Recipient.Recipien
     ViewGroup pendingIndicatorStub = (ViewGroup) findViewById(R.id.pending_indicator_stub);
 
     if (pendingIndicatorStub != null) {
-      LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+      LayoutInflater inflater = LayoutInflater.from(context);
       if (Build.VERSION.SDK_INT >= 11) inflater.inflate(R.layout.conversation_item_pending_v11, pendingIndicatorStub, true);
       else                             inflater.inflate(R.layout.conversation_item_pending, pendingIndicatorStub, true);
     }
@@ -154,33 +151,33 @@ public class ConversationItem extends LinearLayout implements Recipient.Recipien
     this.statusManager            = new StatusManager(pendingIndicator, sentIndicator, deliveredIndicator, failedIndicator, pendingApprovalIndicator);
 
     setOnClickListener(clickListener);
+    PassthroughClickListener passthroughClickListener = new PassthroughClickListener();
     if (mmsDownloadButton != null) mmsDownloadButton.setOnClickListener(mmsDownloadClickListener);
-    if (mediaThumbnail != null) {
-      mediaThumbnail.setThumbnailClickListener(new ThumbnailClickListener());
-      mediaThumbnail.setOnLongClickListener(new MultiSelectLongClickListener());
-      mediaThumbnail.setDownloadClickListener(new ThumbnailDownloadClickListener());
-    }
+    mediaThumbnail.setThumbnailClickListener(new ThumbnailClickListener());
+    mediaThumbnail.setDownloadClickListener(new ThumbnailDownloadClickListener());
+    mediaThumbnail.setOnLongClickListener(passthroughClickListener);
+    bodyText.setOnLongClickListener(passthroughClickListener);
+    bodyText.setOnClickListener(passthroughClickListener);
   }
 
-  public void set(@NonNull MasterSecret masterSecret,
-                  @NonNull MessageRecord messageRecord,
-                  @NonNull Locale locale,
-                  @NonNull Set<MessageRecord> batchSelected,
-                  @NonNull SelectionClickListener selectionClickListener,
-                  boolean groupThread, boolean pushDestination)
+  @Override
+  public void bind(@NonNull MasterSecret       masterSecret,
+                   @NonNull MessageRecord      messageRecord,
+                   @NonNull Locale             locale,
+                   @NonNull Set<MessageRecord> batchSelected,
+                   boolean groupThread, boolean pushDestination)
   {
     this.masterSecret           = masterSecret;
     this.messageRecord          = messageRecord;
     this.locale                 = locale;
     this.batchSelected          = batchSelected;
-    this.selectionClickListener = selectionClickListener;
     this.groupThread            = groupThread;
     this.pushDestination        = pushDestination;
     this.recipient              = messageRecord.getIndividualRecipient();
 
     this.recipient.addListener(this);
 
-    setSelectionBackgroundDrawables(messageRecord);
+    setSelectionState(messageRecord);
     setBodyText(messageRecord);
     setBubbleState(messageRecord, recipient);
     setStatusIcons(messageRecord);
@@ -198,8 +195,6 @@ public class ConversationItem extends LinearLayout implements Recipient.Recipien
     final TypedArray attrs      = context.obtainStyledAttributes(attributes);
 
     defaultBubbleColor = attrs.getColor(0, Color.WHITE);
-    selectedBackground = attrs.getDrawable(1);
-    normalBackground   = attrs.getDrawable(2);
     attrs.recycle();
   }
 
@@ -227,12 +222,11 @@ public class ConversationItem extends LinearLayout implements Recipient.Recipien
     }
   }
 
-  private void setSelectionBackgroundDrawables(MessageRecord messageRecord) {
-    if (batchSelected.contains(messageRecord)) {
-      setBackgroundDrawable(selectedBackground);
-    } else {
-      setBackgroundDrawable(normalBackground);
-    }
+  private void setSelectionState(MessageRecord messageRecord) {
+    setSelected(batchSelected.contains(messageRecord));
+    mediaThumbnail.setClickable(batchSelected.isEmpty());
+    mediaThumbnail.setLongClickable(batchSelected.isEmpty());
+    bodyText.setAutoLinkMask(batchSelected.isEmpty() ? Linkify.ALL : 0);
   }
 
   private boolean isCaptionlessMms(MessageRecord messageRecord) {
@@ -254,11 +248,6 @@ public class ConversationItem extends LinearLayout implements Recipient.Recipien
     } else {
       bodyText.setText(messageRecord.getDisplayBody());
       bodyText.setVisibility(View.VISIBLE);
-    }
-
-    if (bodyText.isClickable() && bodyText.isFocusable()) {
-      bodyText.setOnLongClickListener(new MultiSelectLongClickListener());
-      bodyText.setOnClickListener(new MultiSelectLongClickListener());
     }
   }
 
@@ -334,12 +323,9 @@ public class ConversationItem extends LinearLayout implements Recipient.Recipien
 
   private void setEvents(MessageRecord messageRecord) {
     setClickable(batchSelected.isEmpty() &&
-                 (messageRecord.isFailed()                     ||
+                 (messageRecord.isFailed() ||
                   messageRecord.isPendingInsecureSmsFallback() ||
                   messageRecord.isBundleKeyExchange()));
-    if (messageRecord.isFailed()) {
-      setOnLongClickListener(new MultiSelectLongClickListener());
-    }
   }
 
   private void setGroupMessageStatus(MessageRecord messageRecord, Recipient recipient) {
@@ -410,7 +396,7 @@ public class ConversationItem extends LinearLayout implements Recipient.Recipien
   }
 
   private class ThumbnailDownloadClickListener implements ThumbnailView.ThumbnailClickListener {
-    @Override public void onClick(View v, Slide slide) {
+    @Override public void onClick(View v, final Slide slide) {
       DatabaseFactory.getPartDatabase(context).setTransferState(messageRecord.getId(), slide.getPart().getPartId(), PartDatabase.TRANSFER_PROGRESS_STARTED);
     }
   }
@@ -430,10 +416,9 @@ public class ConversationItem extends LinearLayout implements Recipient.Recipien
     }
 
     public void onClick(final View v, final Slide slide) {
-      if (!batchSelected.isEmpty()) {
-        selectionClickListener.onItemClick(null, ConversationItem.this, -1, -1);
-      } else if (MediaPreviewActivity.isContentTypeSupported(slide.getContentType()) &&
-                 slide.getThumbnailUri() != null)
+      if (batchSelected.isEmpty() &&
+          MediaPreviewActivity.isContentTypeSupported(slide.getContentType()) &&
+          slide.getThumbnailUri() != null)
       {
         Intent intent = new Intent(context, MediaPreviewActivity.class);
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
@@ -483,11 +468,22 @@ public class ConversationItem extends LinearLayout implements Recipient.Recipien
     }
   }
 
+  private class PassthroughClickListener implements View.OnLongClickListener, View.OnClickListener {
+
+    @Override public boolean onLongClick(View v) {
+      performLongClick();
+      return true;
+    }
+
+    @Override public void onClick(View v) {
+      performClick();
+    }
+  }
   private class ClickListener implements View.OnClickListener {
     public void onClick(View v) {
-      if (messageRecord.isFailed() && !batchSelected.isEmpty()) {
-        selectionClickListener.onItemClick(null, ConversationItem.this, -1, -1);
-      } else if(messageRecord.isFailed()) {
+      if (!batchSelected.isEmpty()) return;
+
+      if (messageRecord.isFailed()) {
         Intent intent = new Intent(context, MessageDetailsActivity.class);
         intent.putExtra(MessageDetailsActivity.MASTER_SECRET_EXTRA, masterSecret);
         intent.putExtra(MessageDetailsActivity.MESSAGE_ID_EXTRA, messageRecord.getId());
@@ -499,19 +495,6 @@ public class ConversationItem extends LinearLayout implements Recipient.Recipien
       } else if (messageRecord.isPendingInsecureSmsFallback()) {
         handleMessageApproval();
       }
-    }
-  }
-
-  private class MultiSelectLongClickListener implements OnLongClickListener, OnClickListener {
-    @Override
-    public boolean onLongClick(View view) {
-      selectionClickListener.onItemLongClick(null, ConversationItem.this, -1, -1);
-      return true;
-    }
-
-    @Override
-    public void onClick(View view) {
-      selectionClickListener.onItemClick(null, ConversationItem.this, -1, -1);
     }
   }
 

--- a/src/org/thoughtcrime/securesms/ConversationListAdapter.java
+++ b/src/org/thoughtcrime/securesms/ConversationListAdapter.java
@@ -101,7 +101,7 @@ public class ConversationListAdapter extends CursorRecyclerViewAdapter<Conversat
   }
 
   @Override
-  public void onBindViewHolder(ViewHolder viewHolder, Cursor cursor) {
+  public void onBindViewHolder(ViewHolder viewHolder, @NonNull Cursor cursor) {
     ThreadDatabase.Reader reader = threadDatabase.readerFor(cursor, masterCipher);
     ThreadRecord          record = reader.getCurrent();
 

--- a/src/org/thoughtcrime/securesms/ConversationListAdapter.java
+++ b/src/org/thoughtcrime/securesms/ConversationListAdapter.java
@@ -100,6 +100,10 @@ public class ConversationListAdapter extends CursorRecyclerViewAdapter<Conversat
                                                                  parent, false), clickListener);
   }
 
+  @Override public void onViewRecycled(ViewHolder holder) {
+    holder.getItem().unbind();
+  }
+
   @Override
   public void onBindViewHolder(ViewHolder viewHolder, @NonNull Cursor cursor) {
     ThreadDatabase.Reader reader = threadDatabase.readerFor(cursor, masterCipher);

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -159,12 +159,6 @@ public class ConversationListFragment extends Fragment
 
   private void initializeListAdapter() {
     list.setAdapter(new ConversationListAdapter(getActivity(), masterSecret, locale, null, this));
-    list.setRecyclerListener(new RecyclerListener() {
-      @Override
-      public void onViewRecycled(ViewHolder holder) {
-        ((ConversationListItem)holder.itemView).unbind();
-      }
-    });
     getLoaderManager().restartLoader(0, null, this);
   }
 

--- a/src/org/thoughtcrime/securesms/ConversationListItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationListItem.java
@@ -49,7 +49,7 @@ import static org.thoughtcrime.securesms.util.SpanUtil.color;
  */
 
 public class ConversationListItem extends RelativeLayout
-                                  implements Recipients.RecipientsModifiedListener
+                                  implements Recipients.RecipientsModifiedListener, Unbindable
 {
   private final static String TAG = ConversationListItem.class.getSimpleName();
 
@@ -115,9 +115,9 @@ public class ConversationListItem extends RelativeLayout
     this.contactPhotoImage.setAvatar(recipients, true);
   }
 
+  @Override
   public void unbind() {
-    if (this.recipients != null)
-      this.recipients.removeListener(this);
+    if (this.recipients != null) this.recipients.removeListener(this);
   }
 
   private void setBatchState(boolean batch) {

--- a/src/org/thoughtcrime/securesms/ConversationUpdateItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationUpdateItem.java
@@ -2,20 +2,25 @@ package org.thoughtcrime.securesms;
 
 import android.content.Context;
 import android.content.Intent;
+import android.support.annotation.NonNull;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.model.MessageRecord;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.Recipients;
 import org.thoughtcrime.securesms.util.GroupUtil;
 import org.thoughtcrime.securesms.util.Util;
 
+import java.util.Locale;
+import java.util.Set;
+
 public class ConversationUpdateItem extends LinearLayout
-    implements Recipients.RecipientsModifiedListener, Recipient.RecipientModifiedListener, Unbindable, View.OnClickListener
+    implements Recipients.RecipientsModifiedListener, Recipient.RecipientModifiedListener, BindableConversationItem, View.OnClickListener
 {
   private static final String TAG = ConversationUpdateItem.class.getSimpleName();
 
@@ -42,7 +47,17 @@ public class ConversationUpdateItem extends LinearLayout
     setOnClickListener(this);
   }
 
-  public void set(MessageRecord messageRecord) {
+  @Override
+  public void bind(@NonNull MasterSecret masterSecret,
+                   @NonNull MessageRecord messageRecord,
+                   @NonNull Locale locale,
+                   @NonNull Set<MessageRecord> batchSelected,
+                   boolean groupThread, boolean pushDestination)
+  {
+    bind(messageRecord);
+  }
+
+  private void bind(@NonNull MessageRecord messageRecord) {
     this.messageRecord = messageRecord;
     this.sender        = messageRecord.getIndividualRecipient();
 
@@ -73,7 +88,7 @@ public class ConversationUpdateItem extends LinearLayout
     Util.runOnMain(new Runnable() {
       @Override
       public void run() {
-        set(messageRecord);
+        bind(messageRecord);
       }
     });
   }

--- a/src/org/thoughtcrime/securesms/ImageMediaAdapter.java
+++ b/src/org/thoughtcrime/securesms/ImageMediaAdapter.java
@@ -19,6 +19,7 @@ package org.thoughtcrime.securesms;
 import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
+import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -64,7 +65,7 @@ public class ImageMediaAdapter extends CursorRecyclerViewAdapter<ViewHolder> {
   }
 
   @Override
-  public void onBindViewHolder(final ViewHolder viewHolder, final Cursor cursor) {
+  public void onBindViewHolder(final ViewHolder viewHolder, final @NonNull Cursor cursor) {
     final ThumbnailView imageView   = viewHolder.imageView;
     final ImageRecord   imageRecord = ImageRecord.from(cursor);
 

--- a/src/org/thoughtcrime/securesms/MessageDetailsActivity.java
+++ b/src/org/thoughtcrime/securesms/MessageDetailsActivity.java
@@ -28,7 +28,6 @@ import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
 import android.widget.ListView;
 import android.widget.TextView;
 
@@ -173,8 +172,8 @@ public class MessageDetailsActivity extends PassphraseRequiredActionBarActivity 
       toFromRes = R.string.message_details_header__from;
     }
     toFrom.setText(toFromRes);
-    conversationItem.set(masterSecret, messageRecord, dynamicLanguage.getCurrentLocale(),
-                         new HashSet<MessageRecord>(), new NullSelectionListener(),
+    conversationItem.bind(masterSecret, messageRecord, dynamicLanguage.getCurrentLocale(),
+                         new HashSet<MessageRecord>(),
                          recipients != messageRecord.getRecipients(),
                          DirectoryHelper.isPushDestination(this, recipients));
     recipientsList.setAdapter(new MessageDetailsRecipientAdapter(this, masterSecret, messageRecord,
@@ -304,15 +303,6 @@ public class MessageDetailsActivity extends PassphraseRequiredActionBarActivity 
         errorText.setVisibility(View.GONE);
         metadataContainer.setVisibility(View.VISIBLE);
       }
-    }
-  }
-
-  private static class NullSelectionListener implements ConversationFragment.SelectionClickListener {
-    @Override
-    public void onItemClick(AdapterView<?> parent, View view, int position, long id) {}
-    @Override
-    public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {
-      return false;
     }
   }
 }

--- a/src/org/thoughtcrime/securesms/database/CursorRecyclerViewAdapter.java
+++ b/src/org/thoughtcrime/securesms/database/CursorRecyclerViewAdapter.java
@@ -19,6 +19,7 @@ package org.thoughtcrime.securesms.database;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.DataSetObserver;
+import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 
 /**
@@ -90,17 +91,34 @@ public abstract class CursorRecyclerViewAdapter<VH extends RecyclerView.ViewHold
            : 0;
   }
 
-  public abstract void onBindViewHolder(VH viewHolder, Cursor cursor);
+  public abstract void onBindViewHolder(VH viewHolder, @NonNull Cursor cursor);
 
   @Override
   public void onBindViewHolder(VH viewHolder, int position) {
+    moveToPositionOrThrow(position);
+    onBindViewHolder(viewHolder, cursor);
+  }
+
+  @Override public int getItemViewType(int position) {
+    moveToPositionOrThrow(position);
+    return getItemViewType(cursor);
+  }
+
+  public int getItemViewType(@NonNull Cursor cursor) {
+    return 0;
+  }
+
+  private void assertActiveCursor() {
     if (!isActiveCursor()) {
       throw new IllegalStateException("this should only be called when the cursor is valid");
     }
+  }
+
+  private void moveToPositionOrThrow(final int position) {
+    assertActiveCursor();
     if (!cursor.moveToPosition(position)) {
       throw new IllegalStateException("couldn't move cursor to position " + position);
     }
-    onBindViewHolder(viewHolder, cursor);
   }
 
   private boolean isActiveCursor() {

--- a/src/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
@@ -56,7 +56,7 @@ public class MmsSmsDatabase extends Database {
                               MmsSmsColumns.MISMATCHED_IDENTITIES,
                               MmsDatabase.NETWORK_FAILURE, TRANSPORT};
 
-    String order           = MmsSmsColumns.NORMALIZED_DATE_RECEIVED + " ASC";
+    String order           = MmsSmsColumns.NORMALIZED_DATE_RECEIVED + " DESC";
 
     String selection       = MmsSmsColumns.THREAD_ID + " = " + threadId;
 

--- a/src/org/thoughtcrime/securesms/util/ViewUtil.java
+++ b/src/org/thoughtcrime/securesms/util/ViewUtil.java
@@ -16,15 +16,18 @@
  */
 package org.thoughtcrime.securesms.util;
 
+import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.support.annotation.IdRes;
+import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.view.animation.FastOutSlowInInterpolator;
 import android.text.TextUtils;
 import android.text.TextUtils.TruncateAt;
+import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewStub;
@@ -109,5 +112,13 @@ public class ViewUtil {
     animation.setStartTime(0);
     view.setVisibility(View.VISIBLE);
     view.startAnimation(animation);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T extends View> T inflate(@NonNull   LayoutInflater inflater,
+                                           @NonNull   ViewGroup      parent,
+                                           @LayoutRes int            layoutResId)
+  {
+    return (T)(inflater.inflate(layoutResId, parent, false));
   }
 }


### PR DESCRIPTION
In preparation for only loading segments of a conversation by default. Gives us animations for free, and I also simplified our selection logic and long-click handling. This new version fixes that annoying bug that caused long-clicking a thumbnail to highlight then immediately unhighlight a conversation item.