### PR TITLE
Show "Blocked" instead of most-recent message as thread-heading message for blocked contacts

### DIFF
--- a/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
@@ -81,6 +81,8 @@ public class ThreadRecord extends DisplayRecord {
       return emphasisAdded(context.getString(org.thoughtcrime.securesms.R.string.ThreadRecord_called_you));
     } else if (SmsDatabase.Types.isMissedCall(type)) {
       return emphasisAdded(context.getString(org.thoughtcrime.securesms.R.string.ThreadRecord_missed_call));
+    } else if (this.recipients.isBlocked()) {
+      return emphasisAdded("Blocked");
     } else {
       if (TextUtils.isEmpty(getBody().getBody())) {
         return new SpannableString(context.getString(R.string.MessageNotifier_no_subject));


### PR DESCRIPTION
Addresses #4237. Seemed pretty straightforward change (though it still needs a translatable string). Can't quickly set up a test to make sure it works, so this PR is an ad to anybody who wants to do a build to verify that it does what the reporter was looking for.