### PR TITLE
"Signalize" some text strings

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -923,7 +923,7 @@
     <string name="preferences__language">Language</string>
     <string name="preferences__language_summary">Language %s</string>
     <string name="preferences__signal_messages_and_calls">Signal messages and calls</string>
-    <string name="preferences__free_secure_messages_and_calls">Free private messages and calls to Signal users</string>
+    <string name="preferences__free_private_messages_and_calls">Free private messages and calls to Signal users</string>
     <string name="preferences__submit_debug_log">Submit debug log</string>
     <string name="preferences__support_wifi_calling">\'WiFi Calling\' compatibility mode</string>
     <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Enable if your device uses SMS/MMS delivery over WiFi (only enable when \'WiFi Calling\' is enabled on your device)</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -18,10 +18,10 @@
         Disable lock screen for messages?
     </string>
     <string name="ApplicationPreferencesActivity_disable">Disable</string>
-    <string name="ApplicationPreferencesActivity_unregistering_title">Unregistering</string>
-    <string name="ApplicationPreferencesActivity_unregistering_text">Unregistering from Signal calls and messages...</string>
-    <string name="ApplicationPreferencesActivity_disable_signal_title">Disable Signal calls and messages?</string>
-    <string name="ApplicationPreferencesActivity_disable_signal_text">Disable Signal calls and messages by unregistering from the server. You will need to re-register your phone number to use them again in the future.</string>
+    <string name="ApplicationPreferencesActivity_unregistering">Unregistering</string>
+    <string name="ApplicationPreferencesActivity_unregistering_from_signal_calls_and_messages">Unregistering from Signal calls and messages...</string>
+    <string name="ApplicationPreferencesActivity_disable_signal_calls_and_messages">Disable Signal calls and messages?</string>
+    <string name="ApplicationPreferencesActivity_disable_signal_calls_and_messages_by_unregistering">Disable Signal calls and messages by unregistering from the server. You will need to re-register your phone number to use them again in the future.</string>
     <string name="ApplicationPreferencesActivity_error_connecting_to_server">Error connecting to server!</string>
     <string name="ApplicationPreferencesActivity_sms_enabled">SMS Enabled</string>
     <string name="ApplicationPreferencesActivity_touch_to_change_your_default_sms_app">Touch to change your default SMS app</string>
@@ -922,8 +922,8 @@
     <string name="preferences__default">Default</string>
     <string name="preferences__language">Language</string>
     <string name="preferences__language_summary">Language %s</string>
-    <string name="preferences__signal_calls_and_messages_title">Signal calls and messages</string>
-    <string name="preferences__signal_calls_and_messages_text">Free secure calls and messages to Signal users</string>
+    <string name="preferences__signal_calls_and_messages">Signal calls and messages</string>
+    <string name="preferences__free_secure_calls_and_messages">Free secure calls and messages to Signal users</string>
     <string name="preferences__submit_debug_log">Submit debug log</string>
     <string name="preferences__support_wifi_calling">\'WiFi Calling\' compatibility mode</string>
     <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Enable if your device uses SMS/MMS delivery over WiFi (only enable when \'WiFi Calling\' is enabled on your device)</string>
@@ -1041,10 +1041,10 @@
     <string name="reminder_header_sms_import_text">Tap to copy your phone\'s SMS messages into its encrypted database.</string>
     <string name="reminder_header_sms_import_button">IMPORT</string>
     <string name="reminder_header_push_title">Enable Signal calls and messages</string>
-    <string name="reminder_header_push_text">Enjoy free secure calls and messages with other Signal users.</string>
+    <string name="reminder_header_push_text">Upgrade your messaging experience.</string>
     <string name="reminder_header_push_button">ENABLE</string>
     <string name="reminder_header_invite_title">Invite to Signal</string>
-    <string name="reminder_header_invite_text">Enjoy free secure calls and messages with %1$s.</string>
+    <string name="reminder_header_invite_text">Take your conversation with %1$s to the next level.</string>
     <string name="reminder_header_invite_button">INVITE</string>
     <string name="reminder_header_close_button">CLOSE</string>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -922,10 +922,8 @@
     <string name="preferences__default">Default</string>
     <string name="preferences__language">Language</string>
     <string name="preferences__language_summary">Language %s</string>
-    <string name="preferences__signal">Signal</string>
-    <string name="preferences__use_the_data_channel_for_communication_with_other_signal_users">
-        Free private messaging and calling to Signal users
-    </string>
+    <string name="preferences__signal_calls_and_messages_title">Signal calls and messages</string>
+    <string name="preferences__signal_calls_and_messages_text">Free secure calls and messages to Signal users</string>
     <string name="preferences__submit_debug_log">Submit debug log</string>
     <string name="preferences__support_wifi_calling">\'WiFi Calling\' compatibility mode</string>
     <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Enable if your device uses SMS/MMS delivery over WiFi (only enable when \'WiFi Calling\' is enabled on your device)</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -285,7 +285,7 @@
     <string name="NotificationMmsMessageRecord_multimedia_message">Multimedia message</string>
 
     <!-- MessageRecord -->
-    <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">Received a message encrypted using an old version of Signal that is no longer supported. Please ask the sender to upgrade to the most recent version and resend the message.</string>
+    <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">Received a message encrypted using an old version of Signal that is no longer supported. Please ask the sender to update to the most recent version and resend the message.</string>
     <string name="MessageRecord_left_group">You have left the group.</string>
     <string name="MessageRecord_updated_group">Updated the group.</string>
     <string name="MessageRecord_s_called_you">%s called you</string>
@@ -1033,7 +1033,7 @@
     <!-- reminder_header -->
     <string name="reminder_header_expired_build">Your build of Signal has expired!</string>
     <string name="reminder_header_expired_build_details">Messages will no longer send successfully, please update to the most recent version.</string>
-    <string name="reminder_header_expired_build_button">UPGRADE</string>
+    <string name="reminder_header_expired_build_button">UPDATE</string>
     <string name="reminder_header_sms_default_title">Use as default SMS app</string>
     <string name="reminder_header_sms_default_text">Tap to make Signal your default SMS app.</string>
     <string name="reminder_header_sms_default_button">SET</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -19,9 +19,9 @@
     </string>
     <string name="ApplicationPreferencesActivity_disable">Disable</string>
     <string name="ApplicationPreferencesActivity_unregistering">Unregistering</string>
-    <string name="ApplicationPreferencesActivity_unregistering_from_signal_calls_and_messages">Unregistering from Signal calls and messages...</string>
-    <string name="ApplicationPreferencesActivity_disable_signal_calls_and_messages">Disable Signal calls and messages?</string>
-    <string name="ApplicationPreferencesActivity_disable_signal_calls_and_messages_by_unregistering">Disable Signal calls and messages by unregistering from the server. You will need to re-register your phone number to use them again in the future.</string>
+    <string name="ApplicationPreferencesActivity_unregistering_from_signal_messages_and_calls">Unregistering from Signal messages and calls...</string>
+    <string name="ApplicationPreferencesActivity_disable_signal_messages_and_calls">Disable Signal messages and calls?</string>
+    <string name="ApplicationPreferencesActivity_disable_signal_messages_and_calls_by_unregistering">Disable Signal messages and calls by unregistering from the server. You will need to re-register your phone number to use them again in the future.</string>
     <string name="ApplicationPreferencesActivity_error_connecting_to_server">Error connecting to server!</string>
     <string name="ApplicationPreferencesActivity_sms_enabled">SMS Enabled</string>
     <string name="ApplicationPreferencesActivity_touch_to_change_your_default_sms_app">Touch to change your default SMS app</string>
@@ -334,7 +334,7 @@
 
     <!-- RecipientPreferencesActivity -->
     <string name="RecipientPreferenceActivity_block_this_contact_question">Block this contact?</string>
-    <string name="RecipientPreferenceActivity_you_will_no_longer_receive_calls_or_messages_from_this_user">You will no longer receive calls or messages from this user.</string>
+    <string name="RecipientPreferenceActivity_you_will_no_longer_receive_messages_or_calls_from_this_user">You will no longer receive messages or calls from this user.</string>
     <string name="RecipientPreferenceActivity_block">Block</string>
     <string name="RecipientPreferenceActivity_unblock_this_contact_question">Unblock this contact?</string>
     <string name="RecipientPreferenceActivity_are_you_sure_you_want_to_unblock_this_contact">Are you sure you want to unblock this contact?</string>
@@ -922,8 +922,8 @@
     <string name="preferences__default">Default</string>
     <string name="preferences__language">Language</string>
     <string name="preferences__language_summary">Language %s</string>
-    <string name="preferences__signal_calls_and_messages">Signal calls and messages</string>
-    <string name="preferences__free_secure_calls_and_messages">Free secure calls and messages to Signal users</string>
+    <string name="preferences__signal_messages_and_calls">Signal messages and calls</string>
+    <string name="preferences__free_secure_messages_and_calls">Free secure messages and calls to Signal users</string>
     <string name="preferences__submit_debug_log">Submit debug log</string>
     <string name="preferences__support_wifi_calling">\'WiFi Calling\' compatibility mode</string>
     <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Enable if your device uses SMS/MMS delivery over WiFi (only enable when \'WiFi Calling\' is enabled on your device)</string>
@@ -1040,8 +1040,8 @@
     <string name="reminder_header_sms_import_title">Import system SMS</string>
     <string name="reminder_header_sms_import_text">Tap to copy your phone\'s SMS messages into its encrypted database.</string>
     <string name="reminder_header_sms_import_button">IMPORT</string>
-    <string name="reminder_header_push_title">Enable Signal calls and messages</string>
-    <string name="reminder_header_push_text">Upgrade your messaging experience.</string>
+    <string name="reminder_header_push_title">Enable Signal messages and calls</string>
+    <string name="reminder_header_push_text">Upgrade your communication experience.</string>
     <string name="reminder_header_push_button">ENABLE</string>
     <string name="reminder_header_invite_title">Invite to Signal</string>
     <string name="reminder_header_invite_text">Take your conversation with %1$s to the next level.</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -923,7 +923,7 @@
     <string name="preferences__language">Language</string>
     <string name="preferences__language_summary">Language %s</string>
     <string name="preferences__signal_messages_and_calls">Signal messages and calls</string>
-    <string name="preferences__free_secure_messages_and_calls">Free secure messages and calls to Signal users</string>
+    <string name="preferences__free_secure_messages_and_calls">Free private messages and calls to Signal users</string>
     <string name="preferences__submit_debug_log">Submit debug log</string>
     <string name="preferences__support_wifi_calling">\'WiFi Calling\' compatibility mode</string>
     <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Enable if your device uses SMS/MMS delivery over WiFi (only enable when \'WiFi Calling\' is enabled on your device)</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1043,10 +1043,10 @@
     <string name="reminder_header_sms_import_text">Tap to copy your phone\'s SMS messages into its encrypted database.</string>
     <string name="reminder_header_sms_import_button">IMPORT</string>
     <string name="reminder_header_push_title">Enable Signal calls and messages</string>
-    <string name="reminder_header_push_text">Upgrade your communication experience.</string>
+    <string name="reminder_header_push_text">Enjoy free secure calls and messages with other Signal users.</string>
     <string name="reminder_header_push_button">ENABLE</string>
     <string name="reminder_header_invite_title">Invite to Signal</string>
-    <string name="reminder_header_invite_text">Take your communication with %1$s to the next level.</string>
+    <string name="reminder_header_invite_text">Enjoy free secure calls and messages with %1$s.</string>
     <string name="reminder_header_invite_button">INVITE</string>
     <string name="reminder_header_close_button">CLOSE</string>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -18,13 +18,10 @@
         Disable lock screen for messages?
     </string>
     <string name="ApplicationPreferencesActivity_disable">Disable</string>
-    <string name="ApplicationPreferencesActivity_unregistering">Unregistering</string>
-    <string name="ApplicationPreferencesActivity_unregistering_from_signal_messages">Unregistering from Signal messages...</string>
-    <string name="ApplicationPreferencesActivity_disable_signal_messages">Disable Signal messages?</string>
-    <string name="ApplicationPreferencesActivity_this_will_disable_signal_messages">
-        This will disable Signal messages by unregistering you from the server.
-        You will need to re-register your phone number to use Signal messages again in the future.
-    </string>
+    <string name="ApplicationPreferencesActivity_unregistering_title">Unregistering</string>
+    <string name="ApplicationPreferencesActivity_unregistering_text">Unregistering from Signal calls and messages...</string>
+    <string name="ApplicationPreferencesActivity_disable_signal_title">Disable Signal calls and messages?</string>
+    <string name="ApplicationPreferencesActivity_disable_signal_text">Disable Signal calls and messages by unregistering you from the server. You will need to re-register your phone number to use them again in the future.</string>
     <string name="ApplicationPreferencesActivity_error_connecting_to_server">Error connecting to server!</string>
     <string name="ApplicationPreferencesActivity_sms_enabled">SMS Enabled</string>
     <string name="ApplicationPreferencesActivity_touch_to_change_your_default_sms_app">Touch to change your default SMS app</string>
@@ -1045,11 +1042,11 @@
     <string name="reminder_header_sms_import_title">Import system SMS</string>
     <string name="reminder_header_sms_import_text">Tap to copy your phone\'s SMS messages into its encrypted database.</string>
     <string name="reminder_header_sms_import_button">IMPORT</string>
-    <string name="reminder_header_push_title">Enable Signal</string>
-    <string name="reminder_header_push_text">Upgrade your messaging experience.</string>
+    <string name="reminder_header_push_title">Enable Signal calls and messages</string>
+    <string name="reminder_header_push_text">Upgrade your communication experience.</string>
     <string name="reminder_header_push_button">ENABLE</string>
     <string name="reminder_header_invite_title">Invite to Signal</string>
-    <string name="reminder_header_invite_text">Take your conversation with %1$s to the next level.</string>
+    <string name="reminder_header_invite_text">Take your communication with %1$s to the next level.</string>
     <string name="reminder_header_invite_button">INVITE</string>
     <string name="reminder_header_close_button">CLOSE</string>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -21,7 +21,7 @@
     <string name="ApplicationPreferencesActivity_unregistering_title">Unregistering</string>
     <string name="ApplicationPreferencesActivity_unregistering_text">Unregistering from Signal calls and messages...</string>
     <string name="ApplicationPreferencesActivity_disable_signal_title">Disable Signal calls and messages?</string>
-    <string name="ApplicationPreferencesActivity_disable_signal_text">Disable Signal calls and messages by unregistering you from the server. You will need to re-register your phone number to use them again in the future.</string>
+    <string name="ApplicationPreferencesActivity_disable_signal_text">Disable Signal calls and messages by unregistering from the server. You will need to re-register your phone number to use them again in the future.</string>
     <string name="ApplicationPreferencesActivity_error_connecting_to_server">Error connecting to server!</string>
     <string name="ApplicationPreferencesActivity_sms_enabled">SMS Enabled</string>
     <string name="ApplicationPreferencesActivity_touch_to_change_your_default_sms_app">Touch to change your default SMS app</string>

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -5,7 +5,7 @@
                         android:defaultValue="false"
                         android:key="pref_toggle_push_messaging"
                         android:title="@string/preferences__signal_messages_and_calls"
-                        android:summary="@string/preferences__free_secure_messages_and_calls"/>
+                        android:summary="@string/preferences__free_private_messages_and_calls"/>
 
     <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
                         android:defaultValue="false"

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -4,8 +4,8 @@
     <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
                         android:defaultValue="false"
                         android:key="pref_toggle_push_messaging"
-                        android:title="@string/preferences__signal_calls_and_messages_title"
-                        android:summary="@string/preferences__signal_calls_and_messages_text"/>
+                        android:title="@string/preferences__signal_calls_and_messages"
+                        android:summary="@string/preferences__free_secure_calls_and_messages"/>
 
     <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
                         android:defaultValue="false"

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -4,8 +4,8 @@
     <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
                         android:defaultValue="false"
                         android:key="pref_toggle_push_messaging"
-                        android:title="@string/preferences__signal_calls_and_messages"
-                        android:summary="@string/preferences__free_secure_calls_and_messages"/>
+                        android:title="@string/preferences__signal_messages_and_calls"
+                        android:summary="@string/preferences__free_secure_messages_and_calls"/>
 
     <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
                         android:defaultValue="false"

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -4,8 +4,8 @@
     <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
                         android:defaultValue="false"
                         android:key="pref_toggle_push_messaging"
-                        android:title="@string/preferences__signal"
-                        android:summary="@string/preferences__use_the_data_channel_for_communication_with_other_signal_users"/>
+                        android:title="@string/preferences__signal_calls_and_messages_title"
+                        android:summary="@string/preferences__signal_calls_and_messages_text"/>
 
     <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
                         android:defaultValue="false"

--- a/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
+++ b/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
@@ -382,7 +382,7 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
       private void handleBlock() {
         new AlertDialogWrapper.Builder(getActivity())
             .setTitle(R.string.RecipientPreferenceActivity_block_this_contact_question)
-            .setMessage(R.string.RecipientPreferenceActivity_you_will_no_longer_receive_calls_or_messages_from_this_user)
+            .setMessage(R.string.RecipientPreferenceActivity_you_will_no_longer_receive_messages_or_calls_from_this_user)
             .setCancelable(true)
             .setNegativeButton(android.R.string.cancel, null)
             .setPositiveButton(R.string.RecipientPreferenceActivity_block, new DialogInterface.OnClickListener() {

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -154,7 +154,7 @@ public class AdvancedPreferenceFragment extends PreferenceFragment {
       private final CheckBoxPreference checkBoxPreference;
 
       public DisablePushMessagesTask(final CheckBoxPreference checkBoxPreference) {
-        super(getActivity(), R.string.ApplicationPreferencesActivity_unregistering, R.string.ApplicationPreferencesActivity_unregistering_from_signal_calls_and_messages);
+        super(getActivity(), R.string.ApplicationPreferencesActivity_unregistering, R.string.ApplicationPreferencesActivity_unregistering_from_signal_messages_and_calls);
         this.checkBoxPreference = checkBoxPreference;
       }
 
@@ -204,8 +204,8 @@ public class AdvancedPreferenceFragment extends PreferenceFragment {
       if (((CheckBoxPreference)preference).isChecked()) {
         AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(getActivity());
         builder.setIconAttribute(R.attr.dialog_info_icon);
-        builder.setTitle(R.string.ApplicationPreferencesActivity_disable_signal_calls_and_messages);
-        builder.setMessage(R.string.ApplicationPreferencesActivity_disable_signal_calls_and_messages_by_unregistering);
+        builder.setTitle(R.string.ApplicationPreferencesActivity_disable_signal_messages_and_calls);
+        builder.setMessage(R.string.ApplicationPreferencesActivity_disable_signal_messages_and_calls_by_unregistering);
         builder.setNegativeButton(android.R.string.cancel, null);
         builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
           @Override

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -154,7 +154,7 @@ public class AdvancedPreferenceFragment extends PreferenceFragment {
       private final CheckBoxPreference checkBoxPreference;
 
       public DisablePushMessagesTask(final CheckBoxPreference checkBoxPreference) {
-        super(getActivity(), R.string.ApplicationPreferencesActivity_unregistering, R.string.ApplicationPreferencesActivity_unregistering_from_signal_messages);
+        super(getActivity(), R.string.ApplicationPreferencesActivity_unregistering_title, R.string.ApplicationPreferencesActivity_unregistering_text);
         this.checkBoxPreference = checkBoxPreference;
       }
 
@@ -204,8 +204,8 @@ public class AdvancedPreferenceFragment extends PreferenceFragment {
       if (((CheckBoxPreference)preference).isChecked()) {
         AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(getActivity());
         builder.setIconAttribute(R.attr.dialog_info_icon);
-        builder.setTitle(R.string.ApplicationPreferencesActivity_disable_signal_messages);
-        builder.setMessage(R.string.ApplicationPreferencesActivity_this_will_disable_signal_messages);
+        builder.setTitle(R.string.ApplicationPreferencesActivity_disable_signal_title);
+        builder.setMessage(R.string.ApplicationPreferencesActivity_disable_signal_text);
         builder.setNegativeButton(android.R.string.cancel, null);
         builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
           @Override

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -154,7 +154,7 @@ public class AdvancedPreferenceFragment extends PreferenceFragment {
       private final CheckBoxPreference checkBoxPreference;
 
       public DisablePushMessagesTask(final CheckBoxPreference checkBoxPreference) {
-        super(getActivity(), R.string.ApplicationPreferencesActivity_unregistering_title, R.string.ApplicationPreferencesActivity_unregistering_text);
+        super(getActivity(), R.string.ApplicationPreferencesActivity_unregistering, R.string.ApplicationPreferencesActivity_unregistering_from_signal_calls_and_messages);
         this.checkBoxPreference = checkBoxPreference;
       }
 
@@ -204,8 +204,8 @@ public class AdvancedPreferenceFragment extends PreferenceFragment {
       if (((CheckBoxPreference)preference).isChecked()) {
         AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(getActivity());
         builder.setIconAttribute(R.attr.dialog_info_icon);
-        builder.setTitle(R.string.ApplicationPreferencesActivity_disable_signal_title);
-        builder.setMessage(R.string.ApplicationPreferencesActivity_disable_signal_text);
+        builder.setTitle(R.string.ApplicationPreferencesActivity_disable_signal_calls_and_messages);
+        builder.setMessage(R.string.ApplicationPreferencesActivity_disable_signal_calls_and_messages_by_unregistering);
         builder.setNegativeButton(android.R.string.cancel, null);
         builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
           @Override

--- a/test/androidTestEspresso/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragmentTest.java
+++ b/test/androidTestEspresso/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragmentTest.java
@@ -97,7 +97,7 @@ public class AdvancedPreferenceFragmentTest extends TextSecureEspressoTestCase<C
     loadActivity(ConversationListActivity.class, STATE_REGISTERED);
     clickAdvancedSettingAndCheckState();
     AdvancedPreferenceFragmentActions.clickTextSecureMessages();
-    onView(withText(R.string.ApplicationPreferencesActivity_disable_signal_title))
+    onView(withText(R.string.ApplicationPreferencesActivity_disable_signal_calls_and_messages))
           .check(matches(isDisplayed()));
     onView(withText(android.R.string.cancel)).perform(click());
   }

--- a/test/androidTestEspresso/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragmentTest.java
+++ b/test/androidTestEspresso/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragmentTest.java
@@ -97,7 +97,7 @@ public class AdvancedPreferenceFragmentTest extends TextSecureEspressoTestCase<C
     loadActivity(ConversationListActivity.class, STATE_REGISTERED);
     clickAdvancedSettingAndCheckState();
     AdvancedPreferenceFragmentActions.clickTextSecureMessages();
-    onView(withText(R.string.ApplicationPreferencesActivity_disable_signal_calls_and_messages))
+    onView(withText(R.string.ApplicationPreferencesActivity_disable_signal_messages_and_calls))
           .check(matches(isDisplayed()));
     onView(withText(android.R.string.cancel)).perform(click());
   }

--- a/test/androidTestEspresso/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragmentTest.java
+++ b/test/androidTestEspresso/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragmentTest.java
@@ -97,7 +97,7 @@ public class AdvancedPreferenceFragmentTest extends TextSecureEspressoTestCase<C
     loadActivity(ConversationListActivity.class, STATE_REGISTERED);
     clickAdvancedSettingAndCheckState();
     AdvancedPreferenceFragmentActions.clickTextSecureMessages();
-    onView(withText(R.string.ApplicationPreferencesActivity_disable_signal_messages))
+    onView(withText(R.string.ApplicationPreferencesActivity_disable_signal_title))
           .check(matches(isDisplayed()));
     onView(withText(android.R.string.cancel)).perform(click());
   }


### PR DESCRIPTION
Adjusts a couple of text strings in order to include calls AND messages.

**Edit:**
If **title strings** like "Enable Signal calls and messages" or "Disable Signal calls and messages?" should prove to be too long, one could go for something like "Enable Signal communication" or "Disable Signal communication?" as alternatives.