### PR TITLE
Clarify app upgrade notification

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1037,7 +1037,7 @@
 
     <!-- reminder_header -->
     <string name="reminder_header_expired_build">Your build of Signal has expired!</string>
-    <string name="reminder_header_expired_build_details">Messages will no longer send successfully, please update to the most recent version.</string>
+    <string name="reminder_header_expired_build_details">Messages will no longer send successfully, please update via the app store.</string>
     <string name="reminder_header_sms_default_title">Use as default SMS app?</string>
     <string name="reminder_header_sms_default_text">Tap to make Signal your default SMS app.</string>
     <string name="reminder_header_sms_import_title">Import system SMS?</string>


### PR DESCRIPTION
My brother is using textsecure and came to me saying that the app was saying it needed to "upgrade" or "update" and would be unusable until that had been done. But he had checked all the menus and settings, and couldn't find out how to do this. In the meantime, he was locked out of messaging. I knew that it meant the had to open up the Play Store and upgrade the app, but he wasn't aware. (He'd turned off auto-updates.)

Perhaps it would be sensible to mention that the upgrade happens through the app store, as he didn't understand and was quite frustrated.