### PR TITLE
fix failed incoming MMS regression

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -338,7 +338,7 @@ public class ConversationItem extends LinearLayout
   private void setFailedStatusIcons() {
     statusManager.displayFailed();
     dateText.setText(R.string.ConversationItem_error_not_delivered);
-    if (indicatorText != null) {
+    if (messageRecord.isOutgoing()) {
       indicatorText.setText(R.string.ConversationItem_click_for_details);
       indicatorText.setVisibility(View.VISIBLE);
     }
@@ -351,7 +351,7 @@ public class ConversationItem extends LinearLayout
   }
 
   private void setMinimumWidth() {
-    if (indicatorText != null && indicatorText.getVisibility() == View.VISIBLE && indicatorText.getText() != null) {
+    if (indicatorText.getVisibility() == View.VISIBLE && indicatorText.getText() != null) {
       final float density = getResources().getDisplayMetrics().density;
       bodyBubble.setMinimumWidth(indicatorText.getText().length() * (int) (6.5 * density) + (int) (22.0 * density));
     } else {


### PR DESCRIPTION
happened when https://github.com/WhisperSystems/TextSecure/commit/db9656c70cbd65ea9cc84728bfbebf68c0678423 copied the indicatorText view from outgoing messages and ConversationItem previously relied on its existence (or lack thereof) to determine whether it should be capable of displaying it.