### PR TITLE
stop listening on old recipient changes

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -929,6 +929,8 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void initializeResources() {
+    if (recipients != null) recipients.removeListener(this);
+    
     recipients       = RecipientFactory.getRecipientsForIds(this, getIntent().getLongArrayExtra(RECIPIENTS_EXTRA), true);
     threadId         = getIntent().getLongExtra(THREAD_ID_EXTRA, -1);
     distributionType = getIntent().getIntExtra(DISTRIBUTION_TYPE_EXTRA, ThreadDatabase.DistributionTypes.DEFAULT);


### PR DESCRIPTION
It appears we were "leaking" and creating race conditions by listening to multiple recipients at the same time in the case of receiving a new intent on a ConversationActivity instance that isn't finished.

I haven't been able to consistently reproduce the issue with the wrong contact showing up in the title bar, but since everyone I know who's experienced it has opened from a notification, this would make sense.