### PR TITLE
unjankify incoming media sharing

### DIFF
--- a/res/layout/share_activity.xml
+++ b/res/layout/share_activity.xml
@@ -1,9 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:id="@+id/drawer_layout"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
+             xmlns:wheel="http://schemas.android.com/apk/res-auto"
+             android:orientation="vertical"
+             android:layout_width="match_parent"
+             android:layout_height="match_parent">
+
+    <FrameLayout android:id="@+id/drawer_layout"
+                 android:layout_width="match_parent"
+                 android:layout_height="match_parent"
+                 android:visibility="gone" />
+
+    <com.pnikosis.materialishprogress.ProgressWheel android:id="@+id/progress_wheel"
+                                                    android:layout_width="70dp"
+                                                    android:layout_height="70dp"
+                                                    android:layout_gravity="center"
+                                                    wheel:matProg_progressIndeterminate="true" />
 
 </FrameLayout>

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -16,7 +16,6 @@
  */
 package org.thoughtcrime.securesms;
 
-import android.annotation.TargetApi;
 import android.content.ActivityNotFoundException;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -95,7 +94,7 @@ import org.thoughtcrime.securesms.mms.OutgoingMediaMessage;
 import org.thoughtcrime.securesms.mms.OutgoingSecureMediaMessage;
 import org.thoughtcrime.securesms.mms.Slide;
 import org.thoughtcrime.securesms.notifications.MessageNotifier;
-import org.thoughtcrime.securesms.providers.CaptureProvider;
+import org.thoughtcrime.securesms.providers.PersistentBlobProvider;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.RecipientFactory;
 import org.thoughtcrime.securesms.recipients.RecipientFormattingException;
@@ -195,7 +194,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private DynamicTheme    dynamicTheme    = new DynamicTheme();
   private DynamicLanguage dynamicLanguage = new DynamicLanguage();
 
-  @TargetApi(Build.VERSION_CODES.KITKAT)
   @Override
   protected void onPreCreate() {
     dynamicTheme.onCreate(this);
@@ -313,13 +311,13 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     switch (reqCode) {
     case PICK_IMAGE:
       boolean isGif = MediaUtil.isGif(MediaUtil.getMimeType(this, data.getData()));
-      setMedia(data.getData(), isGif ? MediaType.GIF : MediaType.IMAGE, false);
+      setMedia(data.getData(), isGif ? MediaType.GIF : MediaType.IMAGE);
       break;
     case PICK_VIDEO:
-      setMedia(data.getData(), MediaType.VIDEO, false);
+      setMedia(data.getData(), MediaType.VIDEO);
       break;
     case PICK_AUDIO:
-      setMedia(data.getData(), MediaType.AUDIO, false);
+      setMedia(data.getData(), MediaType.AUDIO);
       break;
     case PICK_CONTACT_INFO:
       addAttachmentContactInfo(data.getData());
@@ -333,7 +331,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       break;
     case TAKE_PHOTO:
       if (attachmentManager.getCaptureUri() != null) {
-        setMedia(attachmentManager.getCaptureUri(), MediaType.IMAGE, true);
+        setMedia(attachmentManager.getCaptureUri(), MediaType.IMAGE);
       }
       break;
     }
@@ -719,9 +717,9 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
     if (draftText != null)  composeText.setText(draftText);
 
-    if      (draftImage != null) setMedia(draftImage, MediaType.IMAGE, false);
-    else if (draftAudio != null) setMedia(draftAudio, MediaType.AUDIO, false);
-    else if (draftVideo != null) setMedia(draftVideo, MediaType.VIDEO, false);
+    if      (draftImage != null) setMedia(draftImage, MediaType.IMAGE);
+    else if (draftAudio != null) setMedia(draftAudio, MediaType.AUDIO);
+    else if (draftVideo != null) setMedia(draftVideo, MediaType.VIDEO);
 
     if (draftText == null && draftImage == null && draftAudio == null && draftVideo == null) {
       initializeDraftFromDatabase();
@@ -755,11 +753,11 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
           if (draft.getType().equals(Draft.TEXT)) {
             composeText.setText(draft.getValue());
           } else if (draft.getType().equals(Draft.IMAGE)) {
-            setMedia(Uri.parse(draft.getValue()), MediaType.IMAGE, false);
+            setMedia(Uri.parse(draft.getValue()), MediaType.IMAGE);
           } else if (draft.getType().equals(Draft.AUDIO)) {
-            setMedia(Uri.parse(draft.getValue()), MediaType.AUDIO, false);
+            setMedia(Uri.parse(draft.getValue()), MediaType.AUDIO);
           } else if (draft.getType().equals(Draft.VIDEO)) {
-            setMedia(Uri.parse(draft.getValue()), MediaType.VIDEO, false);
+            setMedia(Uri.parse(draft.getValue()), MediaType.VIDEO);
           }
         }
 
@@ -997,8 +995,8 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     }
   }
 
-  private void setMedia(Uri uri, MediaType mediaType, boolean isCapture) {
-    attachmentManager.setMedia(masterSecret, uri, mediaType, getCurrentMediaConstraints(), isCapture);
+  private void setMedia(Uri uri, MediaType mediaType) {
+    attachmentManager.setMedia(masterSecret, uri, mediaType, getCurrentMediaConstraints());
   }
 
   private void addAttachmentContactInfo(Uri contactUri) {
@@ -1038,7 +1036,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       drafts.add(new Draft(Draft.TEXT, composeText.getText().toString()));
     }
 
-    for (Slide slide : attachmentManager.getSlideDeck().getSlides()) {
+    for (Slide slide : attachmentManager.buildSlideDeck().getSlides()) {
       if      (slide.hasAudio()) drafts.add(new Draft(Draft.AUDIO, slide.getUri().toString()));
       else if (slide.hasVideo()) drafts.add(new Draft(Draft.VIDEO, slide.getUri().toString()));
       else if (slide.hasImage()) drafts.add(new Draft(Draft.IMAGE, slide.getUri().toString()));
@@ -1248,7 +1246,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   {
     final Context context                = getApplicationContext();
     OutgoingMediaMessage outgoingMessage = new OutgoingMediaMessage(recipients,
-                                                                    attachmentManager.getSlideDeck(),
+                                                                    attachmentManager.buildSlideDeck(),
                                                                     getMessage(),
                                                                     System.currentTimeMillis(),
                                                                     distributionType);
@@ -1321,7 +1319,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
   @Override
   public void onImageCapture(@NonNull final byte[] imageBytes) {
-    setMedia(CaptureProvider.getInstance(this).create(masterSecret, recipients, imageBytes), MediaType.IMAGE, true);
+    setMedia(PersistentBlobProvider.getInstance(this).create(masterSecret, recipients, imageBytes), MediaType.IMAGE);
     quickAttachmentDrawer.hide(false);
   }
 

--- a/src/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/org/thoughtcrime/securesms/ShareActivity.java
@@ -59,8 +59,8 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity
   private MasterSecret masterSecret;
   private ViewGroup    fragmentContainer;
   private View         progressWheel;
-
   private Uri          resolvedExtra;
+  private boolean      isPassingAlongMedia;
 
   @Override
   protected void onPreCreate() {
@@ -98,11 +98,17 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity
   @Override
   public void onPause() {
     super.onPause();
-    if (!isFinishing()) finish();
+    if (!isPassingAlongMedia && resolvedExtra != null) {
+      PersistentBlobProvider.getInstance(this).delete(resolvedExtra);
+    }
+    if (!isFinishing()) {
+      finish();
+    }
   }
 
   private void initializeMedia() {
     final Context context = this;
+    isPassingAlongMedia = false;
     fragmentContainer.setVisibility(View.GONE);
     progressWheel.setVisibility(View.VISIBLE);
     new AsyncTask<Uri, Void, Uri>() {
@@ -156,6 +162,7 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity
 
   private void handleNewConversation() {
     Intent intent = getBaseShareIntent(NewConversationActivity.class);
+    isPassingAlongMedia = true;
     startActivity(intent);
   }
 
@@ -170,6 +177,7 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity
     intent.putExtra(ConversationActivity.THREAD_ID_EXTRA, threadId);
     intent.putExtra(ConversationActivity.DISTRIBUTION_TYPE_EXTRA, distributionType);
 
+    isPassingAlongMedia = true;
     startActivity(intent);
   }
 

--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -111,12 +111,12 @@ public class AttachmentManager {
     new AsyncTask<Void, Void, Slide>() {
       @Override
       protected void onPreExecute() {
-        if (uri != captureUri) cleanup();
-        else                   cleanupCurrentSlide();
-
         thumbnail.clear();
         thumbnail.showProgressSpinner();
         attachmentView.setVisibility(View.VISIBLE);
+        
+        if (!uri.equals(captureUri)) cleanup();
+        else                         cleanupCurrentSlide();
       }
 
       @Override

--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -36,9 +36,11 @@ import android.widget.Toast;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.ThumbnailView;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
-import org.thoughtcrime.securesms.providers.CaptureProvider;
+import org.thoughtcrime.securesms.providers.PersistentBlobProvider;
 import org.thoughtcrime.securesms.recipients.Recipients;
 import org.thoughtcrime.securesms.util.MediaUtil;
+import org.thoughtcrime.securesms.util.ViewUtil;
+import org.whispersystems.libaxolotl.util.guava.Optional;
 
 import java.io.IOException;
 
@@ -48,15 +50,14 @@ public class AttachmentManager {
   private final Context            context;
   private final View               attachmentView;
   private final ThumbnailView      thumbnail;
-  private final SlideDeck          slideDeck;
   private final AttachmentListener attachmentListener;
 
-  private Uri captureUri;
+  private @NonNull  Optional<Slide> slide = Optional.absent();
+  private @Nullable Uri             captureUri;
 
   public AttachmentManager(Activity view, AttachmentListener listener) {
-    this.attachmentView     = view.findViewById(R.id.attachment_editor);
-    this.thumbnail          = (ThumbnailView) view.findViewById(R.id.attachment_thumbnail);
-    this.slideDeck          = new SlideDeck();
+    this.attachmentView     = ViewUtil.findById(view, R.id.attachment_editor);
+    this.thumbnail          = ViewUtil.findById(view, R.id.attachment_thumbnail);
     this.context            = view;
     this.attachmentListener = listener;
 
@@ -69,11 +70,13 @@ public class AttachmentManager {
     animation.setAnimationListener(new Animation.AnimationListener() {
       @Override
       public void onAnimationStart(Animation animation) {}
+
       @Override
       public void onAnimationRepeat(Animation animation) {}
+
       @Override
       public void onAnimationEnd(Animation animation) {
-        slideDeck.clear();
+        slide = Optional.absent();
         thumbnail.clear();
         attachmentView.setVisibility(View.GONE);
         attachmentListener.onAttachmentChanged();
@@ -84,26 +87,36 @@ public class AttachmentManager {
   }
 
   public void cleanup() {
-    if (captureUri != null) CaptureProvider.getInstance(context).delete(captureUri);
-    captureUri = null;
+    if (captureUri != null) {
+      PersistentBlobProvider.getInstance(context).delete(captureUri);
+      captureUri = null;
+      slide      = Optional.absent();
+    } else {
+      cleanupCurrentSlide();
+    }
   }
 
-  public void setMedia(@NonNull final MasterSecret     masterSecret,
-                       @NonNull final Uri              uri,
-                       @NonNull final MediaType        mediaType,
-                       @NonNull final MediaConstraints constraints,
-                                final boolean          isCapture)
+  private void cleanupCurrentSlide() {
+    if (getSlideUri() != null && PersistentBlobProvider.isAuthority(getSlideUri())) {
+      PersistentBlobProvider.getInstance(context).delete(getSlideUri());
+    }
+    slide = Optional.absent();
+  }
+
+  public void setMedia(@NonNull final MasterSecret masterSecret,
+                       @NonNull final Uri uri,
+                       @NonNull final MediaType mediaType,
+                       @NonNull final MediaConstraints constraints)
   {
     new AsyncTask<Void, Void, Slide>() {
       @Override
       protected void onPreExecute() {
-        slideDeck.clear();
+        if (uri != captureUri) cleanup();
+        else                   cleanupCurrentSlide();
+
         thumbnail.clear();
         thumbnail.showProgressSpinner();
         attachmentView.setVisibility(View.VISIBLE);
-
-        if (isCapture)               captureUri = uri;
-        if (!uri.equals(captureUri)) cleanup();
       }
 
       @Override
@@ -133,7 +146,7 @@ public class AttachmentManager {
                          R.string.ConversationActivity_attachment_exceeds_size_limits,
                          Toast.LENGTH_SHORT).show();
         } else {
-          slideDeck.addSlide(slide);
+          AttachmentManager.this.slide = Optional.of(slide);
           attachmentView.setVisibility(View.VISIBLE);
           thumbnail.setImageResource(masterSecret, slide, false, true);
           attachmentListener.onAttachmentChanged();
@@ -146,9 +159,10 @@ public class AttachmentManager {
     return attachmentView.getVisibility() == View.VISIBLE;
   }
 
-
-  public @NonNull SlideDeck getSlideDeck() {
-    return slideDeck;
+  public @NonNull SlideDeck buildSlideDeck() {
+    SlideDeck deck = new SlideDeck();
+    if (slide.isPresent()) deck.addSlide(slide.get());
+    return deck;
   }
 
   public static void selectVideo(Activity activity, int requestCode) {
@@ -168,7 +182,11 @@ public class AttachmentManager {
     activity.startActivityForResult(intent, requestCode);
   }
 
-  public Uri getCaptureUri() {
+  private @Nullable Uri getSlideUri() {
+    return slide.isPresent() ? slide.get().getUri() : null;
+  }
+
+  public @Nullable Uri getCaptureUri() {
     return captureUri;
   }
 
@@ -176,7 +194,7 @@ public class AttachmentManager {
     try {
       Intent captureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
       if (captureIntent.resolveActivity(activity.getPackageManager()) != null) {
-        captureUri = CaptureProvider.getInstance(context).createForExternal(recipients);
+        captureUri = PersistentBlobProvider.getInstance(context).createForExternal(recipients);
         captureIntent.putExtra(MediaStore.EXTRA_OUTPUT, captureUri);
         activity.startActivityForResult(captureIntent, requestCode);
       }
@@ -221,8 +239,8 @@ public class AttachmentManager {
   private class RemoveButtonListener implements View.OnClickListener {
     @Override
     public void onClick(View v) {
-      clear();
       cleanup();
+      clear();
     }
   }
 

--- a/src/org/thoughtcrime/securesms/mms/PartAuthority.java
+++ b/src/org/thoughtcrime/securesms/mms/PartAuthority.java
@@ -9,7 +9,7 @@ import android.support.annotation.NonNull;
 import org.thoughtcrime.securesms.attachments.AttachmentId;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
-import org.thoughtcrime.securesms.providers.CaptureProvider;
+import org.thoughtcrime.securesms.providers.PersistentBlobProvider;
 import org.thoughtcrime.securesms.providers.PartProvider;
 import org.thoughtcrime.securesms.providers.SingleUseBlobProvider;
 
@@ -25,7 +25,7 @@ public class PartAuthority {
 
   private static final int PART_ROW       = 1;
   private static final int THUMB_ROW      = 2;
-  private static final int CAPTURE_ROW    = 3;
+  private static final int PERSISTENT_ROW = 3;
   private static final int SINGLE_USE_ROW = 4;
 
   private static final UriMatcher uriMatcher;
@@ -34,7 +34,7 @@ public class PartAuthority {
     uriMatcher = new UriMatcher(UriMatcher.NO_MATCH);
     uriMatcher.addURI("org.thoughtcrime.securesms", "part/*/#", PART_ROW);
     uriMatcher.addURI("org.thoughtcrime.securesms", "thumb/*/#", THUMB_ROW);
-    uriMatcher.addURI(CaptureProvider.AUTHORITY, CaptureProvider.EXPECTED_PATH, CAPTURE_ROW);
+    uriMatcher.addURI(PersistentBlobProvider.AUTHORITY, PersistentBlobProvider.EXPECTED_PATH, PERSISTENT_ROW);
     uriMatcher.addURI(SingleUseBlobProvider.AUTHORITY, SingleUseBlobProvider.PATH, SINGLE_USE_ROW);
   }
 
@@ -50,8 +50,8 @@ public class PartAuthority {
       case THUMB_ROW:
         partUri = new PartUriParser(uri);
         return DatabaseFactory.getAttachmentDatabase(context).getThumbnailStream(masterSecret, partUri.getPartId());
-      case CAPTURE_ROW:
-        return CaptureProvider.getInstance(context).getStream(masterSecret, ContentUris.parseId(uri));
+      case PERSISTENT_ROW:
+        return PersistentBlobProvider.getInstance(context).getStream(masterSecret, ContentUris.parseId(uri));
       case SINGLE_USE_ROW:
         return SingleUseBlobProvider.getInstance().getStream(ContentUris.parseId(uri));
       default:

--- a/src/org/thoughtcrime/securesms/providers/PersistentBlobProvider.java
+++ b/src/org/thoughtcrime/securesms/providers/PersistentBlobProvider.java
@@ -6,7 +6,6 @@ import android.content.UriMatcher;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.support.annotation.NonNull;
-import android.support.v4.util.SparseArrayCompat;
 import android.util.Log;
 
 import org.thoughtcrime.securesms.crypto.DecryptingPartInputStream;
@@ -21,25 +20,27 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
-public class CaptureProvider {
-  private static final String TAG           = CaptureProvider.class.getSimpleName();
-  private static final String URI_STRING    = "content://org.thoughtcrime.securesms/capture";
-  public  static final Uri    CONTENT_URI   = Uri.parse(URI_STRING);
-  public  static final String AUTHORITY     = "org.thoughtcrime.securesms";
-  public  static final String EXPECTED_PATH = "capture/*/#";
-  private static final int    MATCH         = 1;
-  public static final UriMatcher uriMatcher = new UriMatcher(UriMatcher.NO_MATCH) {{
+public class PersistentBlobProvider {
+  private static final String     TAG           = PersistentBlobProvider.class.getSimpleName();
+  private static final String     URI_STRING    = "content://org.thoughtcrime.securesms/capture";
+  public  static final Uri        CONTENT_URI   = Uri.parse(URI_STRING);
+  public  static final String     AUTHORITY     = "org.thoughtcrime.securesms";
+  public  static final String     EXPECTED_PATH = "capture/*/#";
+  private static final int        MATCH         = 1;
+  private static final UriMatcher MATCHER       = new UriMatcher(UriMatcher.NO_MATCH) {{
     addURI(AUTHORITY, EXPECTED_PATH, MATCH);
   }};
 
-  private static volatile CaptureProvider instance;
+  private static volatile PersistentBlobProvider instance;
 
-  public static CaptureProvider getInstance(Context context) {
+  public static PersistentBlobProvider getInstance(Context context) {
     if (instance == null) {
-      synchronized (CaptureProvider.class) {
+      synchronized (PersistentBlobProvider.class) {
         if (instance == null) {
-          instance = new CaptureProvider(context);
+          instance = new PersistentBlobProvider(context);
         }
       }
     }
@@ -47,9 +48,9 @@ public class CaptureProvider {
   }
 
   private final Context context;
-  private final SparseArrayCompat<byte[]> cache = new SparseArrayCompat<>();
+  private final Map<Long, byte[]> cache = new HashMap<>();
 
-  private CaptureProvider(Context context) {
+  private PersistentBlobProvider(Context context) {
     this.context = context.getApplicationContext();
   }
 
@@ -57,19 +58,31 @@ public class CaptureProvider {
                     @NonNull Recipients recipients,
                     @NonNull byte[] imageBytes)
   {
-    final int id = generateId(recipients);
+    final long id = generateId(recipients);
     cache.put(id, imageBytes);
-    persistToDisk(masterSecret, id, imageBytes);
+    return create(masterSecret, new ByteArrayInputStream(imageBytes), id);
+  }
+
+  public Uri create(@NonNull MasterSecret masterSecret,
+                    @NonNull InputStream input)
+  {
+    return create(masterSecret, input, System.currentTimeMillis());
+  }
+
+  private Uri create(MasterSecret masterSecret, InputStream input, long id) {
+    persistToDisk(masterSecret, id, input);
     final Uri uniqueUri = Uri.withAppendedPath(CONTENT_URI, String.valueOf(System.currentTimeMillis()));
     return ContentUris.withAppendedId(uniqueUri, id);
   }
 
-  private void persistToDisk(final MasterSecret masterSecret, final int id, final byte[] imageBytes) {
+  private void persistToDisk(final MasterSecret masterSecret, final long id,
+                             final InputStream input)
+  {
     new AsyncTask<Void, Void, Void>() {
       @Override protected Void doInBackground(Void... params) {
         try {
           final OutputStream output = new EncryptingPartOutputStream(getFile(id), masterSecret);
-          Util.copy(new ByteArrayInputStream(imageBytes), output);
+          Util.copy(input, output);
         } catch (IOException e) {
           Log.w(TAG, e);
         }
@@ -92,14 +105,14 @@ public class CaptureProvider {
   }
 
   public boolean delete(@NonNull Uri uri) {
-    switch (uriMatcher.match(uri)) {
+    switch (MATCHER.match(uri)) {
     case MATCH: return getFile(ContentUris.parseId(uri)).delete();
     default:    return new File(uri.getPath()).delete();
     }
   }
 
   public @NonNull InputStream getStream(MasterSecret masterSecret, long id) throws IOException {
-    final byte[] cached = cache.get((int)id);
+    final byte[] cached = cache.get(id);
     return cached != null ? new ByteArrayInputStream(cached)
                           : new DecryptingPartInputStream(getFile(id), masterSecret);
   }
@@ -110,5 +123,9 @@ public class CaptureProvider {
 
   private File getFile(long id) {
     return new File(context.getDir("captures", Context.MODE_PRIVATE), id + ".jpg");
+  }
+
+  public static boolean isAuthority(@NonNull Uri uri) {
+    return MATCHER.match(uri) == MATCH;
   }
 }

--- a/src/org/thoughtcrime/securesms/providers/SingleUseBlobProvider.java
+++ b/src/org/thoughtcrime/securesms/providers/SingleUseBlobProvider.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 public class SingleUseBlobProvider {
 
-  private static final String TAG = CaptureProvider.class.getSimpleName();
+  private static final String TAG = SingleUseBlobProvider.class.getSimpleName();
 
   public  static final String AUTHORITY   = "org.thoughtcrime.securesms";
   public  static final String PATH        = "memory/*/#";


### PR DESCRIPTION
There were some incorrect assumptions about how long we're allowed to read from a Uri passed in via a share intent to us. Turns out not long at all - once the activity that receives the intent finishes, the Uri is no longer guaranteed to be readable.

ShareActivity now writes a copy of the media to our own storage while the media remains relevant.

fixes #3989
