### PR TITLE
initialize draft after security

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -214,6 +214,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     initializeActionBar();
     initializeViews();
     initializeResources();
+    initializeSecurity();
     initializeDraft();
   }
 
@@ -229,6 +230,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
     setIntent(intent);
     initializeResources();
+    initializeSecurity();
     initializeDraft();
 
     if (fragment != null) {
@@ -243,7 +245,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     dynamicLanguage.onResume(this);
     quickAttachmentDrawer.onResume();
 
-    initializeSecurity();
     initializeEnabledCheck();
     initializeMmsEnabledCheck();
     composeText.setTransport(sendButton.getSelectedTransport());


### PR DESCRIPTION
I feel like this should have been this way from the beginning anyway, as if the security state of the recipient changes for any reason between a pause and resume, we want to re-evaluate whether we can still send the attachment.