### PR TITLE
Canonicalize entries in canonical address database.

### DIFF
--- a/src/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
@@ -289,8 +289,6 @@ public class MmsSmsDatabase extends Database {
     public MessageRecord getCurrent() {
       String type = cursor.getString(cursor.getColumnIndexOrThrow(TRANSPORT));
 
-      Log.w("MmsSmsDatabase", "Type: " + type);
-
       if      (MmsSmsDatabase.MMS_TRANSPORT.equals(type)) return getMmsReader().getCurrent();
       else if (MmsSmsDatabase.SMS_TRANSPORT.equals(type)) return getSmsReader().getCurrent();
       else                                                throw new AssertionError("Bad type: " + type);


### PR DESCRIPTION
Make all our queries E164, so eventually everything in there
will be E164.  Stops thrashing between formats.

// FREEBIE