### PR TITLE
Fix two message ordering issues.

### DIFF
--- a/src/org/thoughtcrime/securesms/database/MmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MmsDatabase.java
@@ -727,7 +727,7 @@ public class MmsDatabase extends MessagingDatabase {
     contentValues.put(MESSAGE_BOX, type);
     contentValues.put(THREAD_ID, threadId);
     contentValues.put(READ, 1);
-    contentValues.put(DATE_RECEIVED, contentValues.getAsLong(DATE_SENT));
+    contentValues.put(DATE_RECEIVED, System.currentTimeMillis());
     contentValues.remove(ADDRESS);
 
     long messageId = insertMediaMessage(masterSecret, addresses, message.getBody(),

--- a/src/org/thoughtcrime/securesms/database/SmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/SmsDatabase.java
@@ -471,7 +471,7 @@ public class SmsDatabase extends MessagingDatabase {
     contentValues.put(ADDRESS, PhoneNumberUtils.formatNumber(message.getRecipients().getPrimaryRecipient().getNumber()));
     contentValues.put(THREAD_ID, threadId);
     contentValues.put(BODY, message.getMessageBody());
-    contentValues.put(DATE_RECEIVED, date);
+    contentValues.put(DATE_RECEIVED, System.currentTimeMillis());
     contentValues.put(DATE_SENT, date);
     contentValues.put(READ, 1);
     contentValues.put(TYPE, type);

--- a/src/org/thoughtcrime/securesms/jobs/PushDecryptJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushDecryptJob.java
@@ -82,7 +82,7 @@ public class PushDecryptJob extends ContextJob {
   public PushDecryptJob(Context context, long pushMessageId, long smsMessageId, String sender) {
     super(context, JobParameters.newBuilder()
                                 .withPersistence()
-                                .withGroupId(sender)
+                                .withGroupId("__PUSH_DECRYPT_JOB__")
                                 .withWakeLock(true, 5, TimeUnit.SECONDS)
                                 .create());
     this.messageId    = pushMessageId;
@@ -94,6 +94,7 @@ public class PushDecryptJob extends ContextJob {
 
   @Override
   public void onRun() throws NoSuchMessageException {
+
     if (!IdentityKeyUtil.hasIdentityKey(context)) {
       Log.w(TAG, "Skipping job, waiting for migration...");
       MessageNotifier.updateNotification(context, null, true, -2);


### PR DESCRIPTION
1) The group ID for jobs that process received messages was
   previously set to the sender's e164.  This guaranteed
   serialization of messages per-recipient, while allowing
   processing of multiple recipients in parallel.  Unfortunately
   in the case of groups, this results in out of order
   conversations, since the "sender" for each message is
   different.  And we can't determine that it was a group
   message until *after* we process it.  So this change just
   puts all message processing from all senders in one big queue.

2) Synchronization messages were always being displayed before
   received messages, due to the "received time" for those
   being set to the time they were sent.

Fixes #3618
Fixes #2385

// FREEBIE