### PR TITLE
Fix "MMS download failed" click intercept

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -329,7 +329,7 @@ public class ConversationItem extends LinearLayout
 
   private boolean shouldInterceptClicks(MessageRecord messageRecord) {
     return batchSelected.isEmpty() &&
-           (messageRecord.isFailed() ||
+            ((messageRecord.isFailed() && !messageRecord.isMmsNotification()) ||
             messageRecord.isPendingInsecureSmsFallback() ||
             messageRecord.isBundleKeyExchange());
   }


### PR DESCRIPTION
Fixes #4153
// FREEBIE

Addressed only the single case in #4153 ; there may be other conditions where the click should not be intercepted.  Please advise if any such cases should be handled, and I'll update the PR.