### PR TITLE
Signal: Clarify a string.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -912,7 +912,7 @@
     <string name="preferences__language_summary">Language %s</string>
     <string name="preferences__signal_messages">Signal messages</string>
     <string name="preferences__use_the_data_channel_for_communication_with_other_signal_users">
-        Free private messaging to Signal and Signal users
+        Free private messaging to Signal users
     </string>
     <string name="preferences__submit_debug_log">Submit debug log</string>
     <string name="preferences__support_wifi_calling">\'WiFi Calling\' compatibility mode</string>


### PR DESCRIPTION
TextSecure is legacy now and Signal is the new product name

// FREEBIE