### PR TITLE
fix crash from incorrect send job

### DIFF
--- a/src/org/thoughtcrime/securesms/jobs/PushMediaSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushMediaSendJob.java
@@ -102,6 +102,13 @@ public class PushMediaSendJob extends PushSendJob implements InjectableType {
       throws RetryLaterException, InsecureFallbackApprovalException, UntrustedIdentityException,
              UndeliverableMessageException
   {
+    if (message.getRecipients() == null                       ||
+        message.getRecipients().getPrimaryRecipient() == null ||
+        message.getRecipients().getPrimaryRecipient().getNumber() == null)
+    {
+      throw new UndeliverableMessageException("No destination address.");
+    }
+
     TextSecureMessageSender messageSender = messageSenderFactory.create();
 
     try {


### PR DESCRIPTION
A friend found themselves in a bad state by having an old TS, clicking on "resend" that was erroneously available from the bug described in #4153, and finding themselves in a bad state until they deleted their message in airplane mode.
