### PR TITLE
Fix unhandled exception log word order

### DIFF
--- a/src/org/thoughtcrime/redphone/call/ResponderCallManager.java
+++ b/src/org/thoughtcrime/redphone/call/ResponderCallManager.java
@@ -111,7 +111,7 @@ public class ResponderCallManager extends CallManager {
       Log.w(TAG, e);
       callStateListener.notifyCallDisconnected();
     } catch( RuntimeException e ) {
-      Log.e(TAG, "Died unhandled with exception!");
+      Log.e(TAG, "Died with unhandled exception!");
       Log.w(TAG, e);
       callStateListener.notifyClientFailure();
     }


### PR DESCRIPTION
// FREEBIE

Consistent with `InitiatingCallManager.java`

    } catch( RuntimeException e ) {
      Log.e(TAG, "Died with unhandled exception!");
      Log.w(TAG, e);
      callStateListener.notifyClientFailure();
    }